### PR TITLE
#537 FUNC LIB - adding definition of FSO and MyDocs folder - Deleting old 'save your work' files

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -6,6 +6,8 @@
 'been tested in other scripts first. This document is actively used by live scripts, so it needs to be functionally complete at all times.
 '
 '============THAT MEANS THAT IF YOU BREAK THIS SCRIPT, ALL OTHER SCRIPTS ****STATEWIDE**** WILL NOT WORK! MODIFY WITH CARE!!!!!============
+Dim objFSO
+Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 'CHANGELOG BLOCK ===========================================================================================================
 actual_script_name = name_of_script
@@ -424,9 +426,6 @@ end function
 Const ForReading = 1
 Const ForWriting = 2
 Const ForAppending = 8
-
-Dim objFSO
-Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 'Needs to determine MyDocs directory before proceeding.
 Set wshshell = CreateObject("WScript.Shell")
@@ -3575,13 +3574,6 @@ function changelog_display()
 
 		'Now determines name of file
 		local_changelog_path = user_myDocs_folder & "scripts-local-changelog-entries.txt"
-
-		Const ForReading = 1
-		Const ForWriting = 2
-		Const ForAppending = 8
-
-		Dim objFSO
-		Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 		'Before doing comparisons, it needs to see what the most recent item added to the list was.
 		last_item_added_to_changelog = split(changelog(0), " | ")

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -423,13 +423,12 @@ end function
 
 'Preloading worker_signature, as a constant to be used in scripts---------------------------------------------------------------------------------------------------------
 
-Const ForReading = 1
-Const ForWriting = 2
-Const ForAppending = 8
+Const ForReading = 1			'These Constants are used for enumeration in file manipulation functions.
+Const ForWriting = 2			'See the 'OpenAsTextStream' method
+Const ForAppending = 8			'https://docs.microsoft.com/en-us/office/vba/language/reference/user-interface-help/openastextstream-method
 
-'Needs to determine MyDocs directory before proceeding.
-Set wshshell = CreateObject("WScript.Shell")
-user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
+Set wshshell = CreateObject("WScript.Shell")						'creating the wscript method to interact with the system
+user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"	'defining the my documents folder for use in saving script details/variables between script runs
 
 'Now it determines the signature
 With (CreateObject("Scripting.FileSystemObject"))															'Creating an FSO
@@ -442,21 +441,24 @@ With (CreateObject("Scripting.FileSystemObject"))															'Creating an FSO
 	END IF
 END WITH
 
-Set objFolder = objFSO.GetFolder(user_myDocs_folder)
-Set colFiles = objFolder.Files
-For Each objFile in colFiles
-	delete_this_file = False
-	this_file_name = objFile.Name
-	this_file_type = objFile.Type
-	this_file_created_date = objFile.DateCreated
-	this_file_path = objFile.Path
+'Now we check MyDocs to see if there is script saved work files that need to be removed.
+'This is necessary for correct records managment and data security.
+'This runs every time we open the Func Lib and happens in the background, ensuring no interruption in other script functions
+Set objFolder = objFSO.GetFolder(user_myDocs_folder)										'Creates an oject of the whole my documents folder
+Set colFiles = objFolder.Files																'Creates an array/collection of all the files in the folder
+For Each objFile in colFiles																'looping through each file
+	delete_this_file = False																'Default to NOT delete the file
+	this_file_name = objFile.Name															'Grabing the file name
+	this_file_type = objFile.Type															'Grabing the file type
+	this_file_created_date = objFile.DateCreated											'Reading the date created
+	this_file_path = objFile.Path															'Grabing the path for the file
 
-	If InStr(this_file_name, "caf-answers-") <> 0 Then delete_this_file = True
-	If InStr(this_file_name, "interview-answers-") <> 0 Then delete_this_file = True
-	If this_file_type <> "Text Document" then delete_this_file = False
-	If DateDiff("d", this_file_created_date, date) < 8 Then delete_this_file = False
+	If InStr(this_file_name, "caf-answers-") <> 0 Then delete_this_file = True				'We want to delete files that say 'caf-answers-' as this is how the UTILITIES - Complete Phone CAF script creates the save your work doc
+	If InStr(this_file_name, "interview-answers-") <> 0 Then delete_this_file = True		'We want to delete files that say 'interview-answers-' as this is how the NOTES - Interview script creates the save your work doc
+	If this_file_type <> "Text Document" then delete_this_file = False						'We do NOT want to delete files that are NOT TXT file types
+	If DateDiff("d", this_file_created_date, date) < 8 Then delete_this_file = False		'We do NOT want to delete files that are 7 days old or less - we may need to reference the saved work in these files.
 
-	If delete_this_file = True Then objFSO.DeleteFile(this_file_path)
+	If delete_this_file = True Then objFSO.DeleteFile(this_file_path)						'If we have determined that we need to delete the file - here we delete it
 Next
 
 '----------------------------------------------------------------------------------------------------Email addresses for the teams

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -421,6 +421,13 @@ end function
 
 'Preloading worker_signature, as a constant to be used in scripts---------------------------------------------------------------------------------------------------------
 
+Const ForReading = 1
+Const ForWriting = 2
+Const ForAppending = 8
+
+Dim objFSO
+Set objFSO = CreateObject("Scripting.FileSystemObject")
+
 'Needs to determine MyDocs directory before proceeding.
 Set wshshell = CreateObject("WScript.Shell")
 user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
@@ -435,6 +442,23 @@ With (CreateObject("Scripting.FileSystemObject"))															'Creating an FSO
 		worker_sig_command.Close																			'Closes the file
 	END IF
 END WITH
+
+Set objFolder = objFSO.GetFolder(user_myDocs_folder)
+Set colFiles = objFolder.Files
+For Each objFile in colFiles
+	delete_this_file = False
+	this_file_name = objFile.Name
+	this_file_type = objFile.Type
+	this_file_created_date = objFile.DateCreated
+	this_file_path = objFile.Path
+
+	If InStr(this_file_name, "caf-answers-") <> 0 Then delete_this_file = True
+	If InStr(this_file_name, "interview-answers-") <> 0 Then delete_this_file = True
+	If this_file_type <> "Text Document" then delete_this_file = False
+	If DateDiff("d", this_file_created_date, date) < 8 Then delete_this_file = False
+
+	If delete_this_file = True Then objFSO.DeleteFile(this_file_path)
+Next
 
 '----------------------------------------------------------------------------------------------------Email addresses for the teams
 IF current_worker_number =	"X127F3P" 	THEN email_address = "HSPH.ES.MA.EPD.Adult@hennepin.us"
@@ -6349,8 +6373,8 @@ End Function
 function ONLY_create_MAXIS_friendly_date(date_variable)
 '--- This function creates a MM DD YY date.
 '~~~~~ date_variable: the name of the variable to output
-    date_variable = dateadd("d", 0, date_variable)    'janky way to convert to a date, but hey it works.    
-    var_month     = right("0" & DatePart("m",    date_variable), 2) 
+    date_variable = dateadd("d", 0, date_variable)    'janky way to convert to a date, but hey it works.
+    var_month     = right("0" & DatePart("m",    date_variable), 2)
     var_day       = right("0" & DatePart("d",    date_variable), 2)
     var_year      = right("0" & DatePart("yyyy", date_variable), 2)
 	date_variable = var_month &"/" & var_day & "/" & var_year

--- a/Test scripts/Casey/functions/erase_txt_files.vbs
+++ b/Test scripts/Casey/functions/erase_txt_files.vbs
@@ -1,0 +1,33 @@
+'FUNCTION to erase old txt files from MY Documents made by scripts.
+'FILE NAMES
+    'interview-answers'
+    'caf-answers-'
+
+function erase_week_old_save_your_work_txt_files()
+    ' Set wshshell = CreateObject("WScript.Shell")
+    Dim objFSO
+    Set objFSO = CreateObject("Scripting.FileSystemObject")
+
+    'Needs to determine MyDocs directory before proceeding.
+    Set wshshell = CreateObject("WScript.Shell")
+    user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
+
+    Set objFolder = objFSO.GetFolder(user_myDocs_folder)
+    Set colFiles = objFolder.Files
+    For Each objFile in colFiles
+        delete_this_file = False
+        this_file_name = objFile.Name
+        this_file_type = objFile.Type
+        this_file_created_date = objFile.DateCreated
+        this_file_path = objFile.Path
+
+        If InStr(this_file_name, "caf-answers-") <> 0 Then delete_this_file = True
+        If InStr(this_file_name, "interview-answers-") <> 0 Then delete_this_file = True
+        If this_file_type <> "Text Document" then delete_this_file = False
+        If DateDiff("d", this_file_created_date, date) < 8 Then delete_this_file = False
+
+        If delete_this_file = True Then objFSO.DeleteFile(this_file_path)
+    Next
+end function
+
+erase_week_old_save_your_work_txt_files

--- a/admin/work-assignment-from-excel.vbs
+++ b/admin/work-assignment-from-excel.vbs
@@ -166,11 +166,6 @@ Const assignment_list_col_number = 6
 Dim COLUMN_ARRAY()
 ReDim COLUMN_ARRAY(assignment_list_col_number, 0)
 
-'These constants are used for writing to the txt file
-Const ForReading = 1
-Const ForWriting = 2
-Const ForAppending = 8
-
 'END DECLARATIONS BLOCK ====================================================================================================
 
 'THE SCRIPT ================================================================================================================
@@ -303,10 +298,7 @@ For each_column = 0 to UBound(COLUMN_ARRAY,2)
     End If
 Next
 
-Set wshshell = CreateObject("WScript.Shell")
 assignment_folder = master_list_folder
-Dim objFSO
-Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 Dim objTextStream
 assignment_status_path = assignment_folder & "assignment-status.txt"

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -2215,20 +2215,10 @@ end function
 function save_your_work()
 'This function records the variables into a txt file so that it can be retrieved by the script if run later.
 
-	'Needs to determine MyDocs directory before proceeding.
-	' Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
-
 	'Now determines name of file
 	If MAXIS_case_number <> "" Then
 		local_changelog_path = user_myDocs_folder & "interview-answers-" & MAXIS_case_number & "-info.txt"
 	End If
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	' Dim objFSO
-	' Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -2991,20 +2981,9 @@ end function
 
 function restore_your_work(vars_filled)
 'this function looks to see if a txt file exists for the case that is being run to pull already known variables back into the script from a previous run
-'
-	'Needs to determine MyDocs directory before proceeding.
-	' Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
 
 	'Now determines name of file
 	local_changelog_path = user_myDocs_folder & "interview-answers-" & MAXIS_case_number & "-info.txt"
-
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	' Dim objFSO
-	' Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -3382,6 +3361,7 @@ function restore_your_work(vars_filled)
 							HH_MEMB_ARRAY(other_names, known_membs)					= array_info(6)
 							HH_MEMB_ARRAY(age, known_membs)							= array_info(7)
 							' MsgBox "~" & HH_MEMB_ARRAY(age, known_membs) & "~"
+							If HH_MEMB_ARRAY(age, known_membs) = "" Then HH_MEMB_ARRAY(age, known_membs) = 0
 							HH_MEMB_ARRAY(age, known_membs) = HH_MEMB_ARRAY(age, known_membs) * 1
 							HH_MEMB_ARRAY(date_of_birth, known_membs)				= array_info(8)
 							HH_MEMB_ARRAY(ssn, known_membs)							= array_info(9)
@@ -5108,10 +5088,6 @@ Dim confirm_ievs_info_read, case_card_info, clt_knows_how_to_use_ebt_card, snap_
 Dim show_pg_one_memb01_and_exp, show_pg_one_address, show_pg_memb_list, show_q_1_6
 Dim show_q_7_11, show_q_14_15, show_q_21_24, show_qual, show_pg_last, discrepancy_questions
 
-Set wshshell = CreateObject("WScript.Shell")
-Dim objFSO
-Set objFSO = CreateObject("Scripting.FileSystemObject")
-
 show_pg_one_memb01_and_exp	= 1
 show_pg_one_address			= 2
 show_pg_memb_list			= 3
@@ -5325,13 +5301,7 @@ If family_cash_case = True Then family_cash_case_yn = "Yes"
 'If we already know the variables because we used 'restore your work' OR if there is no case number, we don't need to read the information from MAXIS
 If vars_filled = FALSE AND no_case_number_checkbox = unchecked Then
 	'Needs to determine MyDocs directory before proceeding.
-	' Set WshShell = CreateObject("WScript.Shell")
-
-	user_myDocs_folder = WshShell.SpecialFolders("MyDocuments") & "\"
 	intvw_msg_file = user_myDocs_folder & "interview message.txt"
-
-	' Dim objFSO
-	' Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	If objFSO.FileExists(intvw_msg_file) = False then
 		Set objTextStream = objFSO.OpenTextFile(intvw_msg_file, 2, true)
@@ -8845,18 +8815,11 @@ If discrepancies_exist = True Then
 	objSelection.TypeText vbCr
 End If
 
-' objSelection.TypeText "Verbal Signature accepted on " & caf_form_date
-
-' MsgBox "DOC IS CREATED"			'This can be used for testing so we don't add fake documents to the assignment folder.
-
 'Here we are creating the file path and saving the file
 file_safe_date = replace(date, "/", "-")		'dates cannot have / for a file name so we change it to a -
+
 'We set the file path and name based on case number and date. We can add other criteria if important.
 'This MUST have the 'pdf' file extension to work
-
-'THIS IS THE TESTING FILE'
-' pdf_doc_path = t_drive & "\Eligibility Support\Restricted\QI - Quality Improvement\BZ scripts project\TEMP - Interview Notes PDF Folder\CAF - " & MAXIS_case_number & " on " & file_safe_date & ".pdf"
-'THIS IS THE REAL FILE'
 pdf_doc_path = t_drive & "\Eligibility Support\Assignments\Interview Notes for ECF\Interview - " & MAXIS_case_number & " on " & file_safe_date & ".pdf"
 If developer_mode = True Then pdf_doc_path = t_drive & "\Eligibility Support\Assignments\Interview Notes for ECF\Archive\TRAINING REGION Interviews - NOT for ECF\Interview - " & MAXIS_case_number & " on " & file_safe_date & ".pdf"
 
@@ -8866,29 +8829,11 @@ If developer_mode = True Then pdf_doc_path = t_drive & "\Eligibility Support\Ass
 'The number '17' is a Word Ennumeration that defines this should be saved as a PDF.
 objDoc.SaveAs pdf_doc_path, 17
 
-'Now we interact with the system again
-' Dim objFSO
-' Set objFSO = CreateObject("Scripting.FileSystemObject")
 'This looks to see if the PDF file has been correctly saved. If it has the file will exists in the pdf file path
 If objFSO.FileExists(pdf_doc_path) = TRUE Then
 	'This allows us to close without any changes to the Word Document. Since we have the PDF we do not need the Word Doc
 	objDoc.Close wdDoNotSaveChanges
 	objWord.Quit						'close Word Application instance we opened. (any other word instances will remain)
-
-	' 'Needs to determine MyDocs directory before proceeding.
-	' Set wshshell = CreateObject("WScript.Shell")
-	' user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
-	' 'this is the file for the 'save your work' functionality.
-	' If MAXIS_case_number <> "" Then
-	' 	local_changelog_path = user_myDocs_folder & "caf-answers-" & MAXIS_case_number & "-info.txt"
-	' Else
-	' 	local_changelog_path = user_myDocs_folder & "caf-answers-new-case-info.txt"
-	' End If
-	'
-	' 'we are checking the save your work text file. If it exists we need to delete it because we don't want to save that information locally.
-	' If objFSO.FileExists(local_changelog_path) = True then
-	' 	objFSO.DeleteFile(local_changelog_path)			'DELETE
-	' End If
 
 	'Now we MEMO'
 	Call start_a_new_spec_memo(memo_opened, False, "N", "N", "N", other_name, other_street, other_city, other_state, other_zip, False)

--- a/utilities/complete-phone-caf.vbs
+++ b/utilities/complete-phone-caf.vbs
@@ -368,22 +368,12 @@ end function
 function save_your_work()
 'This function records the variables into a txt file so that it can be retrieved by the script if run later.
 
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
-
 	'Now determines name of file
 	If MAXIS_case_number <> "" Then
 		local_changelog_path = user_myDocs_folder & "caf-answers-" & MAXIS_case_number & "-info.txt"
 	Else
 		local_changelog_path = user_myDocs_folder & "caf-answers-new-case-info.txt"
 	End If
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	Dim objFSO
-	Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -626,21 +616,10 @@ end function
 
 function restore_your_work(vars_filled)
 'this function looks to see if a txt file exists for the case that is being run to pull already known variables back into the script from a previous run
-'
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
 
 	'Now determines name of file
 	If MAXIS_case_number <> "" Then local_changelog_path = user_myDocs_folder & "caf-answers-" & MAXIS_case_number & "-info.txt"
 	If no_case_number_checkbox = checked Then local_changelog_path = user_myDocs_folder & "caf-answers-new-case-info.txt"
-
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	Dim objFSO
-	Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -3876,18 +3855,13 @@ If no_case_number_checkbox = checked Then pdf_doc_path = t_drive & "\Eligibility
 'The number '17' is a Word Ennumeration that defines this should be saved as a PDF.
 objDoc.SaveAs pdf_doc_path, 17
 
-'Now we interact with the system again
-Dim objFSO
-Set objFSO = CreateObject("Scripting.FileSystemObject")
+
 'This looks to see if the PDF file has been correctly saved. If it has the file will exists in the pdf file path
 If objFSO.FileExists(pdf_doc_path) = TRUE Then
 	'This allows us to close without any changes to the Word Document. Since we have the PDF we do not need the Word Doc
 	objDoc.Close wdDoNotSaveChanges
 	objWord.Quit						'close Word Application instance we opened. (any other word instances will remain)
 
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
 	'this is the file for the 'save your work' functionality.
 	If MAXIS_case_number <> "" Then
 		local_changelog_path = user_myDocs_folder & "caf-answers-" & MAXIS_case_number & "-info.txt"

--- a/utilities/complete-phone-csr.vbs
+++ b/utilities/complete-phone-csr.vbs
@@ -5,7 +5,7 @@ STATS_counter = 1               'sets the stats counter at one
 STATS_manualtime = 600          'manual run time in seconds
 STATS_denomination = "C"        'C is for each case
 'END OF stats block=========================================================================================================
-' run_locally = TRUE
+run_locally = TRUE
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
 	IF run_locally = FALSE or run_locally = "" THEN	   'If the scripts are set to run locally, it skips this and uses an FSO below.
@@ -1898,20 +1898,8 @@ function save_your_work()
 'For scripts that work during 'live' interaction with clients/others this functionality is important to prevent loss of time and frustration
 'This function is script specific because the variables need to be defined for each script within this dialog and the enumberation codes need to be script specific
 
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
-
 	'Now creates the name of file
 	local_work_save_path = user_myDocs_folder & "csr-answers-" & MAXIS_case_number & "-info.txt"
-
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	'Needed for interacting with files in the computer
-	Dim objFSO
-	Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -2024,20 +2012,8 @@ function restore_your_work(vars_filled)
 'It will redefine the variables from the text file that was saved from a previous run if one exists.
 'This function must be script specific as the variables are hard coded within in.
 
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
-
 	'Creates the file name based on the convention we have defined
 	local_work_save_path = user_myDocs_folder & "csr-answers-" & MAXIS_case_number & "-info.txt"
-
-	Const ForReading = 1
-	Const ForWriting = 2
-	Const ForAppending = 8
-
-	'Needed for interacting with files in the computer
-	Dim objFSO
-	Set objFSO = CreateObject("Scripting.FileSystemObject")
 
 	With objFSO
 
@@ -3278,18 +3254,12 @@ pdf_doc_path = t_drive & "\Eligibility Support\Assignments\CSR Forms for ECF\CSR
 'The number '17' is a Word Ennumeration that defines this should be saved as a PDF.
 objDoc.SaveAs pdf_doc_path, 17
 
-'Now we interact with the system again
-Dim objFSO
-Set objFSO = CreateObject("Scripting.FileSystemObject")
 'This looks to see if the PDF file has been correctly saved. If it has the file will exists in the pdf file path
 If objFSO.FileExists(pdf_doc_path) = TRUE Then
 	'This allows us to close without any changes to the Word Document. Since we have the PDF we do not need the Word Doc
 	objDoc.Close wdDoNotSaveChanges
 	objWord.Quit						'close Word Application instance we opened. (any other word instances will remain)
 
-	'Needs to determine MyDocs directory before proceeding.
-	Set wshshell = CreateObject("WScript.Shell")
-	user_myDocs_folder = wshShell.SpecialFolders("MyDocuments") & "\"
 	'this is the file for the 'save your work' functionality.
 	local_work_save_path = user_myDocs_folder & "csr-answers-" & MAXIS_case_number & "-info.txt"
 	'we are checking the save your work text file. If it exists we need to delete it because we don't want to save that information locally.

--- a/utilities/complete-phone-csr.vbs
+++ b/utilities/complete-phone-csr.vbs
@@ -5,7 +5,7 @@ STATS_counter = 1               'sets the stats counter at one
 STATS_manualtime = 600          'manual run time in seconds
 STATS_denomination = "C"        'C is for each case
 'END OF stats block=========================================================================================================
-run_locally = TRUE
+' run_locally = TRUE
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
 	IF run_locally = FALSE or run_locally = "" THEN	   'If the scripts are set to run locally, it skips this and uses an FSO below.


### PR DESCRIPTION
This pull request will handle for two main items that are linked.

1. We need to review script created files in the MyDocs folder and delete old ones. This is a safety measure for complicated scripts but needs to be cleaned up regularly. 
2.  Since we use wshshell and objFSO in the main FuncLib run, we need to remove those seperate calls from the scripts. 

Updates for deleting old files. 
Every time the FuncLib is run the script will review 'MyDocs' to look for a file with the naming convention from Interview or Complete Phone CAF. It will then review for a txt file type and the date created. If the date was more than a week ago, the script will delete the file. 

Updates for the reserved variables and constants 
 objFSO - variable for the FileScripting Object 
wshshell - variable for the Script Shell Object 
user_myDocs_folder - variable for the 'MyDocs' folder 
ForReading - CONSTANT for the enumeration for the file manipulation functions
ForWriting - CONSTANT for the enumeration for the file manipulation functions
ForAppending - CONSTANT for the enumeration for the file manipulation functions