### PR TITLE
#642 - UTILITIES - Request Access to PRIV Case

### DIFF
--- a/utilities/request-access-to-priv-case.vbs
+++ b/utilities/request-access-to-priv-case.vbs
@@ -72,6 +72,7 @@ DO
 		Dialog1 = "" 'Blanking out previous dialog detail
 		BeginDialog Dialog1, 0, 0, 306, 110, "PRIV Case Access"
 		  EditBox 80, 25, 60, 15, MAXIS_case_number
+		  CheckBox 160, 30, 125, 10, "Check here if you are on the phone", resident_on_phone_checkbox
 		  EditBox 80, 45, 60, 15, x_number
 		  EditBox 80, 65, 200, 15, notes
 		  EditBox 80, 90, 115, 15, worker_name
@@ -80,6 +81,7 @@ DO
 		    CancelButton 255, 90, 50, 15
 		  Text 10, 10, 280, 10, "Request Knowledge Now to update MAXIS to allow you access to a privileged case."
 		  Text 10, 30, 70, 10, "PRIV Case Number:"
+		  Text 170, 40, 60, 10, "with the resident."
 		  Text 20, 50, 55, 10, "Your X-Number:"
 		  Text 15, 70, 60, 10, "Information/Notes:"
 		  Text 20, 95, 55, 10, "Sign your Email"
@@ -99,6 +101,19 @@ DO
 		If err_msg <> "" Then MsgBox "*** NOTICE ***" & vbNewLine & "Please resolve to continue:" & vbNewLine & err_msg
 	Loop until err_msg = ""
 
+	Call back_to_SELF
+
+	Call navigate_to_MAXIS_panel("STAT", "SUMM")
+	'READ WHERE PRIVED TO
+
+	' If in X127966 or X127Y86 – these cases are Safe at Home cases and cannot be transferred. The call/work needs to be sent to one of the Safe at Home workers. HSR MANUAL ABOUT SAFE AT HOME CASES
+	'
+	' If it is in x127FG1, x127FG2, or x127EW4 then it is handled by Team 469 and cannot be transferred. The call/work needs to be sent to Team 469. HSR MANUAL ABOUT FOSTER CARE CASES.
+
+	'ALERT IF NO ACCESS TO BE GRANTED
+
+	'IF checkbox is checked, then alert to use teams and give link to Knowledge Now and end script
+	'https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/Lists/Knowledge%20Now/calendar.aspx '
 	email_subject = "PRIV Case Access Request"
 
 	notes = trim(notes)

--- a/utilities/request-access-to-priv-case.vbs
+++ b/utilities/request-access-to-priv-case.vbs
@@ -1,7 +1,7 @@
 name_of_script = "UTILITIES - Request Access to PRIV Case.vbs"
 start_time = timer
 STATS_counter = 1                     	'sets the stats counter at one
-STATS_manualtime = 45                	'manual run time in seconds - INCLUDES A POLICY LOOKUP
+STATS_manualtime = 90                	'manual run time in seconds - INCLUDES A POLICY LOOKUP
 STATS_denomination = "C"       		'C is for each CASE
 'END OF stats block=========================================================================================================
 
@@ -43,6 +43,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("08/19/2020", "PRIV Case Access script will now review for Foster Care and Safe at Home restricted baskets to provide the correct email action for the case entered. Additionally, script will no longer send an email if it is indicated that the resident is on the phone, these requests are more timely when completed in Teams.", "Casey Love, Hennepin County")
 call changelog_update("08/19/2020", "Initial version.", "Casey Love, Hennepin County")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
@@ -133,6 +134,7 @@ DO
 
 	'If a privileged case type was identified there is special handling to send an email to the correct worker/team
 	If priv_case_type <> "" Then
+		STATS_manualtime = STATS_manualtime + 120 								'adding time for review of restricted baskets and process as the script has completed this.
 		Do
 			BeginDialog Dialog1, 0, 0, 306, 165, "Case is in a restricted basket"
 			  EditBox 10, 70, 290, 15, case_contact_reason
@@ -184,6 +186,7 @@ DO
 		If ButtonPressed = send_email_to_team_btn Then
 			email_body = "~~This email is generated from completion of the 'Request Access to PRIV Case' Script.~~" & vbCr & vbCr & email_body
 			call create_outlook_email(priv_case_worker_email, "", email_subject, email_body, "", TRUE)
+			STATS_manualtime = STATS_manualtime + (timer - start_time)						'This script allows for the writing of the email - so the manual time is adjusted as email length will vary
 		End If
 		call script_end_procedure_with_error_report(end_msg)			'End the script run here because if the case is in one of these types, we do not need to request from Knowledge Now
 	End If
@@ -227,7 +230,7 @@ Loop until message_confirmed = vbYes
 email_body = "~~This email is generated from completion of the 'Request Access to PRIV Case' Script.~~" & vbCr & vbCr & email_body
 call create_outlook_email("HSPH.EWS.QUALITYIMPROVEMENT@hennepin.us", "", email_subject, email_body, "", TRUE)
 
-STATS_manualtime = STATS_manualtime + (timer - start_time)
+STATS_manualtime = STATS_manualtime + (timer - start_time)						'This script allows for the writing of the email - so the manual time is adjusted as email length will vary
 end_msg = "Thank you!" & vbCr & "Your request for access has been sent to QI Knowledge Now." & vbCr & vbCr
 end_msg = end_msg & "Content of your Email to Knowledge Now:" & vbCr & "----------------------------------------------------------" & vbCr
 end_msg = end_msg & "Subject: " & email_subject & vbCr & vbCr

--- a/utilities/request-access-to-priv-case.vbs
+++ b/utilities/request-access-to-priv-case.vbs
@@ -104,6 +104,82 @@ DO
 	Call back_to_SELF
 
 	Call navigate_to_MAXIS_panel("STAT", "SUMM")
+
+	EMReadScreen priv_worker_x_number, 7, 24, 65
+	If priv_worker_x_number = "X127966" OR priv_worker_x_number = "X127AP7" OR priv_worker_x_number = "X127Q95" OR priv_worker_x_number = "X127FAT" Then
+		priv_case_type = "Safe at Home"
+		If priv_worker_x_number = "X127966" Then
+			priv_case_worker_name = "Florence Manley"
+			priv_case_worker_email = "Florence.Manley@hennepin.us"
+		End If
+		If priv_worker_x_number = "X127AP7" Then
+			priv_case_worker_name = "Ryan Kierth"
+			priv_case_worker_email = "Ryan.Kierth@hennepin.us"
+		End If
+		If priv_worker_x_number = "X127Q95" Then
+			priv_case_worker_name = "Shanna Hansen"
+			priv_case_worker_email = "Shanna.Hansen@hennepin.us"
+		End If
+		If priv_worker_x_number = "X127FAT" Then
+			priv_case_worker_name = "See Xiong"
+			priv_case_worker_email = "See.Xiong@hennepin.us"
+		End If
+	End If
+
+	If priv_worker_x_number = "x127FG1" OR priv_worker_x_number = "x127FG2" OR priv_worker_x_number = "x127EW4" Then
+		priv_case_type = "Foster Care"
+		priv_case_worker_name = "Team 469"
+		priv_case_worker_email = "hsph.es.team.469@hennepin.us"
+	End If
+
+	If priv_case_type <> "" Then
+		Do
+			BeginDialog Dialog1, 0, 0, 306, 165, "Dialog"
+			  EditBox 10, 70, 290, 15, case_contact_reason
+			  EditBox 10, 100, 290, 15, notes
+			  ButtonGroup ButtonPressed
+			    PushButton 170, 125, 130, 15, "Send an Email about this Case", send_email_to_team_btn
+			    PushButton 170, 145, 130, 15, "No Email Needed", no_email_button
+			  Text 10, 10, 295, 10, "This case is privileged and is not transferred outside of the team that works on the cases."
+			  Text 25, 25, 60, 10, "PRIV Case type:"
+			  Text 85, 25, 85, 10, priv_case_type
+			  Text 20, 40, 65, 10, "PRIV Case worker:"
+			  Text 85, 40, 85, 10, priv_case_worker_name
+			  Text 10, 60, 70, 10, "Reason for Contact:"
+			  Text 10, 90, 95, 10, "Additional Notes for Email:"
+			EndDialog
+
+			dialog Dialog1
+
+			If ButtonPressed = send_email_to_team_btn Then
+				email_subject = "PRIV Case Access Request"
+
+				notes = trim(notes)
+				worker_name = trim(worker_name)
+
+				email_body = "Please update MAXIS to allow access to this privileged case." & vbCr & vbCr
+
+				email_body = email_body & "Case Number: " & MAXIS_case_number & vbCr
+				email_body = email_body & "Worker Number for transfer: " & x_number & vbCr & vbCr
+
+				If notes <> "" Then email_body = email_body & "Notes: " & notes & vbCr & vbCr
+				email_body = email_body & "---" & vbCr
+				If worker_name <> "" Then email_body = email_body & "Signed, " & vbCr & worker_name
+
+				message_confirmed = MsgBox("REVIEW THE WORDING OF YOUR EMAIL TO KNOWLEDGE NOW:" & vbCr & vbCr & email_subject & vbCr & vbCr & email_body, vbQuestion + vbYesNo, email_subject)
+
+			End If
+
+			If ButtonPressed = no_email_button Then
+
+			End If
+		Loop until message_confirmed = vbYes OR ButtonPressed = no_email_button
+		If ButtonPressed = send_email_to_team_btn Then 
+			email_body = "~~This email is generated from completion of the 'Request Access to PRIV Case' Script.~~" & vbCr & vbCr & email_body
+			call create_outlook_email("HSPH.EWS.QUALITYIMPROVEMENT@hennepin.us", "", email_subject, email_body, "", TRUE)
+		End If
+		call script_end_procedure_with_error_report("")
+	End If
 	'READ WHERE PRIVED TO
 
 	' If in X127966 or X127Y86 – these cases are Safe at Home cases and cannot be transferred. The call/work needs to be sent to one of the Safe at Home workers. HSR MANUAL ABOUT SAFE AT HOME CASES

--- a/utilities/request-access-to-priv-case.vbs
+++ b/utilities/request-access-to-priv-case.vbs
@@ -237,3 +237,44 @@ end_msg = end_msg & "Subject: " & email_subject & vbCr & vbCr
 end_msg = end_msg & email_body
 
 call script_end_procedure_with_error_report(end_msg)
+
+'----------------------------------------------------------------------------------------------------Closing Project Documentation
+'------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------
+'
+'------Dialogs--------------------------------------------------------------------------------------------------------------------
+'--Dialog1 = "" on all dialogs -------------------------------------------------11/09/2021
+'--Tab orders reviewed & confirmed----------------------------------------------11/09/2021
+'--Mandatory fields all present & Reviewed--------------------------------------11/09/2021
+'--All variables in dialog match mandatory fields-------------------------------
+'
+'-----CASE:NOTE-------------------------------------------------------------------------------------------------------------------
+'--All variables are CASE:NOTEing (if required)---------------------------------N/A
+'--CASE:NOTE Header doesn't look funky------------------------------------------N/A
+'--Leave CASE:NOTE in edit mode if applicable-----------------------------------N/A
+'-----General Supports-------------------------------------------------------------------------------------------------------------
+'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------N/A
+'--MAXIS_background_check reviewed (if applicable)------------------------------N/A
+'--PRIV Case handling reviewed -------------------------------------------------N/A
+'--Out-of-County handling reviewed----------------------------------------------N/A
+'--script_end_procedures (w/ or w/o error messaging)----------------------------11/09/2021
+'--BULK - review output of statistics and run time/count (if applicable)--------N/A
+'
+'-----Statistics--------------------------------------------------------------------------------------------------------------------
+'--Manual time study reviewed --------------------------------------------------11/09/2021
+'--Incrementors reviewed (if necessary)-----------------------------------------N/A
+'--Denomination reviewed -------------------------------------------------------11/09/2021
+'--Script name reviewed---------------------------------------------------------11/09/2021
+'--BULK - remove 1 incrementor at end of script reviewed------------------------N/A
+
+'-----Finishing up------------------------------------------------------------------------------------------------------------------
+'--Confirm all GitHub taks are complete-----------------------------------------11/09/2021
+'--comment Code-----------------------------------------------------------------11/09/2021
+'--Update Changelog for release/update------------------------------------------11/09/2021
+'--Remove testing message boxes-------------------------------------------------11/09/2021
+'--Remove testing code/unnecessary code-----------------------------------------11/09/2021
+'--Review/update SharePoint instructions----------------------------------------11/09/2021
+'--Review Best Practices using BZS page ----------------------------------------N/A
+'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------N/A
+'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------N/A
+'--Complete misc. documentation (if applicable)---------------------------------N/A
+'--Update project team/issue contact (if applicable)----------------------------N/A


### PR DESCRIPTION
Updates to make the Request access to PRIV case more informative.

Identifies if case is privileged to the foster care team or to a safe at home worker. This changes the email that is sent.

Also recommends using Teams instead of Email for if resident is on the phone.