### PR TITLE
#643 - NOTES - Interview - handling so we don't divide by zero

### DIFF
--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -2261,8 +2261,8 @@ function display_expedited_dialog()
 				EXP_JOBS_ARRAY(jobs_employer_const, exp_job_count) = JOBS_ARRAY(jobs_employer_name, each_caf_job)
 				EXP_JOBS_ARRAY(jobs_wage_const, exp_job_count) = JOBS_ARRAY(jobs_hourly_wage, each_caf_job)
 
-				If IsNumeric(JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)) = True and IsNumeric(JOBS_ARRAY(jobs_hourly_wage, each_caf_job)) = True Then 
-                    If JOBS_ARRAY(jobs_hourly_wage, each_caf_job) > 0 Then
+				If IsNumeric(JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)) = True and IsNumeric(JOBS_ARRAY(jobs_hourly_wage, each_caf_job)) = True Then
+                    If JOBS_ARRAY(jobs_hourly_wage, each_caf_job) > 0 Then      'making sure we are not dividing by zero. I will not be defaulting to a zero income job - no autofils
     					monthly_hours = JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)/JOBS_ARRAY(jobs_hourly_wage, each_caf_job)
     					weekly_hours = monthly_hours/4
     					EXP_JOBS_ARRAY(jobs_hours_const, exp_job_count) = weekly_hours

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -2261,11 +2261,13 @@ function display_expedited_dialog()
 				EXP_JOBS_ARRAY(jobs_employer_const, exp_job_count) = JOBS_ARRAY(jobs_employer_name, each_caf_job)
 				EXP_JOBS_ARRAY(jobs_wage_const, exp_job_count) = JOBS_ARRAY(jobs_hourly_wage, each_caf_job)
 
-				If IsNumeric(JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)) = True and IsNumeric(JOBS_ARRAY(jobs_hourly_wage, each_caf_job)) = True Then
-					monthly_hours = JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)/JOBS_ARRAY(jobs_hourly_wage, each_caf_job)
-					weekly_hours = monthly_hours/4
-					EXP_JOBS_ARRAY(jobs_hours_const, exp_job_count) = weekly_hours
-					EXP_JOBS_ARRAY(jobs_frequency_const, exp_job_count) = "Weekly"
+				If IsNumeric(JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)) = True and IsNumeric(JOBS_ARRAY(jobs_hourly_wage, each_caf_job)) = True Then 
+                    If JOBS_ARRAY(jobs_hourly_wage, each_caf_job) > 0 Then
+    					monthly_hours = JOBS_ARRAY(jobs_gross_monthly_earnings, each_caf_job)/JOBS_ARRAY(jobs_hourly_wage, each_caf_job)
+    					weekly_hours = monthly_hours/4
+    					EXP_JOBS_ARRAY(jobs_hours_const, exp_job_count) = weekly_hours
+    					EXP_JOBS_ARRAY(jobs_frequency_const, exp_job_count) = "Weekly"
+                    End If
 				End If
 
 				exp_job_count = exp_job_count + 1


### PR DESCRIPTION
Sometimes when Job information is entered into the Interview script in the jobs area, people are entering $0 as the wage amount. Then when the script tries to do math for the Expedited Determination, it hits an overflow error because you can't divide by zero. Added an If statement to be sure that it isn't 0 before we continue.