### PR TITLE
ACTIONS - grh rate 2, If statement never true

### DIFF
--- a/actions/add-grh-rate-2-to-mmis.vbs
+++ b/actions/add-grh-rate-2-to-mmis.vbs
@@ -120,9 +120,8 @@ If grh_status <> "ACTV" then
 	script_end_procedure("GRH case status is " & grh_status & ". The script will now end.")
 End if
 
-county_code_rep = replace(worker_county_code, "x", "X")
 EMReadscreen current_county, 4, 21, 21
-If current_county <> county_code_rep then script_end_procedure("Out-of-county case. Cannot update. The script will now end.")
+If current_county <> UCase(worker_county_code) then script_end_procedure("Out-of-county case. Cannot update. The script will now end.")
 
 Call HCRE_panel_bypass			'Function to bypass a jenky HCRE panel. If the HCRE panel has fields not completed/'reds up' this gets us out of there.
 

--- a/actions/add-grh-rate-2-to-mmis.vbs
+++ b/actions/add-grh-rate-2-to-mmis.vbs
@@ -120,8 +120,9 @@ If grh_status <> "ACTV" then
 	script_end_procedure("GRH case status is " & grh_status & ". The script will now end.")
 End if
 
+county_code_rep = replace(worker_county_code, "x", "X")
 EMReadscreen current_county, 4, 21, 21
-If current_county <> worker_county_code then script_end_procedure("Out-of-county case. Cannot update. The script will now end.")
+If current_county <> county_code_rep then script_end_procedure("Out-of-county case. Cannot update. The script will now end.")
 
 Call HCRE_panel_bypass			'Function to bypass a jenky HCRE panel. If the HCRE panel has fields not completed/'reds up' this gets us out of there.
 


### PR DESCRIPTION
Counties using the DHS scripts require their global variables county code to have a lower case x 
(example: x105 used and not X105)

the var "current_county" reads from maxis as "X105". 
Using replace on line 123 resolves the issue of a lower case x in the global variables without needing to change other DHS scripts to make this script work. This should also have no effect on Hennepin running the code. 