### PR TITLE
#749 - NOTES - CAF - Stability added for CASE NOTE functionality

### DIFF
--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -9310,6 +9310,7 @@ If HC_checkbox = checked Then
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    Call back_to_SELF
 
 End If
 
@@ -9644,6 +9645,9 @@ If interview_waived = TRUE Then
     CALL write_variable_in_CASE_NOTE("Details can be seen in a SIR announcement on 4/14/2021")
     CALL write_variable_in_CASE_NOTE("---")
     CALL write_variable_in_CASE_NOTE(worker_signature)
+
+    PF3
+    Call back_to_SELF
 End If
 
 If interview_required = TRUE AND interview_completed_case_note_found = False Then
@@ -9725,6 +9729,7 @@ If interview_required = TRUE AND interview_completed_case_note_found = False The
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    Call back_to_SELF
 End If
 
 'Verification NOTE
@@ -9765,6 +9770,7 @@ If trim(verifs_needed) <> "" AND verifications_requested_case_note_found = False
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    Call back_to_SELF
 End If
 
 If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = False Then
@@ -9779,6 +9785,8 @@ If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = Fals
     Call write_variable_in_CASE_NOTE("---")
     Call write_variable_in_CASE_NOTE(worker_signature)
 
+    PF3
+    Call back_to_SELF
 End If
 
 'MAIN CAF Information NOTE

--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -9014,9 +9014,11 @@ If trim(FMED) <> "" Then case_has_expenses = TRUE
 'THE CASE NOTES-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 'Expedited Determination Case Note
 'Navigates to case note, and checks to make sure we aren't in inquiry.
+case_notes_information = "CASE NOTES ATTEMPTED AND OUTCOME %^% %^%"
 If HC_checkbox = checked Then
-
+    case_notes_information = case_notes_information & "HC NOTE Attempted %^%"
     hc_note_header = HC_datestamp & " " & HC_document_received & ": " & HC_form_status
+    case_notes_information = case_notes_information & "Script Header - " & hc_note_header & " %^%"
 
     Call start_a_blank_CASE_NOTE
     Call write_variable_in_CASE_NOTE(hc_note_header)
@@ -9310,6 +9312,9 @@ If HC_checkbox = checked Then
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    EMReadScreen top_note_header, 55, 5, 25
+    case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+
     Call back_to_SELF
 
 End If
@@ -9630,6 +9635,8 @@ interview_note = FALSE
 'Navigates to case note, and checks to make sure we aren't in inquiry.
 ' If SNAP_checkbox = checked OR family_cash = TRUE OR CAF_type = "Application" then
 If interview_waived = TRUE Then
+    case_notes_information = case_notes_information & "Interview Waived NOTE Attempted %^%"
+    case_notes_information = case_notes_information & "Script Header - " & "Interview for the Renewal was WAIVED" & " %^%"
     Call start_a_blank_CASE_NOTE
 
     CALL write_variable_in_CASE_NOTE("Interview for the Renewal was WAIVED")
@@ -9647,11 +9654,16 @@ If interview_waived = TRUE Then
     CALL write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    EMReadScreen top_note_header, 55, 5, 25
+    case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+
     Call back_to_SELF
 End If
 
 If interview_required = TRUE AND interview_completed_case_note_found = False Then
     interview_note = TRUE
+    case_notes_information = case_notes_information & "Interview Completed NOTE Attempted %^%"
+    case_notes_information = case_notes_information & "Script Header - " & "~ Interview Completed on " & interview_date & " ~" & " %^%"
     Call start_a_blank_CASE_NOTE
 
     CALL write_variable_in_CASE_NOTE("~ Interview Completed on " & interview_date & " ~")
@@ -9729,6 +9741,9 @@ If interview_required = TRUE AND interview_completed_case_note_found = False The
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    EMReadScreen top_note_header, 55, 5, 25
+    case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+
     Call back_to_SELF
 End If
 
@@ -9746,6 +9761,8 @@ If trim(verifs_needed) <> "" AND verifications_requested_case_note_found = False
         verifs_array = array(verifs_needed)
     End If
 
+    case_notes_information = case_notes_information & "Verifs NOTE Attempted %^%"
+    case_notes_information = case_notes_information & "Script Header - " & "VERIFICATIONS REQUESTED" & " %^%"
     Call start_a_blank_CASE_NOTE
 
     Call write_variable_in_CASE_NOTE("VERIFICATIONS REQUESTED")
@@ -9770,10 +9787,15 @@ If trim(verifs_needed) <> "" AND verifications_requested_case_note_found = False
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    EMReadScreen top_note_header, 55, 5, 25
+    case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+
     Call back_to_SELF
 End If
 
 If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = False Then
+    case_notes_information = case_notes_information & "Qualifying Questions NOTE Attempted %^%"
+    case_notes_information = case_notes_information & "Script Header - " & "CAF Qualifying Questions had an answer of 'YES' for at least one question" & " %^%"
     Call start_a_blank_CASE_NOTE
 
     Call write_variable_in_CASE_NOTE("CAF Qualifying Questions had an answer of 'YES' for at least one question")
@@ -9786,16 +9808,22 @@ If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = Fals
     Call write_variable_in_CASE_NOTE(worker_signature)
 
     PF3
+    EMReadScreen top_note_header, 55, 5, 25
+    case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+
     Call back_to_SELF
 End If
 
 'MAIN CAF Information NOTE
 'Navigates to case note, and checks to make sure we aren't in inquiry.
+case_notes_information = case_notes_information & "MAIN CAF NOTE Attempted %^%"
 Call start_a_blank_CASE_NOTE
 
 If CAF_form = "HUF (DHS-8107)" Then
+    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " HUF for " & prog_and_type_list & CAF_status & " %^% %^%"
     CALL write_variable_in_CASE_NOTE(CAF_datestamp & " HUF for " & prog_and_type_list & CAF_status)
 Else
+    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " CAF for " & prog_and_type_list & CAF_status & " %^% %^%"
     CALL write_variable_in_CASE_NOTE(CAF_datestamp & " CAF for " & prog_and_type_list & CAF_status)
 End If
 Call write_bullet_and_variable_in_CASE_NOTE("Form Received", CAF_form)
@@ -10180,5 +10208,8 @@ END IF
 end_msg = "Success! " & CAF_form & " has been successfully noted. Please remember to run the Approved Programs, Closed Programs, or Denied Programs scripts if  results have been APP'd."
 If do_not_update_prog = 1 Then end_msg = end_msg & vbNewLine & vbNewLine & "It was selected that PROG would NOT be updated because " & no_update_reason
 If interview_waived = TRUE Then end_msg = "INTERVIEW WAIVED" & vbCR & vbCr & end_msg
+
+
+case_notes_information
 
 script_end_procedure_with_error_report(end_msg)

--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -50,6 +50,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("03/17/2022", "BUG FIX##~##There have been reports of some of the required CASE:NOTEs missing from the script run at the end. We have updated some of the background functionality in this script to keep this from happening. If you notice issues with CASE:NOTEs missing at the end of this script run, report them to the BlueZone Script Team.", "Casey Love, Hennepin County")
 call changelog_update("12/20/2021", "Removal of interview completed button. ", "MiKayla Handley")
 call changelog_update("10/04/2021", "The CAF script now has 'SAVE YOUR WORK' functionality in testing. If the script fails, run it again on the same case and information should be filled back in to the dialog.##~##", "Casey Love, Hennepin County")
 Call changelog_update("09/01/2021", "Expedited Determination Functionality has been completely enhanced.##~####~##The functionality to guide through the assesment of a case meeting expedited criteria has been updated. This new functionality adds a series of 3 new dialogs to support this process.##~####~##This new functionality matches the scripts NOTES - Expedited Determination and the new script NOTES - Interview.##~##", "Casey Love, Hennepin County")

--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -1205,7 +1205,6 @@ function save_your_work()
             objTextStream.WriteLine "notes_on_other_assets" & "^~^~^~^~^~^~^" & notes_on_other_assets
             objTextStream.WriteLine "MEDI" & "^~^~^~^~^~^~^" & MEDI
             objTextStream.WriteLine "DISQ" & "^~^~^~^~^~^~^" & DISQ
-            If MFIP_DVD_checkbox = checked Then objTextStream.WriteLine "MFIP_DVD_checkbox" & "^~^~^~^~^~^~^" & "CHECKED"
             'EXP DET'
             objTextStream.WriteLine "full_determination_done" & "^~^~^~^~^~^~^" & full_determination_done
             ' Call run_expedited_determination_script_functionality(
@@ -1599,8 +1598,6 @@ function save_your_work()
             script_run_lowdown = script_run_lowdown & vbCr & "notes_on_other_assets" & ": " & notes_on_other_assets
             script_run_lowdown = script_run_lowdown & vbCr & "MEDI" & ": " & MEDI
             script_run_lowdown = script_run_lowdown & vbCr & "DISQ" & ": " & DISQ
-            If MFIP_DVD_checkbox = checked Then script_run_lowdown = script_run_lowdown & vbCr & "MFIP_DVD_checkbox" & ": " & "CHECKED"
-            If MFIP_DVD_checkbox = unchecked Then script_run_lowdown = script_run_lowdown & vbCr & "MFIP_DVD_checkbox" & ": " & "UNCHECKED"
             'EXP DET'
             script_run_lowdown = script_run_lowdown & vbCr & "full_determination_done" & ": " & full_determination_done & vbCr & vbCr
             ' Call run_expedited_determination_script_functionality(
@@ -1696,7 +1693,7 @@ function save_your_work()
             If client_delay_TIKL_checkbox = unchecked Then script_run_lowdown = script_run_lowdown & vbCr & "client_delay_TIKL_checkbox" & ": " & "UNCHECKED" & vbCr & vbCr
             script_run_lowdown = script_run_lowdown & vbCr & "verif_req_form_sent_date" & ": " & verif_req_form_sent_date
             script_run_lowdown = script_run_lowdown & vbCr & "worker_signature" & ": " & worker_signature
-            script_run_lowdown = script_run_lowdown & vbCr & "script_information_was_restored" & ":" & script_information_was_restored
+            script_run_lowdown = script_run_lowdown & vbCr & "script_information_was_restored" & ": " & script_information_was_restored
             case_note_lowdown = replace(case_notes_information, "%^%", vbCr)
             script_run_lowdown = script_run_lowdown & vbCr & vbCr & case_note_lowdown
         End If
@@ -2279,8 +2276,6 @@ function restore_your_work(vars_filled)
                         If line_info(0) = "notes_on_other_assets" Then notes_on_other_assets = line_info(1)
                         If line_info(0) = "MEDI" Then MEDI = line_info(1)
                         If line_info(0) = "DISQ" Then DISQ = line_info(1)
-                        ' If MFIP_DVD_checkbox = checked Then objTextStream.WriteLine
-                        If line_info(0) = "MFIP_DVD_checkbox" and line_info(1) = "CHECKED" Then MFIP_DVD_checkbox = checked
                         'EXP DET'
                         If line_info(0) = "full_determination_done" Then full_determination_done = line_info(1)
                         If UCase(full_determination_done) = "TRUE" Then full_determination_done = True
@@ -5388,7 +5383,7 @@ Dim prosp_heat_air, prosp_electric, prosp_phone, ABPS, ACCI, notes_on_acct, note
 Dim FACI, FMED, IMIG, INSA, cit_id, other_assets, case_changes, PREG, earned_income, notes_on_rest, SCHL, notes_on_jobs, notes_on_time, notes_on_sanction, notes_on_wreg, full_abawd_info, notes_on_abawd
 Dim notes_on_abawd_two, notes_on_abawd_three, programs_applied_for, TIKL_checkbox, interview_memb_list, shel_memb_list, verification_memb_list, notes_on_busi, Used_Interpreter_checkbox
 Dim arep_id_info, CS_forms_sent_date, notes_on_ssa_income, notes_on_VA_income, notes_on_WC_income, other_uc_income_notes, notes_on_other_UNEA, hest_information, notes_on_other_deduction, expense_notes
-Dim address_confirmation_checkbox, manual_total_shelter, app_month_assets, confirm_no_account_panel_checkbox, notes_on_other_assets, MEDI, DISQ, MFIP_DVD_checkbox, full_determination_done
+Dim address_confirmation_checkbox, manual_total_shelter, app_month_assets, confirm_no_account_panel_checkbox, notes_on_other_assets, MEDI, DISQ, full_determination_done
 Dim determined_income, determined_assets, determined_shel, determined_utilities, calculated_resources, calculated_expenses, calculated_low_income_asset_test, calculated_resources_less_than_expenses_test
 Dim is_elig_XFS, approval_date, applicant_id_on_file_yn, applicant_id_through_SOLQ, delay_explanation, snap_denial_explain, case_assesment_text, next_steps_one, next_steps_two, next_steps_three
 Dim next_steps_four, postponed_verifs_yn, list_postponed_verifs, day_30_from_application, other_snap_state, other_state_reported_benefit_end_date, other_state_benefits_openended, other_state_contact_yn
@@ -7867,7 +7862,6 @@ Do
                       EditBox 50, 245, 500, 15, EMPS
                       ButtonGroup ButtonPressed
                         PushButton 25, 265, 15, 15, "!", tips_and_tricks_emps_button
-                      CheckBox 50, 270, 180, 10, "Sent MFIP financial orientation DVD to participant(s).", MFIP_DVD_checkbox
                       EditBox 60, 290, 495, 15, verifs_needed
                       GroupBox 105, 310, 355, 25, "Dialog Tabs"
                       Text 110, 320, 300, 10, "                       |                    |                   |                  |                    |                    |   7 - Assets    |"
@@ -8994,7 +8988,6 @@ If trim(all_abawd_notes) <> "" Then case_has_personal = TRUE
 If trim(notes_on_time) <> "" Then case_has_personal = TRUE
 If trim(notes_on_sanction) <> "" Then case_has_personal = TRUE
 If trim(EMPS) <> "" Then case_has_personal = TRUE
-If MFIP_DVD_checkbox = checked Then case_has_personal = TRUE
 If trim(MEDI) <> "" Then case_has_personal = TRUE
 If trim(DIET) <> "" Then case_has_personal = TRUE
 If trim(case_changes) <> "" Then case_has_personal = TRUE
@@ -10158,7 +10151,6 @@ Call write_bullet_and_variable_in_CASE_NOTE("Diet", DIET)
 Call write_bullet_and_variable_in_CASE_NOTE("Time Tracking (MFIP)", notes_on_time)
 Call write_bullet_and_variable_in_CASE_NOTE("MFIP Sanction", notes_on_sanction)
 Call write_bullet_and_variable_in_CASE_NOTE("MF/DWP Employment Services", EMPS)
-If MFIP_DVD_checkbox = checked Then Call write_variable_in_CASE_NOTE("* MFIP financial orientation DVD sent to participant(s).")
 
 If case_has_expenses = TRUE Then
     Call write_variable_in_CASE_NOTE("===== EXPENSES =====")

--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -1285,6 +1285,9 @@ function save_your_work()
             If client_delay_TIKL_checkbox = checked Then objTextStream.WriteLine "client_delay_TIKL_checkbox" & "^~^~^~^~^~^~^" & "CHECKED"
             objTextStream.WriteLine "verif_req_form_sent_date" & "^~^~^~^~^~^~^" & verif_req_form_sent_date
             objTextStream.WriteLine "worker_signature" & "^~^~^~^~^~^~^" & worker_signature
+            objTextStream.WriteLine "script_information_was_restored" & "^~^~^~^~^~^~^" & script_information_was_restored
+
+            objTextStream.WriteLine case_notes_information
             ' objTextStream.WriteLine "" & "^~^~^~^~^~^~^" &
 
             'Close the object so it can be opened again shortly
@@ -1693,6 +1696,9 @@ function save_your_work()
             If client_delay_TIKL_checkbox = unchecked Then script_run_lowdown = script_run_lowdown & vbCr & "client_delay_TIKL_checkbox" & ": " & "UNCHECKED" & vbCr & vbCr
             script_run_lowdown = script_run_lowdown & vbCr & "verif_req_form_sent_date" & ": " & verif_req_form_sent_date
             script_run_lowdown = script_run_lowdown & vbCr & "worker_signature" & ": " & worker_signature
+            script_run_lowdown = script_run_lowdown & vbCr & "script_information_was_restored" & ":" & script_information_was_restored
+            case_note_lowdown = replace(case_notes_information, "%^%", vbCr)
+            script_run_lowdown = script_run_lowdown & vbCr & vbCr & case_note_lowdown
         End If
     End With
 end function
@@ -1702,6 +1708,7 @@ function restore_your_work(vars_filled)
 
 	'Now determines name of file
 	local_changelog_path = user_myDocs_folder & "caf-variables-" & MAXIS_case_number & "-info.txt"
+    script_information_was_restored = True
 
 	With objFSO
 
@@ -1814,7 +1821,8 @@ function restore_your_work(vars_filled)
                         If UCase(none_expense) = "FALSE" Then none_expense = False
                         If line_info(0) = "all_utilities" Then all_utilities = line_info(1)
                         If line_info(0) = "do_we_have_applicant_id" Then do_we_have_applicant_id = line_info(1)
-
+                        If UCase(do_we_have_applicant_id) = "TRUE" Then do_we_have_applicant_id = True
+                        If UCase(do_we_have_applicant_id) = "FALSE" Then do_we_have_applicant_id = False
                         If line_info(0) = "adult_cash" Then adult_cash = line_info(1)
                         If UCase(adult_cash) = "TRUE" Then adult_cash = True
                         If UCase(adult_cash) = "FALSE" Then adult_cash = False
@@ -1868,6 +1876,8 @@ function restore_your_work(vars_filled)
                         If line_info(0) = "interview_with" Then interview_with = line_info(1)
                         If line_info(0) = "interview_type" Then interview_type = line_info(1)
                         If line_info(0) = "verifications_requested_case_note_found" Then verifications_requested_case_note_found = line_info(1)
+                        If UCase(verifications_requested_case_note_found) = "TRUE" Then verifications_requested_case_note_found = True
+                        If UCase(verifications_requested_case_note_found) = "FALSE" Then verifications_requested_case_note_found = False
                         If line_info(0) = "verifs_needed" Then verifs_needed = line_info(1)
                         If line_info(0) = "caf_qualifying_questions_case_note_found" Then caf_qualifying_questions_case_note_found = line_info(1)
                         If UCase(caf_qualifying_questions_case_note_found) = "TRUE" Then caf_qualifying_questions_case_note_found = True
@@ -2261,6 +2271,8 @@ function restore_your_work(vars_filled)
                         If line_info(0) = "address_confirmation_checkbox" and line_info(1) = "CHECKED" Then address_confirmation_checkbox = checked
                         If line_info(0) = "manual_total_shelter" Then manual_total_shelter = line_info(1)
                         If line_info(0) = "manual_amount_used" Then manual_amount_used = line_info(1)
+                        If UCase(manual_amount_used) = "TRUE" Then manual_amount_used = True
+                        If UCase(manual_amount_used) = "FALSE" Then manual_amount_used = False
                         If line_info(0) = "app_month_assets" Then app_month_assets = line_info(1)
                         ' If confirm_no_account_panel_checkbox = checked Then objTextStream.WriteLine
                         If line_info(0) = "confirm_no_account_panel_checkbox" and line_info(1) = "CHECKED" Then confirm_no_account_panel_checkbox = checked
@@ -5422,6 +5434,8 @@ Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
 Call remove_dash_from_droplist(county_list)
 Call find_user_name(worker_name)
 script_run_lowdown = ""
+case_notes_information = "No CASE NOTEs Attempted"
+script_information_was_restored = False
 
 Dialog1 = ""
 BeginDialog Dialog1, 0, 0, 281, 185, "CAF Script Case number dialog"
@@ -8872,9 +8886,6 @@ If HC_checkbox = checked Then
     End If
 End If
 
-'Adding a colon to the beginning of the CAF status variable if it isn't blank (simplifies writing the header of the case note)
-If CAF_status <> "" then CAF_status = ": " & CAF_status
-
 'Adding footer month to the recertification case notes
 If CAF_type = "Recertification" then CAF_type = MAXIS_footer_month & "/" & MAXIS_footer_year & " recert"
 progs_list = ""
@@ -9015,6 +9026,7 @@ If trim(FMED) <> "" Then case_has_expenses = TRUE
 'Expedited Determination Case Note
 'Navigates to case note, and checks to make sure we aren't in inquiry.
 case_notes_information = "CASE NOTES ATTEMPTED AND OUTCOME %^% %^%"
+If HC_checkbox = unchecked Then case_notes_information = case_notes_information & "No HC NOTE Attempted - HC not checked %^% %^%"
 If HC_checkbox = checked Then
     case_notes_information = case_notes_information & "HC NOTE Attempted %^%"
     hc_note_header = HC_datestamp & " " & HC_document_received & ": " & HC_form_status
@@ -9314,6 +9326,7 @@ If HC_checkbox = checked Then
     PF3
     EMReadScreen top_note_header, 55, 5, 25
     case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+    save_your_work
 
     Call back_to_SELF
 
@@ -9634,6 +9647,7 @@ interview_note = FALSE
 'Interview Incomfation Detail Case Note
 'Navigates to case note, and checks to make sure we aren't in inquiry.
 ' If SNAP_checkbox = checked OR family_cash = TRUE OR CAF_type = "Application" then
+If interview_waived = False Then case_notes_information = case_notes_information & "No Interview Waived NOTE Attempted - interview waived is false %^% %^%"
 If interview_waived = TRUE Then
     case_notes_information = case_notes_information & "Interview Waived NOTE Attempted %^%"
     case_notes_information = case_notes_information & "Script Header - " & "Interview for the Renewal was WAIVED" & " %^%"
@@ -9656,10 +9670,17 @@ If interview_waived = TRUE Then
     PF3
     EMReadScreen top_note_header, 55, 5, 25
     case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+    save_your_work
 
     Call back_to_SELF
 End If
 
+If interview_required = False or interview_completed_case_note_found = True Then
+    case_notes_information = case_notes_information & "No Interview Completed NOTE Attempted "
+    If interview_required = False Then case_notes_information = case_notes_information & "- interview required is false"
+    If interview_completed_case_note_found = True Then case_notes_information = case_notes_information & "- interview completed case note was found"
+    case_notes_information = case_notes_information & " %^% %^%"
+End If
 If interview_required = TRUE AND interview_completed_case_note_found = False Then
     interview_note = TRUE
     case_notes_information = case_notes_information & "Interview Completed NOTE Attempted %^%"
@@ -9743,12 +9764,19 @@ If interview_required = TRUE AND interview_completed_case_note_found = False The
     PF3
     EMReadScreen top_note_header, 55, 5, 25
     case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+    save_your_work
 
     Call back_to_SELF
 End If
 
 'Verification NOTE
 verifs_needed = replace(verifs_needed, "[Information here creates a SEPARATE CASE/NOTE.]", "")
+If trim(verifs_needed) = "" or verifications_requested_case_note_found = True Then
+    case_notes_information = case_notes_information & "No Verifs NOTE Attempted "
+    If trim(verifs_needed) = "" Then case_notes_information = case_notes_information & "- verif field is blank"
+    If verifications_requested_case_note_found = True Then case_notes_information = case_notes_information & "- verif case note was found"
+    case_notes_information = case_notes_information & " %^% %^%"
+End If
 If trim(verifs_needed) <> "" AND verifications_requested_case_note_found = False Then
 
     verif_counter = 1
@@ -9789,10 +9817,17 @@ If trim(verifs_needed) <> "" AND verifications_requested_case_note_found = False
     PF3
     EMReadScreen top_note_header, 55, 5, 25
     case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+    save_your_work
 
     Call back_to_SELF
 End If
 
+If qual_questions_yes = False or caf_qualifying_questions_case_note_found = True Then
+    case_notes_information = case_notes_information & "No Qualifying Questions NOTE Attempted "
+    If qual_questions_yes = False Then case_notes_information = case_notes_information & "- no qualifying questions were yes"
+    If caf_qualifying_questions_case_note_found = True Then case_notes_information = case_notes_information & "- qualifying questions case note was found"
+    case_notes_information = case_notes_information & " %^% %^%"
+End If
 If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = False Then
     case_notes_information = case_notes_information & "Qualifying Questions NOTE Attempted %^%"
     case_notes_information = case_notes_information & "Script Header - " & "CAF Qualifying Questions had an answer of 'YES' for at least one question" & " %^%"
@@ -9810,6 +9845,7 @@ If qual_questions_yes = TRUE AND caf_qualifying_questions_case_note_found = Fals
     PF3
     EMReadScreen top_note_header, 55, 5, 25
     case_notes_information = case_notes_information & "MX Header - " & top_note_header & " %^% %^%"
+    save_your_work
 
     Call back_to_SELF
 End If
@@ -9820,11 +9856,11 @@ case_notes_information = case_notes_information & "MAIN CAF NOTE Attempted %^%"
 Call start_a_blank_CASE_NOTE
 
 If CAF_form = "HUF (DHS-8107)" Then
-    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " HUF for " & prog_and_type_list & CAF_status & " %^% %^%"
-    CALL write_variable_in_CASE_NOTE(CAF_datestamp & " HUF for " & prog_and_type_list & CAF_status)
+    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " HUF for " & prog_and_type_list & ": " & CAF_status & " %^% %^%"
+    CALL write_variable_in_CASE_NOTE(CAF_datestamp & " HUF for " & prog_and_type_list & ": " & CAF_status)
 Else
-    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " CAF for " & prog_and_type_list & CAF_status & " %^% %^%"
-    CALL write_variable_in_CASE_NOTE(CAF_datestamp & " CAF for " & prog_and_type_list & CAF_status)
+    case_notes_information = case_notes_information & "Script Header - " & CAF_datestamp & " CAF for " & prog_and_type_list & ": " & CAF_status & " %^% %^%"
+    CALL write_variable_in_CASE_NOTE(CAF_datestamp & " CAF for " & prog_and_type_list & ": " & CAF_status)
 End If
 Call write_bullet_and_variable_in_CASE_NOTE("Form Received", CAF_form)
 'Programs requested
@@ -10209,7 +10245,6 @@ end_msg = "Success! " & CAF_form & " has been successfully noted. Please remembe
 If do_not_update_prog = 1 Then end_msg = end_msg & vbNewLine & vbNewLine & "It was selected that PROG would NOT be updated because " & no_update_reason
 If interview_waived = TRUE Then end_msg = "INTERVIEW WAIVED" & vbCR & vbCr & end_msg
 
-
-case_notes_information
+save_your_work
 
 script_end_procedure_with_error_report(end_msg)


### PR DESCRIPTION
Added:
1. Back to self between each note to ensure MAXIS is moving in the right way.
2. report out about the attempts of the script in creating CASE NOTE in the save your work and script run lowdown.
3. Found a string/boolean issue with restore your work that might actually be the cause - reviewed variables and added resolution code for the boolean variables. 
4. Removed MFIP DVD functionality
5. Added a script run lowdown detail to dindicate if a script run is using restore your work for future error report review

All functionality is ready for review.