### PR TITLE
#764 and #775 NOTES - Application Received - adding handling for checking ADDR and CCAP Reqquests

### DIFF
--- a/case-assignment/application-received.vbs
+++ b/case-assignment/application-received.vbs
@@ -43,6 +43,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 		Execute text_from_the_other_script
 	END IF
 END IF
+running_from_ca_menu = True
 call run_from_GitHub(script_repository & "notes/application-received.vbs")
 
 'END FUNCTIONS LIBRARY BLOCK================================================================================================

--- a/notes/application-received.vbs
+++ b/notes/application-received.vbs
@@ -706,7 +706,7 @@ If was_ccap_requested = "Yes - Child Care Requested" Then
     Call find_user_name(the_person_running_the_script)
 
     ccap_email_subject = "ES - CA - Financial Case " & MAXIS_case_number & " - " & case_name & " also requests CCAP"
-    ccap_email_body = "MNbenefits Applicvation received requesting CCAP with other financial programs."
+    ccap_email_body = "MNbenefits Application received requesting CCAP with other financial programs."
     If trim(confirmation_number) <> "" Then ccap_email_body = ccap_email_body & vbCr & "Confirmation Number: " & confirmation_number
     ccap_email_body = ccap_email_body & vbCr & vbCr & "MAXIS Case Number: " & MAXIS_case_number
     ccap_email_body = ccap_email_body & vbCr & "MAXIS Case Name: " & case_name

--- a/notes/application-received.vbs
+++ b/notes/application-received.vbs
@@ -214,6 +214,12 @@ IF IsDate(application_date) = False THEN                   'If we could NOT find
 End if
 
 Call back_to_SELF
+Call navigate_to_MAXIS_screen("STAT", "MEMB")
+EMReadscreen last_name, 25, 6, 30
+EMReadscreen first_name, 12, 6, 63
+last_name = replace(last_name, "_", "")
+first_name = replace(first_name, "_", "")
+case_name = last_name & ", " & first_name
 Call navigate_to_MAXIS_screen("STAT", "PROG")           'going here because this is a good background for the dialog to display against.
 
 IF IsDate(application_date) = False THEN
@@ -270,17 +276,18 @@ End If
 ' EndDialog
 
 'since this dialog has different displays for SNAP cases vs non-snap cases - there are differences in the dialog size
-dlg_len = 225
-If snap_status = "PENDING" Then dlg_len = 335
+dlg_len = 240
+If snap_status = "PENDING" Then dlg_len = 350
 
 'This is the dialog with the application information.
 Dialog1 = "" 'Blanking out previous dialog detail
 BeginDialog Dialog1, 0, 0, 266, dlg_len, "Application Received for: " & programs_applied_for & " on " & application_date
-  GroupBox 5, 5, 255, 120, "Application Information"
-  DropListBox 85, 40, 95, 15, "Select One:"+chr(9)+"Fax"+chr(9)+"Mail"+chr(9)+"Mystery Doc Queue"+chr(9)+"Online"+chr(9)+"Phone-Verbal Request"+chr(9)+"Request to APPL Form"+chr(9)+"Virtual Drop Box", how_application_rcvd
-  DropListBox 85, 60, 95, 15, "Select One:"+chr(9)+"CAF"+chr(9)+"6696"+chr(9)+"HCAPP"+chr(9)+"HC-Certain Populations"+chr(9)+"LTC"+chr(9)+"MHCP B/C Cancer"+chr(9)+"MNbenefits"+chr(9)+"N/A"+chr(9)+"Verbal Request", application_type
+  GroupBox 5, 5, 255, 140, "Application Information"
+  DropListBox 85, 40, 95, 45, "Select One:"+chr(9)+"Fax"+chr(9)+"Mail"+chr(9)+"Mystery Doc Queue"+chr(9)+"Online"+chr(9)+"Phone-Verbal Request"+chr(9)+"Request to APPL Form"+chr(9)+"Virtual Drop Box", how_application_rcvd
+  DropListBox 85, 60, 95, 45, "Select One:"+chr(9)+"CAF"+chr(9)+"6696"+chr(9)+"HCAPP"+chr(9)+"HC-Certain Populations"+chr(9)+"LTC"+chr(9)+"MHCP B/C Cancer"+chr(9)+"MNbenefits"+chr(9)+"N/A"+chr(9)+"Verbal Request", application_type
   EditBox 85, 85, 95, 15, confirmation_number
   DropListBox 85, 105, 170, 45, "Select One:"+chr(9)+"Adults"+chr(9)+"Families"+chr(9)+"Specialty", population_of_case
+  DropListBox 85, 125, 95, 45, "No - Only ES Programs"+chr(9)+"Yes - Child Care Requested", was_ccap_requested
   Text 15, 25, 65, 10, "Date of Application:"
   Text 85, 25, 60, 10, application_date
   Text 185, 20, 65, 10, "Pending Programs:"
@@ -330,25 +337,26 @@ BeginDialog Dialog1, 0, 0, 266, dlg_len, "Application Received for: " & programs
     y_pos = y_pos + 10
   End If
   Text 10, 45, 70, 10, "Application Received:"
-  Text 10, 65, 65, 10, "Type of Application:"
+  Text 15, 65, 65, 10, "Type of Application:"
   Text 85, 75, 50, 10, "Confirmation #:"
   Text 10, 110, 70, 10, "Population/Specialty"
-  y_pos = 135
+  Text 7, 130, 75, 10, "Was CCAP Reuested?"
+  y_pos = 150
   If snap_status = "PENDING" Then
-      GroupBox 5, 130, 255, 105, "Expedited Screening"
-      EditBox 130, 145, 50, 15, income
-      EditBox 130, 165, 50, 15, assets
-      EditBox 130, 185, 50, 15, rent
-      CheckBox 15, 215, 55, 10, "Heat (or AC)", heat_AC_check
-      CheckBox 85, 215, 45, 10, "Electricity", electric_check
-      CheckBox 140, 215, 35, 10, "Phone", phone_check
-      Text 25, 150, 95, 10, "Income received this month:"
-      Text 30, 170, 95, 10, "Cash, checking, or savings: "
-      Text 30, 190, 90, 10, "AMT paid for rent/mortgage:"
-      GroupBox 10, 205, 170, 25, "Utilities claimed (check below):"
-      GroupBox 185, 140, 70, 65, "**IMPORTANT**"
-      Text 190, 155, 60, 45, "The income, assets and shelter costs fields will default to $0 if left blank. "
-      y_pos = 245
+      GroupBox 5, 150, 255, 105, "Expedited Screening"
+      EditBox 130, 165, 50, 15, income
+      EditBox 130, 185, 50, 15, assets
+      EditBox 130, 205, 50, 15, rent
+      CheckBox 15, 235, 55, 10, "Heat (or AC)", heat_AC_check
+      CheckBox 85, 235, 45, 10, "Electricity", electric_check
+      CheckBox 140, 235, 35, 10, "Phone", phone_check
+      Text 25, 170, 95, 10, "Income received this month:"
+      Text 30, 190, 95, 10, "Cash, checking, or savings: "
+      Text 30, 210, 90, 10, "AMT paid for rent/mortgage:"
+      GroupBox 10, 225, 170, 25, "Utilities claimed (check below):"
+      GroupBox 185, 160, 70, 65, "**IMPORTANT**"
+      Text 190, 175, 60, 45, "The income, assets and shelter costs fields will default to $0 if left blank. "
+      y_pos = 260
   End If
   CheckBox 15, y_pos, 220, 10, "Check here if a HH Member is active on another MAXIS Case.", hh_memb_on_active_case_checkbox
   y_pos = y_pos + 15
@@ -684,6 +692,22 @@ IF how_application_rcvd = "Request to APPL Form" and METS_retro_checkbox = UNCHE
     CALL create_outlook_email("", "", "MAXIS case #" & maxis_case_number & " Request to APPL form received-APPL'd in MAXIS-ACTION REQUIRED.", "", "", FALSE)
     ELSEIF Auto_Newborn_checkbox = CHECKED THEN CALL create_outlook_email("", "", "MAXIS case #" & maxis_case_number & " Request to APPL form received-APPL'd in MAXIS-ACTION REQUIRED.", "", "", FALSE)
 END IF
+If was_ccap_requested = "Yes - Child Care Requested" Then
+    Call find_user_name(the_person_running_the_script)
+
+    ccap_email_subject = "ES - CA - Financial Case " & MAXIS_case_number & " - " & case_name & " also requests CCAP"
+    ccap_email_body = "MNbenefits Applicvation received requesting CCAP with other financial programs."
+    ccap_email_body = ccap_email_body & vbCr & "Confirmation Number: " & confirmation_number
+    ccap_email_body = ccap_email_body & vbCr & vbCr & "MAXIS Case Number: " & MAXIS_case_number
+    ccap_email_body = ccap_email_body & vbCr & "MAXIS Case Name: " & case_name
+    ccap_email_body = ccap_email_body & vbCr & vbCr & "Application form can be found in the ECF case file for this case."
+    ccap_email_body = ccap_email_body & vbCr & vbCr & "Thank you,"
+    ccap_email_body = ccap_email_body & vbCr & the_person_running_the_script
+    If running_from_ca_menu = True Then ccap_email_body = ccap_email_body & vbCr & "Case Assignment Team"
+
+    ' Call create_outlook_email("HSPH.ResourcesCCAP@hennepin.us", "", ccap_email_subject, ccap_email_body, "", True)
+    Call create_outlook_email("Casey.love@hennepin.us", "", ccap_email_subject, ccap_email_body, "", True)
+End If
 
 IF METS_retro_checkbox = CHECKED and team_603_email_checkbox = UNCHECKED THEN CALL create_outlook_email("", "", "MAXIS case #" & maxis_case_number & "/METS IC #" & METS_case_number & " Retro Request APPL'd in MAXIS-ACTION REQUIRED.", "", "", FALSE)
 

--- a/notes/application-received.vbs
+++ b/notes/application-received.vbs
@@ -213,6 +213,15 @@ IF IsDate(application_date) = False THEN                   'If we could NOT find
     application_date = pnd2_appl_date
 End if
 
+Call navigate_to_MAXIS_screen("SPEC", "MEMO")
+PF5
+EMReadScreen recipient_type, 6, 5, 15
+PF3
+If recipient_type <> "CLIENT" Then
+    script_run_lowdown = script_run_lowdown & vbCr & "First MEMO Recipient was: " & recipient_type
+    Call script_end_procedure_with_error_report("This case appears to have an issue with the ADDR panel. Proper case actions cannot occur if the ADDR panel is missing, blank, or has another error.")
+End If
+
 Call back_to_SELF
 Call navigate_to_MAXIS_screen("STAT", "MEMB")
 EMReadscreen last_name, 25, 6, 30

--- a/notes/application-received.vbs
+++ b/notes/application-received.vbs
@@ -53,6 +53,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County
+call changelog_update("04/18/2022", "Added a checkbox if the application also requests Child Care Assistance. The script will send an email to the CCAP team alerting them to the request so that follow up can happen following CCAP process.", "Casey Love, Hennepin County")
 call changelog_update("03/29/2022", "Removed APPLYMN as application option.", "Ilse Ferris, Hennepin County")
 call changelog_update("03/11/2022", "Added randomizer functionality for Adults appplications that appear expedited. Caseloads suggested will be either EX1 or EX2", "Ilse Ferris, Hennepin County")
 call changelog_update("03/07/2022", "Updated METS retro contact from Team 601 to Team 603.", "Ilse Ferris, Hennepin County")

--- a/notes/application-received.vbs
+++ b/notes/application-received.vbs
@@ -388,6 +388,7 @@ Do
         err_msg = ""
         Dialog Dialog1
         cancel_confirmation
+        If application_type = "MNbenefits" AND how_application_rcvd = "Select One:" Then how_application_rcvd = "Online"
 	    IF how_application_rcvd = "Select One:" then err_msg = err_msg & vbNewLine & "* Please enter how the application was received to the agency."
         'IF application_type = "N/A" and other_notes = "" THEN err_msg = err_msg & vbNewLine & "* Please enter in other notes what type of application was received to the agency."
 	    IF application_type = "Select One:" then err_msg = err_msg & vbNewLine & "* Please enter the type of application received."
@@ -706,7 +707,7 @@ If was_ccap_requested = "Yes - Child Care Requested" Then
 
     ccap_email_subject = "ES - CA - Financial Case " & MAXIS_case_number & " - " & case_name & " also requests CCAP"
     ccap_email_body = "MNbenefits Applicvation received requesting CCAP with other financial programs."
-    ccap_email_body = ccap_email_body & vbCr & "Confirmation Number: " & confirmation_number
+    If trim(confirmation_number) <> "" Then ccap_email_body = ccap_email_body & vbCr & "Confirmation Number: " & confirmation_number
     ccap_email_body = ccap_email_body & vbCr & vbCr & "MAXIS Case Number: " & MAXIS_case_number
     ccap_email_body = ccap_email_body & vbCr & "MAXIS Case Name: " & case_name
     ccap_email_body = ccap_email_body & vbCr & vbCr & "Application form can be found in the ECF case file for this case."
@@ -714,8 +715,7 @@ If was_ccap_requested = "Yes - Child Care Requested" Then
     ccap_email_body = ccap_email_body & vbCr & the_person_running_the_script
     If running_from_ca_menu = True Then ccap_email_body = ccap_email_body & vbCr & "Case Assignment Team"
 
-    ' Call create_outlook_email("HSPH.ResourcesCCAP@hennepin.us", "", ccap_email_subject, ccap_email_body, "", True)
-    Call create_outlook_email("Casey.love@hennepin.us", "", ccap_email_subject, ccap_email_body, "", True)
+    Call create_outlook_email("HSPH.ResourcesCCAP@hennepin.us", "", ccap_email_subject, ccap_email_body, "", True)
 End If
 
 IF METS_retro_checkbox = CHECKED and team_603_email_checkbox = UNCHECKED THEN CALL create_outlook_email("", "", "MAXIS case #" & maxis_case_number & "/METS IC #" & METS_case_number & " Retro Request APPL'd in MAXIS-ACTION REQUIRED.", "", "", FALSE)


### PR DESCRIPTION
Updates have been made to the NOTES - Application Received script so that we are helping to handle for sending CCAP requests to the right place and they do not get lost in the shuffle. 

1. Droplist to indicate that CCAP was requested on the Application. This will generate an email to the CCAP team. 
2. Once case number is received, the script will check MEMO to make sure the CLIENT is listed as the first recipient option. If not, there may be an issue with the ADDR panel. 

Approval from the CA and CCAP teams to start this Monday 4/18/22. 

@IlseFerris and @MiKaylaH22  - sorry to last minute this, but can we rush the review a little?