### PR TITLE
#836, #829, #828 Functions Library - Small bugs and enhancements

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -3349,6 +3349,7 @@ function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
         If ABPS_current = "________________________  First: ____________" then ABPS_current = "Parent unknown"
         ABPS_current = replace(ABPS_current, "  First:", ",")
         ABPS_current = replace(ABPS_current, "_", "")
+		ABPS_current = trim(ABPS_current)
         ABPS_current = split(ABPS_current)
         For each ABPS_part in ABPS_current
           first_letter = ucase(left(ABPS_part, 1))

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -9034,6 +9034,8 @@ function navigate_to_MAXIS_screen(function_to_go_to, command_to_go_to)
 '~~~~~ function_to_go_to: needs to be MAXIS function like "STAT" or "REPT"
 '~~~~~ command_to_go_to: needs to be MAXIS function like "WREG" or "ACTV"
 '===== Keywords: MAXIS, navigate
+	function_to_go_to = UCase(function_to_go_to)
+	command_to_go_to = UCase(command_to_go_to)
 	EMSendKey "<enter>"
 	EMWaitReady 0, 0
 	EMReadScreen MAXIS_check, 5, 1, 39
@@ -9077,7 +9079,7 @@ function navigate_to_MAXIS_screen(function_to_go_to, command_to_go_to)
 		End if
 
 		If already_at_the_correct_screen = False Then
-			If current_case_number = MAXIS_case_number and MAXIS_function = ucase(function_to_go_to) and STAT_note_check <> "NOTE" and at_correct_footer_month = True then
+			If current_case_number = MAXIS_case_number and MAXIS_function = function_to_go_to and STAT_note_check <> "NOTE" and at_correct_footer_month = True then
 				row = 1
 				col = 1
 				EMSearch "Command: ", row, col

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -5715,10 +5715,9 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 		'IF USING THIS FUNCTION IN A DAIL SCRUBBER SCRIPT - BE SURE TO ENTER A SetCursor BEFORE CALLING THE FUNCTION - OR OTHERWISE ENSURE THE CURSOR IS ON THE DAIL
 		EMSendKey "H"		'H is the command for CASE/CURR
 		TRANSMIT
-	Else
-		'If the DAIL conditions weren't met, the script will use the navigate function to get to CASE/CURR - this will lose the tie to the DAIL if called in a DAIL scrubber
-    	Call navigate_to_MAXIS_screen("CASE", "CURR")           				'First the function will navigate to CASE/CURR so the inofrmation discovered is based on current status
 	End If
+	'Now navigate to CASE CURR - if we are already there (by using the DAIL) this won't move as the function now checks to see if we are already at the screen 
+	Call navigate_to_MAXIS_screen("CASE", "CURR")           				'First the function will navigate to CASE/CURR so the inofrmation discovered is based on current status
 
     family_cash_case = FALSE                                					'defaulting all of the booleans
     adult_cash_case = FALSE

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -5705,8 +5705,22 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 '~~~~~ list_active_programs: string of all the programs that appear active, app open, or app close
 '~~~~~ list_pending_programs: string of all the programs that appear pending
 '===== Keywords: MAXIS, case status, output, status
-    Call navigate_to_MAXIS_screen("CASE", "CURR")           'First the function will navigate to CASE/CURR so the inofrmation discovered is based on current status
-    family_cash_case = FALSE                                'defaulting all of the booleans
+	EMReadScreen on_DAIL_check, 4, 2, 48 										'Read the top of the page to see if we are on DAIL DAIL - this will have different navigation to get to CASE CURR if we are on the DAIL
+	EMReadScreen no_pop_up_on_DAIL, 9, 4, 24 									'Ensuring that there isn't a DAIL open on the page - which would inhibit direct navigating
+	EMGetCursor dail_row, dail_col												'Navigating using the DAIL requires that the cursor has been set on the correct DAIL message, this will check to be sure the cursor is set to what is likely to be a DAIL navigation line
+	'The function will try to use commands from DAIL to navigate to CASE/CURR
+	'It makes sure on_DAIL is 'DAIL' and the Selection option is visible
+	'The command line function is always in column 3 and betweet row 6 and 18
+	If on_DAIL_check = "DAIL" and no_pop_up_on_DAIL = "Selection" and dail_col = 3 and dail_row > 5 and dail_row < 19 Then
+		'IF USING THIS FUNCTION IN A DAIL SCRUBBER SCRIPT - BE SURE TO ENTER A SetCursor BEFORE CALLING THE FUNCTION - OR OTHERWISE ENSURE THE CURSOR IS ON THE DAIL
+		EMSendKey "H"		'H is the command for CASE/CURR
+		TRANSMIT
+	Else
+		'If the DAIL conditions weren't met, the script will use the navigate function to get to CASE/CURR - this will lose the tie to the DAIL if called in a DAIL scrubber
+    	Call navigate_to_MAXIS_screen("CASE", "CURR")           				'First the function will navigate to CASE/CURR so the inofrmation discovered is based on current status
+	End If
+
+    family_cash_case = FALSE                                					'defaulting all of the booleans
     adult_cash_case = FALSE
     ga_case = FALSE
     msa_case = FALSE


### PR DESCRIPTION
This pull resolves three issues:

#836 - Autofill_editbox_from_MAXIS - when reading ABPS, if there is a space before the last name, a null item is created when split into an array of details in the function. Adding a trim to the variable before splitting will resolve this issue. 

#828 - determine_program_and_cases_status - changing the navigation to CASE/CURR to handle differently if starting from the DAIL.

#829 - navigate_to_MAXIS_screen - check to see if we are already at the right screen before having the script move.

Ready for review.