### PR TITLE
316 ensure worker signature is in all scripts that case/note

### DIFF
--- a/deu/adh-info-and-hearing.vbs
+++ b/deu/adh-info-and-hearing.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: CALL changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/16/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/30/2019", "Removed FSS Data Team from automated emails per request.", "Ilse Ferris, Hennepin County")
 CALL changelog_update("01/29/2018", "Updated to correct for member # error.", "MiKayla Handley, Hennepin County")
@@ -176,7 +177,6 @@ IF ADH_option = "ADH waiver signed" THEN
     CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
 	CALL write_variable_in_case_note("----- ----- ----- ----- -----")
     CALL write_variable_in_CASE_NOTE(worker_signature)
- 	CALL write_variable_in_case_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
 	'Function create_outlook_email(email_recip, email_recip_CC, email_subject, email_body, email_attachment, send_email)
 	CALL create_outlook_email("Lea.Bloomquist@hennepin.us", "HSPH.ES.TEAM.TTL@hennepin.us;" & fraud_email, "1st Fraud DISQ/Claims--ADH Waiver Signed for #" &  MAXIS_case_number, "Member #: " & memb_number & vbcr & "Client signed ADH waiver on: " & date_waiver_signed & " waiving his/her right to an Administrative Disqualification Hearing for wrongfully obtaining public assistance." & vbcr & "Programs: " & program_droplist & vbcr & "Period of Offense: " & start_date & " - " & end_date & vbcr & "See case notes for further details.", "", False)
 END IF
@@ -262,8 +262,6 @@ IF ADH_option = "Hearing Held" THEN
      CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
 	 CALL write_variable_in_case_note("----- ----- ----- ----- -----")
      CALL write_variable_in_CASE_NOTE(worker_signature)
-	 CALL write_variable_in_case_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-     PF3
 	 'Drafting an email. Does not send the email!!!!
 	 'Function create_outlook_email(email_recip, email_recip_CC, email_subject, email_body, email_attachment, send_email)
 	 CALL create_outlook_email("Lea.Bloomquist@hennepin.us", "HSPH.ES.TEAM.TTL@hennepin.us;" & fraud_email, "1st Fraud DISQ/Claims--ADH Hearing Held for #" &  MAXIS_case_number, "Member #: " & memb_number & vbcr & "Administrative Disqualification Hearing for Wrongfully Obtaining Public Assistance was held on: " & hearing_date & vbcr & "Order was signed: " & date_order_signed & vbcr & "Programs: " & program_droplist & vbcr & "Period of Offense: " & start_date & " - " & end_date & vbcr & "See case notes for further details.", "", False)

--- a/deu/appeal-summary-completed.vbs
+++ b/deu/appeal-summary-completed.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/16/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("04/13/2017", "Initial version.", "MiKayla Handley, Hennepin County")
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
@@ -97,6 +98,5 @@ Call write_bullet_and_variable_in_CASE_NOTE("Effective date of action being appe
 Call write_bullet_and_variable_in_CASE_NOTE("Action client is appealing:", action_client_is_appealing)
 Call write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
 CALL write_variable_in_CASE_NOTE(worker_signature)
-Call write_variable_in_CASE_NOTE("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
 
 script_end_procedure_with_error_report("Appeal Summary case note complete.")

--- a/deu/appeal-summary-completed.vbs
+++ b/deu/appeal-summary-completed.vbs
@@ -84,7 +84,7 @@ Do
 		IF IsNumeric(claim_number) = false THEN err_msg = err_msg & vbNewLine & "* Please enter a valid claim number."
 		IF Isdate(effective_date) = false THEN err_msg = err_msg & vbNewLine & "* Please enter the effective date."
 		IF action_client_is_appealing = "" THEN err_msg = err_msg & vbNewLine & "* Please enter action that client is appealing."
-		IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+		IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
 		IF err_msg <> "" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
     Loop until err_msg = ""
  	Call check_for_password(are_we_passworded_out)

--- a/deu/atr-received.vbs
+++ b/deu/atr-received.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: CALL changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("06/21/2022", "Updated handling for non-disclosure agreement and closing documentation.", "MiKayla Handley, Hennepin County") '#493
 CALL changelog_update("01/02/2018", "Corrected IEVS match error due to new year.", "MiKayla Handley, Hennepin County")
 CALL changelog_update("12/27/2017", "Corrected spelling error.", "MiKayla Handley, Hennepin County")
@@ -87,9 +88,9 @@ CALL navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB", is_this_priv)
 IF is_this_priv = TRUE THEN script_end_procedure("This case is privileged, the script will now end.")
 client_array = "Select One:" & "|"
 
-DO								'reads the reference number, last name, first name, and THEN puts it into a single string THEN into the array
-EMReadscreen ref_nbr, 3, 4, 33
-EMReadScreen access_denied_check, 13, 24, 2
+DO	'reads the reference number, last name, first name, and THEN puts it into a single string THEN into the array
+	EMReadscreen ref_nbr, 3, 4, 33
+	EMReadScreen access_denied_check, 13, 24, 2
 If access_denied_check = "ACCESS DENIED" Then
 	PF10
 	last_name = "UNABLE TO FIND"
@@ -472,7 +473,6 @@ IF claim_referral_tracking_dropdown <> "Not Needed" THEN
 	IF case_note_only = TRUE THEN CALL write_variable_in_case_note("Maxis case is inactive unable to add or update MISC panel")
 	CALL write_variable_in_case_note("-----")
 	CALL write_variable_in_case_note(worker_signature)
-	PF3
 END IF
 '-------------------------------------------------------------------------------------------------The case note
 start_a_blank_case_note
@@ -486,18 +486,17 @@ CALL write_bullet_and_variable_in_case_note("Period", IEVS_period)
 CALL write_bullet_and_variable_in_case_note("Active Programs", programs)
 CALL write_bullet_and_variable_in_case_note("Source of income", income_source)
 CALL write_variable_in_CASE_NOTE ("----- ----- ----- ----- -----")
-IF DISQ_action = "Pending verif" THEN CALL write_variable_in_CASE_NOTE("* Pending verification of income or asset")
-IF DISQ_action = "Deleted DISQ" THEN CALL write_variable_in_CASE_NOTE("* Updated DISQ panel")
+IF DISQ_action = "Pending verif" THEN CALL write_variable_in_CASE_NOTE("* Pending verification of income or asset.")
+IF DISQ_action = "Deleted DISQ" THEN CALL write_variable_in_CASE_NOTE("* Updated DISQ panel.")
 CALL write_bullet_and_variable_in_case_note("Verifications Received", pending_verifs)
 CALL write_bullet_and_variable_in_case_note("Source Address:", source_address)
 CALL write_bullet_and_variable_in_case_note("Fax/Phone:", source_phone)
 CALL write_bullet_and_variable_in_case_note("Response to Difference Notice", notice_sent)
 IF notice_sent = "Y" THEN CALL write_variable_in_CASE_NOTE("* IEVP updated as responded to difference notice")
 CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
-IF DISQ_action <> "Pending verif" THEN CALL write_variable_in_CASE_NOTE("---The case may be elligble for REIN if all necessary paperwork has been received")
+IF DISQ_action <> "Pending verif" THEN CALL write_variable_in_CASE_NOTE("---The case may be eligible for REIN if all necessary paperwork has been received.")
 CALL write_variable_in_CASE_NOTE ("----- ----- ----- ----- -----")
 CALL write_variable_in_case_note(worker_signature)
-CALL write_variable_in_CASE_NOTE ("DEBT ESTABLISHMENT UNIT 612-348-4290 EXT 1-1-1")
 
 script_end_procedure_with_error_report("ATR case note updated successfully." & vbNewLine & "Please remember to update/delete the DISQ panel")
 '----------------------------------------------------------------------------------------------------Closing Project Documentation
@@ -536,7 +535,7 @@ script_end_procedure_with_error_report("ATR case note updated successfully." & v
 '--Update Changelog for release/update------------------------------------------06/24/2022
 '--Remove testing message boxes-------------------------------------------------06/24/2022
 '--Remove testing code/unnecessary code-----------------------------------------06/24/2022
-'--Review/update SharePoint instructions----------------------------------------06/24/2022 'TODO'
+'--Review/update SharePoint instructions----------------------------------------06/24/2022 
 '--Other SharePoint sites review (HSR Manual, etc.)-----------------------------06/24/2022
 '--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------06/24/2022
 '--Complete misc. documentation (if applicable)---------------------------------06/24/2022

--- a/deu/bulk-match-cleared.vbs
+++ b/deu/bulk-match-cleared.vbs
@@ -56,6 +56,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/16/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("07/26/2022", "Updated handling for claim referral tracking.", "MiKayla Handley, Hennepin County") '#991
 CALL changelog_update("06/30/2022", "Updated handling for new upervisor.", "MiKayla Handley, Hennepin County") '#498
@@ -519,7 +520,6 @@ For item = 0 to UBound(match_based_array, 2)
     	        CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
     	        CALL write_variable_in_case_note("----- ----- ----- ----- -----")
 				CALL write_variable_in_case_note(worker_signature)
-    	        CALL write_variable_in_case_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
     	        PF3 'to save casenote'
     	    	match_based_array(comments_const, item) = "Match Cleared and Case Noted."
 		    END IF

--- a/deu/ebt-out-of-state.vbs
+++ b/deu/ebt-out-of-state.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/19/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("02/22/2021", "Removed handling for other option.", "MiKayla Handley, Hennepin County")
 call changelog_update("01/14/2021", "Updated handling for review case to update for overpayment at a later date.", "MiKayla Handley, Hennepin County")
@@ -80,7 +81,6 @@ BeginDialog Dialog1, 0, 0, 291, 85, "EBT OUT OF STATE "
   Text 5, 70, 60, 10, "Worker signature:"
 EndDialog
 
-
 DO
 	DO
 		err_msg = ""
@@ -115,7 +115,8 @@ IF action_taken = "Initial review" THEN
       Text 5, 70, 45, 10, "Other notes: "
       Text 5, 10, 35, 10, "Date due:"
     EndDialog
-    Do
+
+ 	Do
     	Do
             err_msg = ""
     		Dialog Dialog1
@@ -146,6 +147,7 @@ IF action_taken = "Client responds to request" THEN
       GroupBox 5, 25, 185, 35, "Verification received: "
       Text 5, 70, 45, 10, "Other notes: "
     EndDialog
+
 	Do
     	Do
             err_msg = ""
@@ -179,7 +181,8 @@ IF action_taken = "No response received" THEN
       Text 5, 70, 55, 10, "Closure reason:"
       Text 5, 10, 45, 10, "Date closed:"
     EndDialog
-    Do
+
+	Do
     	Do
             err_msg = ""
     		Dialog Dialog1
@@ -227,5 +230,4 @@ start_a_blank_case_note      'navigates to case/note and puts case/note into edi
 	CALL write_bullet_and_variable_in_CASE_NOTE("Other notes", other_notes)
 	CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- -----")
     CALL write_variable_in_CASE_NOTE(worker_signature)
-	Call write_variable_in_CASE_NOTE("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
 script_end_procedure_with_error_report("EBT out of state case note complete.")

--- a/deu/match-cleared.vbs
+++ b/deu/match-cleared.vbs
@@ -977,9 +977,8 @@ IF resolution_status = "CC-Overpayment Only" or HC_OP_checkbox = CHECKED THEN '-
     CALL write_bullet_and_variable_in_CCOL_NOTE("Date verification received", income_rcvd_date)
     CALL write_bullet_and_variable_in_CCOL_NOTE("Reason for overpayment", Reason_OP)
     CALL write_bullet_and_variable_in_CCOL_NOTE("Other responsible member(s)", OT_resp_memb)
-    CALL write_variable_in_CCOL_note("----- ----- ----- ----- ----- ----- -----")
-    CALL write_variable_in_CCOL_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-    PF3 'to save CCOL casenote'
+	CALL write_variable_in_ccol_note("----- ----- ----- ----- -----")
+	CALL write_variable_in_ccol_note(worker_signature)
 
 	'-------------------------------The following will generate a TIKL formatted date for 10 days from now, and add it to the TIKL
 	IF tenday_checkbox = CHECKED THEN CALL create_TIKL("Unable to close due to 10 day cutoff. Verification of match should have returned by now. If not received and processed, take appropriate action.", 0, date, True, TIKL_note_text)

--- a/deu/match-cleared.vbs
+++ b/deu/match-cleared.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: CALL changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/28/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/08/2020", "Updated BUG when clearing match BO-Other added back IULB notes per DEU request.", "MiKayla Handley, Hennepin County") '#922
 CALL changelog_update("06/21/2022", "Updated handling for non-disclosure agreement and closing documentation.", "MiKayla Handley, Hennepin County") '#493
@@ -849,7 +850,6 @@ IF claim_referral_tracking_dropdown <> "Not Needed" THEN
     IF case_note_only = TRUE THEN CALL write_variable_in_case_note("Maxis case is inactive unable to add or update MISC panel")
     CALL write_variable_in_case_note("-----")
     CALL write_variable_in_case_note(worker_signature)
-    PF3
 END IF
 start_a_blank_case_note
 IF match_type = "WAGE" THEN CALL write_variable_in_case_note("-----" & IEVS_quarter & " QTR " & IEVS_year & " WAGE MATCH"  & " (" & first_name & ") " & cleared_header & header_note & "-----")
@@ -915,10 +915,8 @@ IF resolution_status = "CC-Overpayment Only" or HC_OP_checkbox = CHECKED THEN
     CALL write_bullet_and_variable_in_case_note("Other responsible member(s)", OT_resp_memb)
 END IF
 CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
-CALL write_variable_in_case_note("----- ----- ----- ----- ----- ----- -----")
+CALL write_variable_in_case_note("----- ----- ----- ----- -----")
 CALL write_variable_in_case_note(worker_signature)
-CALL write_variable_in_case_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-PF3 'to save casenote'
 
 IF resolution_status = "CC-Overpayment Only" or HC_OP_checkbox = CHECKED THEN '-----------------------------------------------------------------------------------------OP CASENOTE
     IF HC_claim_number <> "" THEN

--- a/deu/overpayment-claim-entered.vbs
+++ b/deu/overpayment-claim-entered.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/16/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("06/21/2022", "Updated handling for non-disclosure agreement and closing documentation.", "MiKayla Handley, Hennepin County") '#493
 CALL changelog_update("10/20/2020", "Removed custom functions from script file. Functions have all been incorporated into the project's Function Library.", "Ilse Ferris, Hennepin County")
@@ -190,7 +191,7 @@ DO
     		IF HC_claim_amount = "" THEN err_msg = err_msg & vbNewLine &  "* Please enter the amount of claim."
     	END IF
         IF EVF_used = "" then err_msg = err_msg & vbNewLine & "* Please enter verification used for the income received. If no verification was received enter N/A."
-    	IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+    	IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
   		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
 	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
@@ -403,7 +404,6 @@ IF OP_program = "FS" or OP_program_II = "FS" or OP_program_III = "FS" or OP_prog
 	Call write_variable_in_case_note("* Entries for these potential claims must be retained until further notice.")
 	Call write_variable_in_case_note("-----")
 	Call write_variable_in_case_note(worker_signature)
-	PF3
 END IF
 '-----------------------------------------------------------------------------------------CASENOTE
 start_a_blank_CASE_NOTE
@@ -436,8 +436,6 @@ CALL write_bullet_and_variable_in_case_note("Other responsible member(s)", OT_re
 'IF ECF_checkbox = CHECKED THEN CALL write_variable_in_CASE_NOTE("* DHS 2776E – Agency Cash Error Overpayment Worksheet form completed in ECF")
 CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
 CALL write_variable_in_case_note(worker_signature)
-CALL write_variable_in_CASE_NOTE("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-PF3 'to save casenote'
 
 IF HC_claim_number <> "" THEN
 	EmWriteScreen "x", 5, 3
@@ -500,9 +498,7 @@ CALL write_bullet_and_variable_in_CCOL_note("Date verification received", income
 CALL write_bullet_and_variable_in_CCOL_note("Reason for overpayment", Reason_OP)
 CALL write_bullet_and_variable_in_CCOL_note("Other responsible member(s)", OT_resp_memb)
 'IF ECF_checkbox = CHECKED THEN CALL write_variable_in_CCOL_note("* DHS 2776E - Agency Cash Error Overpayment Worksheet form completed in ECF")
-CALL write_variable_in_CCOL_note("----- ----- ----- ----- ----- ----- -----")
+CALL write_variable_in_CCOL_note("----- ----- ----- ----- -----")
 CALL write_variable_in_CCOL_note(worker_signature)
-CALL write_variable_in_CCOL_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-PF3'
 
 script_end_procedure_with_error_report("Overpayment case note entered and copied to CCOL please review case note to ensure accuracy.")

--- a/deu/paris-match-cleared-CC-claim-entered.vbs
+++ b/deu/paris-match-cleared-CC-claim-entered.vbs
@@ -40,6 +40,7 @@ END IF
 'CHANGELOG BLOCK ===========================================================================================================
 'Starts by defining a changelog array
 changelog = array()
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature all DEU scripts.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("06/21/2022", "Updated handling for non-disclosure agreement and closing documentation.", "MiKayla Handley, Hennepin County") '#493
 CALL changelog_update("10/20/2020", "Removed custom functions from script file. Functions have all been incorporated into the project's Function Library.", "Ilse Ferris, Hennepin County")
 call changelog_update("08/05/2019", "Updated the term claim referral to use the action taken on MISC.", "MiKayla Handley, Hennepin County")
@@ -423,7 +424,6 @@ IF OP_program = "FS" or OP_program_II = "FS" or OP_program_III = "FS" or OP_prog
 	Call write_variable_in_case_note("* Entries for these potential claims must be retained until further notice.")
 	Call write_variable_in_case_note("-----")
 	Call write_variable_in_case_note(worker_signature)
-	PF3
 END IF
 '-----------------------------------------------------------------------------------------CASENOTE
 start_a_blank_case_note
@@ -458,10 +458,8 @@ If out_state_checkbox = CHECKED THEN Call write_variable_in_case_note("Out of st
 Call write_bullet_and_variable_in_case_note("Other responsible member(s)", OT_resp_memb)
 Call write_bullet_and_variable_in_case_note("Fraud referral made", fraud_referral)
 Call write_bullet_and_variable_in_case_note("Reason for overpayment", overpayment_reason)
-CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
+CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- -----")
 CALL write_variable_in_CASE_NOTE(worker_signature)
-CALL write_variable_in_CASE_NOTE("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-PF3 'have to PF3 because more steps are taken'
 'gathering the case note for the email'
 IF HC_claim_number <> "" THEN
 	EMWriteScreen "x", 5, 3
@@ -529,9 +527,8 @@ If out_state_checkbox = CHECKED THEN Call write_variable_in_CCOL_note("Out of st
 Call write_bullet_and_variable_in_CCOL_note("Other responsible member(s)", OT_resp_memb)
 Call write_bullet_and_variable_in_CCOL_note("Fraud referral made", fraud_referral)
 Call write_bullet_and_variable_in_CCOL_note("Reason for overpayment", overpayment_reason)
-CALL write_variable_in_CCOL_note("----- ----- ----- ----- ----- ----- -----")
-CALL write_variable_in_CCOL_note("DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1")
-PF3 'exit the case note because it is CCOL'
+CALL write_variable_in_CCOL_note("----- ----- ----- ----- -----")
+CALL write_variable_in_CCOL_note(worker_signature)
 script_end_procedure_with_error_report("Success PARIS match overpayment case note entered and copied to CCOL please review case note to ensure accuracy.")
 '----------------------------------------------------------------------------------------------------Closing Project Documentation
 '------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------

--- a/deu/paris-match-cleared.vbs
+++ b/deu/paris-match-cleared.vbs
@@ -43,6 +43,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: CALL changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("10/06/2022", "Update to remove hard coded DEU signature.", "MiKayla Handley, Hennepin County") '#316
 CALL changelog_update("09/19/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("06/23/2022", "Added fix for PARIS matches that were not the 1st DAIL message for a case.", "Ilse Ferris, Hennepin County")
 call changelog_update("06/21/2022", "Added fix for PARI DAIL's while DHS interface with SSN is being repaired. Also made some functional changes to support the user experience.", "Ilse Ferris, Hennepin County")
@@ -334,7 +335,7 @@ IF paris_action = "Yes, send the notice" then
     		IF bene_other_state = "Select One:" THEN err_msg = err_msg & vbNewLine & "* Is the client accessing benefits in other state?"
     		IF contact_other_state = "Select One:" THEN err_msg = err_msg & vbNewLine & "* Did you contact the other state?"
     		IF fraud_referral = "Select One:" THEN err_msg = err_msg & vbnewline & "* You must select a fraud referral entry."
-			IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+			IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
 			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine
     	LOOP UNTIL err_msg = ""
     	CALL check_for_password(are_we_passworded_out)
@@ -377,9 +378,8 @@ IF paris_action = "Yes, send the notice" then
     CALL write_bullet_and_variable_in_CASE_NOTE("Verification Requested", pending_verifs)
     CALL write_bullet_and_variable_in_CASE_NOTE("Verification Due", Due_date)
     CALL write_bullet_and_variable_in_CASE_NOTE("Other notes", other_notes)
-    CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
+    CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- -----")
 	CALL write_variable_in_CASE_NOTE(worker_signature)
-    CALL write_variable_in_CASE_NOTE ("DEBT ESTABLISHMENT UNIT 612-348-4290 EXT 1-1-1")
 
     closing_msg = "Success, the difference notice was sent to this resident."
 Else
@@ -432,7 +432,7 @@ Else
     		IF bene_other_state = "Select One:" THEN err_msg = err_msg & vbNewLine & "* Is the client accessing benefits in other state?"
     		IF contact_other_state = "Select One:" THEN err_msg = err_msg & vbNewLine & "* Did you contact the other state?"
 			IF resolution_status = "Select One:" THEN err_msg = err_msg & vbNewLine & "Please select a resolution status to continue."
-			IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+			IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
 			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine
     	LOOP UNTIL err_msg = ""
 		CALL check_for_password(are_we_passworded_out)
@@ -493,7 +493,6 @@ Else
     CALL write_bullet_and_variable_in_CASE_NOTE("Other notes", other_notes)
     CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
 	CALL write_variable_in_CASE_NOTE(worker_signature)
-    CALL write_variable_in_CASE_NOTE ("DEBT ESTABLISHMENT UNIT 612-348-4290 EXT 1-1-1")
     closing_msg = "Success, your PARIS match has been resolved and case noted."
 END IF
 


### PR DESCRIPTION
In the specialty teams Shelter and DEU the team name was listed in lieu of the worker signature and the worker signature has been added. After the script was released it was discovered that the workers will determine their worker signature with their teams and this is out of the scope of this project. The team name in the signature will be removed for the following scripts:

REMOVED - "DEBT ESTABLISHMENT UNIT 612-348-4290 PROMPTS 1-1-1"

 NOTES - DEU-ADH INFO HEARING
 NOTES - DEU-APPEAL SUMMARY COMPLETED
 NOTES - DEU-ATR RECEIVED
 BULK - DEU-MATCH CLEARED
 NOTES - DEU-EBT OUT OF STATE
 ACTIONS - DEU-MATCH CLEARED
 ACTIONS - DEU-OVERPAYMENT CLAIM ENTERED
 ACTIONS - DEU-PARIS MATCH CLEARED CC
 ACTIONS - DEU-PARIS MATCH CLEARED