### PR TITLE
#316 BUG due to removal of PF3 between case notes

### DIFF
--- a/deu/appeal-summary-completed.vbs
+++ b/deu/appeal-summary-completed.vbs
@@ -96,7 +96,7 @@ Call write_bullet_and_variable_in_CASE_NOTE("Claim number:", claim_number)
 Call write_bullet_and_variable_in_CASE_NOTE("Date appeal request received:", date_appeal_rcvd)
 Call write_bullet_and_variable_in_CASE_NOTE("Effective date of action being appealed:", effective_date)
 Call write_bullet_and_variable_in_CASE_NOTE("Action client is appealing:", action_client_is_appealing)
-Call write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
+Call write_variable_in_CASE_NOTE("----- ----- ----- ----- -----")
 CALL write_variable_in_CASE_NOTE(worker_signature)
 
 script_end_procedure_with_error_report("Appeal Summary case note complete.")

--- a/deu/atr-received.vbs
+++ b/deu/atr-received.vbs
@@ -473,6 +473,7 @@ IF claim_referral_tracking_dropdown <> "Not Needed" THEN
 	IF case_note_only = TRUE THEN CALL write_variable_in_case_note("Maxis case is inactive unable to add or update MISC panel")
 	CALL write_variable_in_case_note("-----")
 	CALL write_variable_in_case_note(worker_signature)
+	PF3 ' to ensure a new case note is started'
 END IF
 '-------------------------------------------------------------------------------------------------The case note
 start_a_blank_case_note
@@ -535,7 +536,7 @@ script_end_procedure_with_error_report("ATR case note updated successfully." & v
 '--Update Changelog for release/update------------------------------------------06/24/2022
 '--Remove testing message boxes-------------------------------------------------06/24/2022
 '--Remove testing code/unnecessary code-----------------------------------------06/24/2022
-'--Review/update SharePoint instructions----------------------------------------06/24/2022 
+'--Review/update SharePoint instructions----------------------------------------06/24/2022
 '--Other SharePoint sites review (HSR Manual, etc.)-----------------------------06/24/2022
 '--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------06/24/2022
 '--Complete misc. documentation (if applicable)---------------------------------06/24/2022

--- a/deu/match-cleared.vbs
+++ b/deu/match-cleared.vbs
@@ -850,7 +850,9 @@ IF claim_referral_tracking_dropdown <> "Not Needed" THEN
     IF case_note_only = TRUE THEN CALL write_variable_in_case_note("Maxis case is inactive unable to add or update MISC panel")
     CALL write_variable_in_case_note("-----")
     CALL write_variable_in_case_note(worker_signature)
+	PF3 ' to ensure a new case note is started'
 END IF
+
 start_a_blank_case_note
 IF match_type = "WAGE" THEN CALL write_variable_in_case_note("-----" & IEVS_quarter & " QTR " & IEVS_year & " WAGE MATCH"  & " (" & first_name & ") " & cleared_header & header_note & "-----")
 IF match_type = "BEER" THEN CALL write_variable_in_case_note("-----" & IEVS_year & " NON-WAGE MATCH(" & match_type_letter & ")" & " (" & first_name & ") " & cleared_header & header_note & "-----")

--- a/deu/match-cleared.vbs
+++ b/deu/match-cleared.vbs
@@ -919,6 +919,7 @@ END IF
 CALL write_bullet_and_variable_in_case_note("Other Notes", other_notes)
 CALL write_variable_in_case_note("----- ----- ----- ----- -----")
 CALL write_variable_in_case_note(worker_signature)
+PF3 ' to ensure we clear the case note for the next action'
 
 IF resolution_status = "CC-Overpayment Only" or HC_OP_checkbox = CHECKED THEN '-----------------------------------------------------------------------------------------OP CASENOTE
     IF HC_claim_number <> "" THEN

--- a/deu/match-cleared.vbs
+++ b/deu/match-cleared.vbs
@@ -981,7 +981,7 @@ IF resolution_status = "CC-Overpayment Only" or HC_OP_checkbox = CHECKED THEN '-
     CALL write_bullet_and_variable_in_CCOL_NOTE("Other responsible member(s)", OT_resp_memb)
 	CALL write_variable_in_ccol_note("----- ----- ----- ----- -----")
 	CALL write_variable_in_ccol_note(worker_signature)
-
+	PF3 ' to ensure we leave the CCOL case note'
 	'-------------------------------The following will generate a TIKL formatted date for 10 days from now, and add it to the TIKL
 	IF tenday_checkbox = CHECKED THEN CALL create_TIKL("Unable to close due to 10 day cutoff. Verification of match should have returned by now. If not received and processed, take appropriate action.", 0, date, True, TIKL_note_text)
 	script_end_procedure_with_error_report("Match has been acted on. Please take any additional action needed for your case.")

--- a/deu/overpayment-claim-entered.vbs
+++ b/deu/overpayment-claim-entered.vbs
@@ -438,6 +438,7 @@ CALL write_bullet_and_variable_in_case_note("Other responsible member(s)", OT_re
 'IF ECF_checkbox = CHECKED THEN CALL write_variable_in_CASE_NOTE("* DHS 2776E – Agency Cash Error Overpayment Worksheet form completed in ECF")
 CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- ----- ----- -----")
 CALL write_variable_in_case_note(worker_signature)
+PF3 ' to ensure we clear the case note for the next action'
 
 IF HC_claim_number <> "" THEN
 	EmWriteScreen "x", 5, 3
@@ -502,5 +503,5 @@ CALL write_bullet_and_variable_in_CCOL_note("Other responsible member(s)", OT_re
 'IF ECF_checkbox = CHECKED THEN CALL write_variable_in_CCOL_note("* DHS 2776E - Agency Cash Error Overpayment Worksheet form completed in ECF")
 CALL write_variable_in_CCOL_note("----- ----- ----- ----- -----")
 CALL write_variable_in_CCOL_note(worker_signature)
-
+PF3 ' to ensure we leave the CCOL case note'
 script_end_procedure_with_error_report("Overpayment case note entered and copied to CCOL please review case note to ensure accuracy.")

--- a/deu/overpayment-claim-entered.vbs
+++ b/deu/overpayment-claim-entered.vbs
@@ -404,7 +404,9 @@ IF OP_program = "FS" or OP_program_II = "FS" or OP_program_III = "FS" or OP_prog
 	Call write_variable_in_case_note("* Entries for these potential claims must be retained until further notice.")
 	Call write_variable_in_case_note("-----")
 	Call write_variable_in_case_note(worker_signature)
+	PF3 ' to ensure a new case note is started'
 END IF
+
 '-----------------------------------------------------------------------------------------CASENOTE
 start_a_blank_CASE_NOTE
 IF IEVS_type = "WAGE" THEN CALL write_variable_in_CASE_NOTE("-----" & IEVS_quarter & " QTR " & IEVS_year & " WAGE MATCH"  & "(" & first_name & ") CLEARED CC-CLAIM ENTERED-----")

--- a/deu/paris-match-cleared-CC-claim-entered.vbs
+++ b/deu/paris-match-cleared-CC-claim-entered.vbs
@@ -462,6 +462,7 @@ Call write_bullet_and_variable_in_case_note("Fraud referral made", fraud_referra
 Call write_bullet_and_variable_in_case_note("Reason for overpayment", overpayment_reason)
 CALL write_variable_in_CASE_NOTE("----- ----- ----- ----- -----")
 CALL write_variable_in_CASE_NOTE(worker_signature)
+PF3 ' to ensure we leave the CCOL case note'
 'gathering the case note for the email'
 IF HC_claim_number <> "" THEN
 	EMWriteScreen "x", 5, 3
@@ -531,6 +532,7 @@ Call write_bullet_and_variable_in_CCOL_note("Fraud referral made", fraud_referra
 Call write_bullet_and_variable_in_CCOL_note("Reason for overpayment", overpayment_reason)
 CALL write_variable_in_CCOL_note("----- ----- ----- ----- -----")
 CALL write_variable_in_CCOL_note(worker_signature)
+PF3 ' to ensure we leave the CCOL case note'
 script_end_procedure_with_error_report("Success PARIS match overpayment case note entered and copied to CCOL please review case note to ensure accuracy.")
 '----------------------------------------------------------------------------------------------------Closing Project Documentation
 '------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------

--- a/deu/paris-match-cleared-CC-claim-entered.vbs
+++ b/deu/paris-match-cleared-CC-claim-entered.vbs
@@ -424,7 +424,9 @@ IF OP_program = "FS" or OP_program_II = "FS" or OP_program_III = "FS" or OP_prog
 	Call write_variable_in_case_note("* Entries for these potential claims must be retained until further notice.")
 	Call write_variable_in_case_note("-----")
 	Call write_variable_in_case_note(worker_signature)
+	PF3 ' to ensure a new case note is started'
 END IF
+
 '-----------------------------------------------------------------------------------------CASENOTE
 start_a_blank_case_note
 CALL write_variable_in_CASE_NOTE ("-----" & INTM_period & " PARIS MATCH " & "(" & first_name &  ") CLEARED " & rez_status & " CLAIM ENTERED-----")


### PR DESCRIPTION
Problem: issue reported with scripts case noting in the same case note. 
Resolution: add the PF3 back in between the case notes to ensure a new case note is entered in the following scripts:  

- [x] ACTIONS - DEU-MATCH CLEARED - added back PF3
- [x] ACTIONS - DEU-OVERPAYMENT CLAIM ENTERED - added back PF3 
- [x] NOTES - DEU-ATR RECEIVED - added back PF3
- [x] NOTES - DEU-ADH INFO HEARING - added back PF3
- [x] NOTES - DEU-APPEAL SUMMARY  COMPLETED - updated formatting in case note 