### PR TITLE
#476 DAIL Scrubber - Read if in INQUIRY

### DIFF
--- a/dail/dail-scrubber.vbs
+++ b/dail/dail-scrubber.vbs
@@ -90,6 +90,20 @@ If dails_before_this_dail_for_this_case = 0 Then dail_row = 6
 EMSendKey "T"
 TRANSMIT
 
+'This functionalitty will identify if the script is being run in INQUIRY
+'Cannot tell if Production or Training, but that is less important
+running_in_INQUIRY = False							'default to false'
+EMSendKey "W"										'attempt to navigate to DAIL/WRIT - wwhich requires write access
+TRANSMIT
+EMReadScreen cannot_access_msg, 17, 24, 2			'reading for the message that states you cannot access WRIT
+If cannot_access_msg = "YOU CANNOT ACCESS" Then		'If found we are most likely in INQUIRY (could be PRIV or Out of County)
+	running_in_INQUIRY = True						'setting the boolean to true
+	EMSendKey " "									'blanking out the 'WRIT' attempt
+Else
+	PF3												'if the message is NOT found, we are in WRIT and need to back out
+End If
+EMSetCursor 6, 3									'resetting the cursor for DAIL movement later - tis is important or we could end up in the wrong case
+
 'The following reads the message in full for the end part (which tells the worker which message was selected)
 EMReadScreen full_message, 60, 6, 20
 full_message = trim(full_message)


### PR DESCRIPTION
Adds a variable to define if we are in INQUIRY so specific DAIL scripts can stop if not able to write/update.

More work needed to evaluate the specific DAIL scripts. This will just put in place the functionality to know if we are in INQUIRY or not.