### PR TITLE
#702 memb 'access denied' issues in scripts and functions

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -11030,6 +11030,7 @@ function read_total_SHEL_on_case(ref_numbers_with_panel, paid_to, rent_amt, rent
 		'MsgBox access_denied_check
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 			last_name = "UNABLE TO FIND"
 			first_name = " - Access Denied"
 			mid_initial = ""

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -8504,6 +8504,7 @@ function HH_member_custom_dialog(HH_member_array)
         'MsgBox access_denied_check
         If access_denied_check = "ACCESS DENIED" Then
             PF10
+			EMWaitReady 0, 0
             last_name = "UNABLE TO FIND"
             first_name = " - Access Denied"
             mid_initial = ""

--- a/actions/full-interview.vbs
+++ b/actions/full-interview.vbs
@@ -450,6 +450,7 @@ class mx_hh_member
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 			last_name = "UNABLE TO FIND"
 			first_name = "Access Denied"
 			mid_initial = ""
@@ -2029,6 +2030,7 @@ class client_income
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 			last_name = "UNABLE TO FIND"
 			first_name = "Access Denied"
 			access_denied = TRUE
@@ -2438,6 +2440,7 @@ class client_assets
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 			last_name = "UNABLE TO FIND"
 			first_name = "Access Denied"
 			access_denied = TRUE
@@ -6193,6 +6196,7 @@ function read_all_the_MEMBs()
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 		End If
 		If client_array <> "" Then client_array = client_array & "|" & ref_nbr
 		If client_array = "" Then client_array = client_array & ref_nbr

--- a/admin/testing_addr_shel_and_hest_functions.vbs
+++ b/admin/testing_addr_shel_and_hest_functions.vbs
@@ -174,6 +174,7 @@ DO								'reads the reference number, last name, first name, and then puts it i
 	'MsgBox access_denied_check
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+		EMWaitReady 0, 0
 		last_name = "UNABLE TO FIND"
 		first_name = " - Access Denied"
 		mid_initial = ""

--- a/deu/atr-received.vbs
+++ b/deu/atr-received.vbs
@@ -93,6 +93,7 @@ DO	'reads the reference number, last name, first name, and THEN puts it into a s
 	EMReadScreen access_denied_check, 13, 24, 2
 If access_denied_check = "ACCESS DENIED" Then
 	PF10
+	EMWaitReady 0, 0
 	last_name = "UNABLE TO FIND"
 	first_name = " - Access Denied"
 	mid_initial = ""

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -4969,6 +4969,7 @@ DO								'reads the reference number, last name, first name, and then puts it i
 	'MsgBox access_denied_check
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+		EMWaitReady 0, 0
 		last_name = "UNABLE TO FIND"
 		first_name = " - Access Denied"
 		mid_initial = ""

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -9197,6 +9197,7 @@ If vars_filled = FALSE AND no_case_number_checkbox = unchecked Then
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 		End If
 		If client_array <> "" Then client_array = client_array & "|" & ref_nbr
 		If client_array = "" Then client_array = client_array & ref_nbr
@@ -9224,6 +9225,7 @@ If vars_filled = FALSE AND no_case_number_checkbox = unchecked Then
 		EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 		If access_denied_check = "ACCESS DENIED" Then
 			PF10
+			EMWaitReady 0, 0
 			HH_MEMB_ARRAY(last_name_const, clt_count) = "UNABLE TO FIND"
 			HH_MEMB_ARRAY(first_name_const, clt_count) = "Access Denied"
 			HH_MEMB_ARRAY(mid_initial, clt_count) = ""

--- a/utilities/va-verification-request.vbs
+++ b/utilities/va-verification-request.vbs
@@ -92,6 +92,7 @@ DO		'reads the reference number, last name, first name, and THEN puts it into a 
     'MsgBox access_denied_check
     If access_denied_check = "ACCESS DENIED" Then
         PF10
+        EMWaitReady 0, 0
         last_name = "UNABLE TO FIND"
         first_name = " - Access Denied"
         mid_initial = ""


### PR DESCRIPTION
I added EMWaitReady to the following scripts:
-  ACTIONS - FULL INTERVIEW: any members after the ACCESS DENIED members won't be added to array
-  DEU - ATR RECEIVED
-  NOTES - CAF
-  NOTES - INTERVIEW
-  UTILITIES - COMPLETE PHONE CAF - this has since been retired. No action needed.
-  UTILITIES - VA VERIFICATION REQUEST
-  HH_member_custom_dialog(HH_member_array)

I did not make these updates:
- TEST SCRIPTS- NOTES COUNTY PAID MEDI B - it looks like this script has been retired. 
-  Function autofill_editbox_from_MAXIS - panel_read_from = "MEMB" - Since HH_member_custom_dialog(HH_member_array) now includes EMWaitReady, I think this function should work in cases with access_denied but let me know if there are other changes needed.

I made these updates but they weren't specifically identified in issue:
- read_total_SHEL_on_case - Updated access_denied_check
- HC Eval - Updated access_denied_check

These scripts weren't identified in the issue but include access_denied_check. I did not update these but can do so.
- resolve-hc-eomc-in-mmis
- admin\track-autoclose-overpayments
- notes\mfip-orientation
- Restart scripts\BULK - restart IMIG
- utilities\uc-verification-request