### PR TITLE
#702 memb 'access denied' issues in scripts and functions addl scripts

### DIFF
--- a/Test scripts/Ilse/Restart scripts/BULK - restart IMIG.vbs
+++ b/Test scripts/Ilse/Restart scripts/BULK - restart IMIG.vbs
@@ -116,6 +116,7 @@ Do
 		If access_check = "ACCESS DENIED" then 
 			objExcel.Cells(excel_row, 5).Value = "Unable to access case."
 			PF10
+			EMWaitReady 0, 0
 			PF3
 		Else 
 		

--- a/admin/resolve-hc-eomc-in-mmis.vbs
+++ b/admin/resolve-hc-eomc-in-mmis.vbs
@@ -390,6 +390,7 @@ For hc_clt = 0 to UBOUND(EOMC_CLIENT_ARRAY, 2)
 	EMReadScreen access_denied_check, 13, 24, 2
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+        EMWaitReady 0, 0
 		EOMC_CLIENT_ARRAY(clt_age, hc_clt) = 2 'TODO - decide what 'age' we want to assign when a MEMB panel is access denied
 	Else
 		EMReadScreen age_of_client, 3, 8, 76

--- a/admin/track-autoclose-overpayments.vbs
+++ b/admin/track-autoclose-overpayments.vbs
@@ -1103,6 +1103,7 @@ DO								'reads the reference number, last name, first name, and then puts it i
 	EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+		EMWaitReady 0, 0
 	End If
 	If client_array <> "" Then client_array = client_array & "|" & ref_nbr
 	If client_array = "" Then client_array = client_array & ref_nbr

--- a/notes/mfip-orientation.vbs
+++ b/notes/mfip-orientation.vbs
@@ -833,6 +833,7 @@ DO								'reads the reference number, last name, first name, and then puts it i
 	EMReadScreen access_denied_check, 13, 24, 2         'Sometimes MEMB gets this access denied issue and we have to work around it.
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+		EMWaitReady 0, 0
 	End If
 	If client_array <> "" Then client_array = client_array & "|" & ref_nbr
 	If client_array = "" Then client_array = client_array & ref_nbr
@@ -860,6 +861,7 @@ For each hh_clt in client_array
 	EMReadScreen access_denied_check, 13, 24, 2         						'Sometimes MEMB gets this access denied issue and we have to work around it.
 	If access_denied_check = "ACCESS DENIED" Then
 		PF10
+		EMWaitReady 0, 0
 		memb_last_name_const = "UNABLE TO FIND"
 		memb_first_name_const = "Access Denied"
 	Else

--- a/utilities/uc-verification-request.vbs
+++ b/utilities/uc-verification-request.vbs
@@ -58,6 +58,7 @@ function custom_HH_member_custom_dialog(HH_member_array)
         'MsgBox access_denied_check
         If access_denied_check = "ACCESS DENIED" Then
             PF10
+            EMWaitReady 0, 0
             last_name = "UNABLE TO FIND"
             first_name = " - Access Denied"
             mid_initial = ""


### PR DESCRIPTION
I updated the following scripts that were not initially identified in the issue but also contain access_denied_check. 

- resolve-hc-eomc-in-mmis
- admin\track-autoclose-overpayments
- notes\mfip-orientation
- Restart scripts\BULK - restart IMIG - I noted in commit but wasn't sure if this needed to be updated as it is in test scripts folder
- utilities\uc-verification-request