### PR TITLE
#1372 correct desert island paths in Func Lib and CLOS

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -97,7 +97,11 @@ class script_bowie
 			    script_URL = script_repository & lcase(url_category) & "\" & lcase(replace(script_name, " ", "-") & ".vbs")
             End If
 		Else
-        	If script_repository = "" then script_repository = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/"    'Assumes we're scriptwriters
+        	If script_repository = "" then
+				script_repository = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/"    'Assumes we're scriptwriters
+				IF on_the_desert_island = TRUE Then script_repository = desert_island_respository
+			End If
+
             If header_exists = TRUE Then
                 script_URL = script_repository & lcase(url_category) & "/" & lcase(header) & "-" & replace(lcase(name_to_use) & ".vbs", " ", "-")
             Else

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -44,25 +44,34 @@ name_of_script = actual_script_name
 
 'LOADING LIST OF SCRIPTS FROM GITHUB REPOSITORY===========================================================================
 IF run_locally = FALSE or run_locally = "" THEN	   'If the scripts are set to run locally, it skips this and uses an FSO below.
-	IF use_master_branch = TRUE THEN			   'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
-		script_list_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/COMPLETE%20LIST%20OF%20SCRIPTS.vbs"
-	Else											'Everyone else should use the release branch.
-		script_list_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/COMPLETE%20LIST%20OF%20SCRIPTS.vbs"
-	End if
+	IF on_the_desert_island = TRUE Then
+		script_list_URL = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Scripts\Script Files\desert-island\COMPLETE LIST OF SCRIPTS.vbs"
+        Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")
+		Set fso_command = run_another_script_fso.OpenTextFile(script_list_URL)
+		text_from_the_other_script = fso_command.ReadAll
+		fso_command.Close
+		Execute text_from_the_other_script
+	Else
+		IF use_master_branch = TRUE THEN			   'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+			script_list_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/COMPLETE%20LIST%20OF%20SCRIPTS.vbs"
+		Else											'Everyone else should use the release branch.
+			script_list_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/COMPLETE%20LIST%20OF%20SCRIPTS.vbs"
+		End if
 
-	SET req = CreateObject("Msxml2.XMLHttp.6.0")				'Creates an object to get a script_list_URL
-	req.open "GET", script_list_URL, FALSE							'Attempts to open the script_list_URL
-	req.send													'Sends request
-	IF req.Status = 200 THEN									'200 means great success
-		Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
-		Execute req.responseText								'Executes the script code
-	ELSE														'Error message
-		critical_error_msgbox = MsgBox ("Something has gone wrong. The script list code stored on GitHub was not able to be reached." & vbNewLine & vbNewLine &_
-                                        "Script list URL: " & script_list_URL & vbNewLine & vbNewLine &_
-                                        "The script has stopped. Please check your Internet connection. Consult a scripts administrator with any questions.", _
-                                        vbOKonly + vbCritical, "BlueZone Scripts Critical Error")
-        StopScript
-	END IF
+		SET req = CreateObject("Msxml2.XMLHttp.6.0")				'Creates an object to get a script_list_URL
+		req.open "GET", script_list_URL, FALSE							'Attempts to open the script_list_URL
+		req.send													'Sends request
+		IF req.Status = 200 THEN									'200 means great success
+			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
+			Execute req.responseText								'Executes the script code
+		ELSE														'Error message
+			critical_error_msgbox = MsgBox ("Something has gone wrong. The script list code stored on GitHub was not able to be reached." & vbNewLine & vbNewLine &_
+											"Script list URL: " & script_list_URL & vbNewLine & vbNewLine &_
+											"The script has stopped. Please check your Internet connection. Consult a scripts administrator with any questions.", _
+											vbOKonly + vbCritical, "BlueZone Scripts Critical Error")
+			StopScript
+		END IF
+	End If
 ELSE
 	script_list_URL = "C:\MAXIS-scripts\COMPLETE LIST OF SCRIPTS.vbs"
 	Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")


### PR DESCRIPTION
When the desert island failed, the redirects didn't work quite right. 

Most of the changes were needed in the local redirects for the desert island, but the Func Lib and CLOS are updated monthly from GH, so we needed to update the GH files with desert island paths.