### PR TITLE
#1418 #1228 FuncLib updates to statistics and determine_prog_and_case_status

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -5892,6 +5892,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "SNAP, "
         End If
 		If left(fs_status, 4) = "REIN" Then
+			fs_status = "REIN"
 			snap_case = TRUE
 			case_rein = TRUE
 		End If
@@ -5913,6 +5914,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "GRH, "
         ENd If
 		If left(grh_status, 4) = "REIN" Then
+			grh_status = "REIN"
 			grh_case = TRUE
 			case_rein = TRUE
 		End If
@@ -5937,6 +5939,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "MSA, "
         ENd If
 		If left(ms_status, 4) = "REIN" Then
+			ms_status = "REIN"
 			msa_case = TRUE
 			adult_cash_case = TRUE
 			case_rein = TRUE
@@ -5961,6 +5964,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "GA, "
         ENd If
 		If left(ga_status, 4) = "REIN" Then
+			ga_status = "REIN"
 			ga_case = TRUE
 			adult_cash_case = TRUE
 			case_rein = TRUE
@@ -5986,6 +5990,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "DWP, "
         ENd If
 		If left(dw_status, 4) = "REIN" Then
+			dw_status = "REIN"
 			dwp_case = TRUE
 			family_cash_case = TRUE
 			case_rein = TRUE
@@ -6011,6 +6016,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "MFIP, "
         ENd If
 		If left(mf_status, 4) = "REIN" Then
+			mf_status = "REIN"
 			mfip_case = TRUE
 			family_cash_case = TRUE
 			case_rein = TRUE
@@ -6075,6 +6081,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			If InStr(list_pending_programs, "HC") = 0 Then list_pending_programs = list_pending_programs & "HC, "
         End If
 		If left(ma_status, 4) = "REIN" Then
+			ma_status = "REIN"
 			ma_case = TRUE
 			case_rein = TRUE
 		End If
@@ -6097,6 +6104,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			If InStr(list_pending_programs, "HC") = 0 Then list_pending_programs = list_pending_programs & "HC, "
         End If
 		If left(qm_status, 4) = "REIN" Then
+			qm_status = "REIN"
 			msp_case = TRUE
 			case_rein = TRUE
 		End If
@@ -6118,6 +6126,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			If InStr(list_pending_programs, "HC") = 0 Then list_pending_programs = list_pending_programs & "HC, "
         End If
 		If left(sl_status, 4) = "REIN" Then
+			sl_status = "REIN"
 			msp_case = TRUE
 			case_rein = TRUE
 		End If
@@ -6139,6 +6148,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			If InStr(list_pending_programs, "HC") = 0 Then list_pending_programs = list_pending_programs & "HC, "
         End If
 		If left(qi_status, 4) = "REIN" Then
+			qi_status = "REIN"
 			msp_case = TRUE
 			case_rein = TRUE
 		End If
@@ -6187,6 +6197,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "EGA, "
         ENd If
 		If left(ega_status, 4) = "REIN" Then
+			ega_status = "REIN"
 			emer_case = TRUE
 			case_rein = TRUE
 		End If
@@ -6208,6 +6219,7 @@ function determine_program_and_case_status_from_CASE_CURR(case_active, case_pend
 			list_pending_programs = list_pending_programs & "EA, "
 		ENd If
 		If left(ea_status, 4) = "REIN" Then
+			ea_status = "REIN"
 			emer_case = TRUE
 			case_rein = TRUE
 		End If

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -11392,6 +11392,8 @@ function script_end_procedure(closing_message)
 '~~~~~ closing_message: message to user in a MsgBox that appears once the script is complete. Example: "Success! Your actions are complete."
 '===== Keywords: MAXIS, MMIS, PRISM, end, script, statistics, stopscript
 	stop_time = timer
+	script_run_end_time = time
+	script_run_end_date = date
 	If closing_message <> "" AND left(closing_message, 3) <> "~PT" then MsgBox closing_message '"~PT" forces the message to "pass through", i.e. not create a pop-up, but to continue without further diversion to the database, where it will write a record with the message
 	script_run_time = stop_time - start_time
 	If is_county_collecting_stats  = True then
@@ -11427,15 +11429,15 @@ function script_end_procedure(closing_message)
         If STATS_enhanced_db = false or STATS_enhanced_db = "" then     'For users of the old db
     		'Opening usage_log and adding a record
     		objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX)" &  _
-    		"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
+    		"VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
 		'collecting case numbers counties
 		Elseif collect_MAXIS_case_number = true then
 			objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS, CASE_NUMBER)" &  _
-			"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
+			"VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
 		 'for users of the new db
 		Else
             objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS)" &  _
-            "VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ")", objConnection, adOpenStatic, adLockOptimistic
+            "VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ")", objConnection, adOpenStatic, adLockOptimistic
         End if
 
 		'Closing the connection

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -11451,6 +11451,8 @@ function script_end_procedure_with_error_report(closing_message)
 '~~~~~ closing_message: message to user in a MsgBox that appears once the script is complete. Example: "Success! Your actions are complete."
 '===== Keywords: MAXIS, MMIS, PRISM, end, script, statistics, stopscript
 	stop_time = timer
+	script_run_end_time = time
+	script_run_end_date = date
     send_error_message = ""
 	If closing_message <> "" AND left(closing_message, 3) <> "~PT" then        '"~PT" forces the message to "pass through", i.e. not create a pop-up, but to continue without further diversion to the database, where it will write a record with the message
         If testing_run = TRUE Then
@@ -11494,15 +11496,15 @@ function script_end_procedure_with_error_report(closing_message)
         If STATS_enhanced_db = false or STATS_enhanced_db = "" then     'For users of the old db
     		'Opening usage_log and adding a record
     		objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX)" &  _
-    		"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
+    		"VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
 		'collecting case numbers counties
 		Elseif collect_MAXIS_case_number = true then
 			objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS, CASE_NUMBER)" &  _
-			"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
+			"VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
 		 'for users of the new db
 		Else
             objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS)" &  _
-            "VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ")", objConnection, adOpenStatic, adLockOptimistic
+            "VALUES ('" & user_ID & "', '" & script_run_end_date & "', '" & script_run_end_time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ")", objConnection, adOpenStatic, adLockOptimistic
         End if
 
 		'Closing the connection


### PR DESCRIPTION
Stats update:
We need to set the script date and time for when the script actually stops and not when the worker presses 'OK' on the end message box. This is facilitated by setting the date and time to variables that are defined before the display of the messagebox. Then, it doesn't matter WHEN the information is written to the data table, it is set from the end of the script run functionality. 

Update to determine_program_and_case_status_from_case_curr
There was an issue when the program status was read from CASE/CURR - there was extra information in the variable. I could only find this on REIN status, this is because the MM YY are listed next to the REIN status on CASE/CURR
![image](https://github.com/Hennepin-County/MAXIS-scripts/assets/13418322/e426fc12-f9ac-447a-aef4-d159d4d4ad03)
The fix just resets the status variable in the function when 'left, 4' is REIN. This way only 'REIN' will pass back out of the function.
