### PR TITLE
#363 DAIL - POSTPONED EXP SNAP VERIFICATIONS enhancement: Add MEMO to functionality

### DIFF
--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -212,7 +212,7 @@ LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 Call write_value_and_transmit("P", 6, 3)
 Call write_value_and_transmit("MEMO", 20, 70)
 'Function to create new MEMO
-Call start_a_new_spec_memo(memo_opened, False, forms_to_arep, forms_to_swkr, send_to_other, other_name, other_street, other_city, other_state, other_zip, False)
+Call start_a_new_spec_memo(memo_opened, False, "Y", "Y", "N", other_name, other_street, other_city, other_state, other_zip, True)
 
 'Write information to SPEC/MEMO
 memo_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose ---"

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -208,7 +208,6 @@ DO
 		cancel_confirmation
 		Call validate_MAXIS_case_number(err_msg, "*")
 		IF trim(verifs_needed) = "" THEN err_msg = err_msg & vbCr & "* Please enter the postponed verifications requested."
-		IF len(trim(verifs_needed)) > 100 THEN err_msg = err_msg & vbCr & "* The list of verifications must be less than 100 characters long. Please shorten."
 		IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
 		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -77,7 +77,20 @@ Else
 	SNAP_followup_text = ", after which a new CAF is required (expedited SNAP closing for postponed verification not returned)."
 END IF
 
-PF3 						'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
+'Navigates back to DAIL
+PF3 						
+
+'Navigates to SPEC/MEMO through DAIL to maintain tie to list
+write_value_and_transmit("P", 6, 3)
+write_value_and_transmit("MEMO", 20, 70)
+'To do - double-check function(ality), ran into issues leaving the DAIL
+' Call start_a_new_spec_memo(memo_opened, search_for_arep_and_swkr, forms_to_arep, forms_to_swkr, send_to_other, other_name, other_street, other_city, other_state, other_zip, False)
+'Opens new MEMO
+PF5
+'Creates new MEMO
+write_value_and_transmit("X", 5, 12)
+
+'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
 EMWriteScreen "N", 6, 3
 transmit
 

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -83,10 +83,6 @@ PF3
 'Search CASE/NOTEs to determine if there is a VERIFICATIONS REQUESTED CASE/NOTE
 call write_value_and_transmit("N", 6, 3)
 
-'To do - remove after testing complete. MAXIS case number identified through DAIL scrubber but not during testing so added in identification of MAXIS case number here
-EMReadScreen MAXIS_case_number, 8, 20, 38
-MAXIS_case_number = trim(replace(MAXIS_case_number,"_", " "))
-
 'Using SNAP application date to set too old date, no need to read for dates prior to SNAP application
 too_old_date = DateAdd("D", -1, SNAP_application_date)
 

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -70,6 +70,7 @@ IF datediff("D", SNAP_application_date, fifteen_of_appl_month) >= 0 Then							'
 	progs_closed = progs_closed & "SNAP/"
 	SNAP_last_REIN_date = dateadd("d", 30, SNAP_application_date)
 	SNAP_followup_text = ", after which a new CAF is required (expedited SNAP closing for postponed verification not returned)."
+	'To do - where is cash_check coming from?
 	IF cash_check <> 1 THEN intake_date = dateadd("d", 1, SNAP_last_REIN_date)			        'if cash is not being closed the intake date needs to be the day after the rein date
 Else
 	progs_closed = progs_closed & "SNAP/"															'if rec'd after the 15th client gets until closure date (end of 2nd month of benefits) to be reinstated.
@@ -82,7 +83,7 @@ PF3
 
 'To do - review functionality to confirm it works properly
 'HERE WE SEARCH CASE:NOTES
-write_value_and_transmit("N", 6, 3)
+call write_value_and_transmit("N", 6, 3)
 
 'We are looking for notes that multiple scripts complete to keep from making duplicate notes
 'To do - likely unnecessary, can delete
@@ -184,14 +185,14 @@ Loop until DateDiff("d", too_old_date, next_note_date) <= 0
 PF3
 
 'Navigates to SPEC/MEMO through DAIL to maintain tie to list
-write_value_and_transmit("P", 6, 3)
-write_value_and_transmit("MEMO", 20, 70)
+Call write_value_and_transmit("P", 6, 3)
+Call write_value_and_transmit("MEMO", 20, 70)
 'To do - double-check function(ality), ran into issues leaving the DAIL
 ' Call start_a_new_spec_memo(memo_opened, search_for_arep_and_swkr, forms_to_arep, forms_to_swkr, send_to_other, other_name, other_street, other_city, other_state, other_zip, False)
 'Opens new MEMO
 PF5
 'Creates new MEMO
-write_value_and_transmit("X", 5, 12)
+Call write_value_and_transmit("X", 5, 12)
 
 'Dialog is defined here so the case number and application date are listed on it
 Dialog1 = ""
@@ -225,6 +226,17 @@ DO
 	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 
+'Write information to SPEC/MEMO
+memo_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose ---"
+write_variable_in_SPEC_MEMO(memo_header)
+write_variable_in_SPEC_MEMO("Reason for closure: Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
+If verifs_needed <> "" then call write_variable_in_SPEC_MEMO("Verifications needed: " & verifs_needed)
+'To do - need to verify if this is necessary, won't it always include this info? 
+If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_variable_in_SPEC_MEMO("Last SNAP reinstatement date", SNAP_last_REIN_date & SNAP_followup_text)
+'Save MEMO and navigate back to DAIL
+PF4
+PF3
+
 'To do - update navigation back to/from DAIL to CASE/NOTE
 'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
 EMWriteScreen "N", 6, 3
@@ -244,6 +256,8 @@ case_note_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose -
 call write_variable_in_case_note(case_note_header)
 call write_bullet_and_variable_in_case_note("Reason for closure", "Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
 If verifs_needed <> "" then call write_bullet_and_variable_in_case_note("Verifs needed", verifs_needed)
+
+'To do - check on the case noting intake notes
 If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_bullet_and_variable_in_case_note("Last SNAP REIN date", SNAP_last_REIN_date & SNAP_followup_text)
 call write_variable_in_case_note("---")
 call write_variable_in_case_note(worker_signature)

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("08/29/2023", "Updated script to include creation of SPEC/MEMO with info on needed verifications.", "Mark Riegel, Hennepin County") '#363
 CALL changelog_update("09/16/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -90,25 +90,22 @@ PF5
 'Creates new MEMO
 write_value_and_transmit("X", 5, 12)
 
-'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
-EMWriteScreen "N", 6, 3
-transmit
-
 'Dialog is defined here so the case number and application date are listed on it
 Dialog1 = ""
-BeginDialog Dialog1, 0, 0, 401, 70, "Verifications Needed"
-  EditBox 90, 5, 305, 15, verifs_needed
-  EditBox 305, 30, 90, 15, worker_signature
-  Text 95, 50, 75, 10, MAXIS_case_number
-  Text 95, 35, 90, 10, SNAP_application_date
-  ButtonGroup ButtonPressed
-    OkButton 295, 50, 50, 15
-    CancelButton 345, 50, 50, 15
-  Text 235, 35, 65, 10, "Sign your case note"
-  Text 10, 10, 70, 10, "Verifications Needed:"
-  Text 10, 35, 65, 10, "Date of application"
-  Text 10, 50, 50, 10, "Case Number"
-  EndDialog
+BeginDialog Dialog1, 0, 0, 401, 120, "Verifications Needed"
+	Text 5, 5, 390, 20, "Please review and confirm the required verifications below. Utilize plain language for the verifications as this will be used to create a MEMO and CASE/NOTE."
+	Text 10, 35, 70, 10, "Verifications Needed:"
+  	EditBox 85, 30, 305, 15, verifs_needed
+  	Text 10, 50, 65, 10, "Date of application:"
+  	Text 85, 50, 90, 10, SNAP_application_date
+  	Text 10, 65, 50, 10, "Case Number:"
+  	Text 85, 65, 75, 10, MAXIS_case_number
+	Text 10, 85, 65, 10, "Worker Signature:"
+  	EditBox 85, 80, 90, 15, worker_signature
+  	ButtonGroup ButtonPressed
+    	OkButton 290, 100, 50, 15
+    	CancelButton 345, 100, 50, 15
+EndDialog
 
 'Runs the dialog to allow workers to sign and to list verifications needed
 DO
@@ -124,6 +121,11 @@ DO
 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
 	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+
+'To do - update navigation back to/from DAIL to CASE/NOTE
+'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
+EMWriteScreen "N", 6, 3
+transmit
 
 'The script checks to make sure it is on the NOTES main list
 EMReadScreen notes_check, 9, 2, 33

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -71,8 +71,6 @@ IF datediff("D", SNAP_application_date, fifteen_of_appl_month) >= 0 Then							'
 	progs_closed = progs_closed & "SNAP/"
 	SNAP_last_REIN_date = dateadd("d", 30, SNAP_application_date)
 	SNAP_followup_text = ", after which a new Combined Application Form (CAF) is required (expedited SNAP closing for postponed verification not returned)."
-	'To do - where is cash_check coming from?
-	IF cash_check <> 1 THEN intake_date = dateadd("d", 1, SNAP_last_REIN_date)			        'if cash is not being closed the intake date needs to be the day after the rein date
 Else
 	progs_closed = progs_closed & "SNAP/"															'if rec'd after the 15th client gets until closure date (end of 2nd month of benefits) to be reinstated.
 	SNAP_last_REIN_date = closure_date
@@ -238,8 +236,7 @@ CALL write_variable_in_SPEC_MEMO(" - 1001 Plymouth Ave N Minneapolis 55411")
 CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
 CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
 Call write_variable_in_SPEC_MEMO(" ")
-'To do - need to verify if this is necessary, won't it always include this info? 
-If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_variable_in_SPEC_MEMO("Last SNAP reinstatement date: " & SNAP_last_REIN_date & SNAP_followup_text)
+
 'Save MEMO and navigate back to DAIL
 PF4
 PF3
@@ -261,9 +258,6 @@ case_note_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose -
 call write_variable_in_case_note(case_note_header)
 call write_bullet_and_variable_in_case_note("Reason for closure", "Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
 If verifs_needed <> "" then call write_bullet_and_variable_in_case_note("Verifications needed", verifs_needed)
-
-'To do - check on the case noting intake notes
-If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_bullet_and_variable_in_case_note("Last SNAP REIN date", SNAP_last_REIN_date & SNAP_followup_text)
 call write_variable_in_case_note("---")
 call write_variable_in_case_note(worker_signature)
 

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -164,7 +164,7 @@ Do
 						verifs_to_add = verifs_to_add & line                    'adding the verif information all together
 					Next
 					If left(verifs_to_add, 2) = "; " Then verifs_to_add = right(verifs_to_add, len(verifs_to_add) - 2)  'trimming the string
-					If verifs_to_add <> "" Then verifs_needed = verifs_needed & verifs_to_add 'adding the information to the variable used in this script 
+					If verifs_to_add <> "" Then verifs_needed = trim(verifs_needed & verifs_to_add) 'adding the information to the variable used in this script 
 				End If
 			End If
 			PF3         'leaving the note

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -233,9 +233,22 @@ LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 
 'Write information to SPEC/MEMO
 memo_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose ---"
-write_variable_in_SPEC_MEMO(memo_header)
-write_variable_in_SPEC_MEMO("Reason for closure: Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
+Call write_variable_in_SPEC_MEMO(memo_header)
+Call write_variable_in_SPEC_MEMO(" ")
+Call write_variable_in_SPEC_MEMO("Reason for closure: Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
+Call write_variable_in_SPEC_MEMO(" ")
 If verifs_needed <> "" then call write_variable_in_SPEC_MEMO("Verifications needed: " & verifs_needed)
+Call write_variable_in_SPEC_MEMO(" ")
+CALL write_variable_in_SPEC_MEMO("*** Submitting Documents:")
+CALL write_variable_in_SPEC_MEMO("- Online at infokeep.hennepin.us or MNBenefits.mn.gov")
+CALL write_variable_in_SPEC_MEMO("  Use InfoKeep to upload documents directly to your case.")
+CALL write_variable_in_SPEC_MEMO("- Mail, Fax, or Drop Boxes at service centers listed below:")
+CALL write_variable_in_SPEC_MEMO(" - 7051 Brooklyn Blvd Brooklyn Center 55429")
+CALL write_variable_in_SPEC_MEMO(" - 1011 1st St S Hopkins 55343")
+CALL write_variable_in_SPEC_MEMO(" - 1001 Plymouth Ave N Minneapolis 55411")
+CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
+CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
+Call write_variable_in_SPEC_MEMO(" ")
 'To do - need to verify if this is necessary, won't it always include this info? 
 If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_variable_in_SPEC_MEMO("Last SNAP reinstatement date: " & SNAP_last_REIN_date & SNAP_followup_text)
 'Save MEMO and navigate back to DAIL
@@ -260,7 +273,7 @@ End If
 case_note_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose ---"
 call write_variable_in_case_note(case_note_header)
 call write_bullet_and_variable_in_case_note("Reason for closure", "Delayed verifications were not submitted and Expedited SNAP Autoclosed.")
-If verifs_needed <> "" then call write_bullet_and_variable_in_case_note("Verifs needed", verifs_needed)
+If verifs_needed <> "" then call write_bullet_and_variable_in_case_note("Verifications needed", verifs_needed)
 
 'To do - check on the case noting intake notes
 If case_noting_intake_dates = True or case_noting_intake_dates = "" then call write_bullet_and_variable_in_case_note("Last SNAP REIN date", SNAP_last_REIN_date & SNAP_followup_text)

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -81,15 +81,8 @@ END IF
 'Navigates back to DAIL
 PF3 						
 
-'To do - review functionality to confirm it works properly
-'HERE WE SEARCH CASE:NOTES
+'Search CASE/NOTEs to determine if there is a VERIFICATIONS REQUESTED CASE/NOTE
 call write_value_and_transmit("N", 6, 3)
-
-'We are looking for notes that multiple scripts complete to keep from making duplicate notes
-'To do - likely unnecessary, can delete
-' look_for_expedited_determination_case_note = False
-' If SNAP_checkbox = checked and the_process_for_snap = "Application" Then look_for_expedited_determination_case_note = True
-' Call Navigate_to_MAXIS_screen("CASE", "NOTE")               'Now we navigate to CASE:NOTES
 
 'To do - remove after testing complete. MAXIS case number identified through DAIL scrubber but not during testing so added in identification of MAXIS case number here
 EMReadScreen MAXIS_case_number, 8, 20, 38
@@ -192,8 +185,6 @@ PF3
 'Navigates to SPEC/MEMO through DAIL to maintain tie to list
 Call write_value_and_transmit("P", 6, 3)
 Call write_value_and_transmit("MEMO", 20, 70)
-'To do - double-check function(ality), ran into issues leaving the DAIL
-' Call start_a_new_spec_memo(memo_opened, search_for_arep_and_swkr, forms_to_arep, forms_to_swkr, send_to_other, other_name, other_street, other_city, other_state, other_zip, False)
 'Opens new MEMO
 PF5
 'Creates new MEMO
@@ -255,8 +246,6 @@ If case_noting_intake_dates = True or case_noting_intake_dates = "" then call wr
 PF4
 PF3
 
-'To do - update navigation back to/from DAIL to CASE/NOTE
-'Navigates to Case Notes from DAIL - maintaining the tie to the list - does this so worker can reveiw case notes while the next dialog is up
 EMWriteScreen "N", 6, 3
 transmit
 

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -183,14 +183,6 @@ Loop until DateDiff("d", too_old_date, next_note_date) <= 0
 'Navigate back to DAIL
 PF3
 
-'Navigates to SPEC/MEMO through DAIL to maintain tie to list
-Call write_value_and_transmit("P", 6, 3)
-Call write_value_and_transmit("MEMO", 20, 70)
-'Opens new MEMO
-PF5
-'Creates new MEMO
-Call write_value_and_transmit("X", 5, 12)
-
 'Dialog is defined here so the case number and application date are listed on it
 Dialog1 = ""
 BeginDialog Dialog1, 0, 0, 401, 120, "Verifications Needed"
@@ -222,6 +214,12 @@ DO
 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
 	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+
+'Navigates to SPEC/MEMO 
+Call write_value_and_transmit("P", 6, 3)
+Call write_value_and_transmit("MEMO", 20, 70)
+'Function to create new MEMO
+Call start_a_new_spec_memo(memo_opened, False, forms_to_arep, forms_to_swkr, send_to_other, other_name, other_street, other_city, other_state, other_zip, False)
 
 'Write information to SPEC/MEMO
 memo_header = "--- SNAP Closed " & closure_date & " - Expedited Autoclose ---"

--- a/dail/postponed-expedited-snap-verifications.vbs
+++ b/dail/postponed-expedited-snap-verifications.vbs
@@ -104,8 +104,9 @@ DO
 		Dialog Dialog1
 		cancel_confirmation
 		Call validate_MAXIS_case_number(err_msg, "*")
-		IF verifs_needed = "" THEN err_msg = err_msg & vbCr & "* Please enter the postponed verifications requested."
-		IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+		IF trim(verifs_needed) = "" THEN err_msg = err_msg & vbCr & "* Please enter the postponed verifications requested."
+		IF len(trim(verifs_needed)) > 30 THEN err_msg = err_msg & vbCr & "* The list of verifications must be less than 30 characters long. Please shorten."
+		IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
 		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
 	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS


### PR DESCRIPTION
Added SPEC/MEMO functionality to script, more specifically:
1. Updated dialog validation for needed verifications
2. Added functionality to pull in verifications needed from CASE/NOTE
3. Added functionality to write information to SPEC/MEMO in a more readable format

I had a question around the cash_check and case_noting_intake_dates variables. These don't appear in the DAIL scrubber or this script so wasn't sure if they were an unintentional carryover.

I included logic to capture the case number from the CASE/NOTE that can be removed once finalized since the DAIL scrubber will capture this.