### PR TITLE
1469 replace snap button link

### DIFF
--- a/notes/caf.vbs
+++ b/notes/caf.vbs
@@ -4887,7 +4887,7 @@ function run_expedited_determination_script_functionality(xfs_screening, caf_one
     te_02_10_01_btn					= 510
 
     hsr_manual_expedited_snap_btn 	= 1000
-    hsr_snap_applications_btn		= 1100
+    hsr_applications_btn	    	= 1100
     ryb_exp_identity_btn			= 1200
     ryb_exp_timeliness_btn			= 1300
     sir_exp_flowchart_btn			= 1400
@@ -4969,7 +4969,7 @@ function run_expedited_determination_script_functionality(xfs_screening, caf_one
     				' GroupBox 5, 220, 390, 100, "Supports"
     				' Text 15, 235, 260, 10, "If you need support in handling for expedited, please access these resources:"
     			    ' PushButton 25, 250, 150, 13, "HSR Manual - Expedited SNAP", hsr_manual_expedited_snap_btn
-    				' PushButton 25, 265, 150, 13, "HSR Manual - SNAP Applications", hsr_snap_applications_btn
+    				' PushButton 25, 265, 150, 13, "HSR Manual - Applications", hsr_applications_btn
     				' PushButton 25, 280, 150, 13, "Retrain Your Brain - Expedited - Identity", ryb_exp_identity_btn
     				' PushButton 25, 295, 150, 13, "Retrain Your Brain - Expedited - Timeliness", ryb_exp_timeliness_btn
     			    ' PushButton 180, 250, 150, 13, "SIR - SNAP Expedited Flowchart", sir_exp_flowchart_btn
@@ -5100,7 +5100,7 @@ function run_expedited_determination_script_functionality(xfs_screening, caf_one
     			End If
     			GroupBox 5, 295, 470, 60, "If you need support in handling for expedited, please access these resources:"
     			PushButton 15, 305, 150, 13, "HSR Manual - Expedited SNAP", hsr_manual_expedited_snap_btn
-    			PushButton 15, 320, 150, 13, "HSR Manual - SNAP Applications", hsr_snap_applications_btn
+    			PushButton 15, 320, 150, 13, "HSR Manual - Applications", hsr_applications_btn
     			PushButton 15, 335, 150, 13, "SIR - SNAP Expedited Flowchart", sir_exp_flowchart_btn
     			PushButton 165, 305, 150, 13, "Retrain Your Brain - Expedited - Identity", ryb_exp_identity_btn
     			PushButton 165, 320, 150, 13, "Retrain Your Brain - Expedited - Timeliness", ryb_exp_timeliness_btn
@@ -5242,7 +5242,7 @@ function run_expedited_determination_script_functionality(xfs_screening, caf_one
 
     		If ButtonPressed >= 1000 Then
     			If ButtonPressed = hsr_manual_expedited_snap_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Expedited_SNAP.aspx"
-    			If ButtonPressed = hsr_snap_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/SNAP_Applications.aspx"
+    			If ButtonPressed = hsr_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Applications.aspx"
     			If ButtonPressed = ryb_exp_identity_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%201%20-%20Identity.mp4"
     			If ButtonPressed = ryb_exp_timeliness_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%202%20-%20Timeliness.mp4"
     			If ButtonPressed = sir_exp_flowchart_btn Then resource_URL = "https://www.dhssir.cty.dhs.state.mn.us/MAXIS/Documents/SNAP%20Expedited%20Service%20Flowchart.pdf"

--- a/notes/expedited-determination.vbs
+++ b/notes/expedited-determination.vbs
@@ -1373,7 +1373,7 @@ knowledge_now_support_btn		= 500
 te_02_10_01_btn					= 510
 
 hsr_manual_expedited_snap_btn 	= 1000
-hsr_snap_applications_btn		= 1100
+hsr_applications_btn		= 1100
 ryb_exp_identity_btn			= 1200
 ryb_exp_timeliness_btn			= 1300
 sir_exp_flowchart_btn			= 1400
@@ -2128,7 +2128,7 @@ Do
 				' GroupBox 5, 220, 390, 100, "Supports"
 				' Text 15, 235, 260, 10, "If you need support in handling for expedited, please access these resources:"
 			    ' PushButton 25, 250, 150, 13, "HSR Manual - Expedited SNAP", hsr_manual_expedited_snap_btn
-				' PushButton 25, 265, 150, 13, "HSR Manual - SNAP Applications", hsr_snap_applications_btn
+				' PushButton 25, 265, 150, 13, "HSR Manual - Applications", hsr_applications_btn
 				' PushButton 25, 280, 150, 13, "Retrain Your Brain - Expedited - Identity", ryb_exp_identity_btn
 				' PushButton 25, 295, 150, 13, "Retrain Your Brain - Expedited - Timeliness", ryb_exp_timeliness_btn
 			    ' PushButton 180, 250, 150, 13, "SIR - SNAP Expedited Flowchart", sir_exp_flowchart_btn
@@ -2242,7 +2242,7 @@ Do
 			End If
 			GroupBox 5, 295, 470, 60, "If you need support in handling for expedited, please access these resources:"
 			PushButton 15, 305, 150, 13, "HSR Manual - Expedited SNAP", hsr_manual_expedited_snap_btn
-			PushButton 15, 320, 150, 13, "HSR Manual - SNAP Applications", hsr_snap_applications_btn
+			PushButton 15, 320, 150, 13, "HSR Manual - Applications", hsr_applications_btn
 			PushButton 15, 335, 150, 13, "SIR - SNAP Expedited Flowchart", sir_exp_flowchart_btn
 			PushButton 165, 305, 150, 13, "Retrain Your Brain - Expedited - Identity", ryb_exp_identity_btn
 			PushButton 165, 320, 150, 13, "Retrain Your Brain - Expedited - Timeliness", ryb_exp_timeliness_btn
@@ -2372,7 +2372,7 @@ Do
 
 		If ButtonPressed >= 1000 Then
 			If ButtonPressed = hsr_manual_expedited_snap_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Expedited_SNAP.aspx"
-			If ButtonPressed = hsr_snap_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/SNAP_Applications.aspx"
+			If ButtonPressed = hsr_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Applications.aspx"
 			If ButtonPressed = ryb_exp_identity_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%201%20-%20Identity.mp4"
 			If ButtonPressed = ryb_exp_timeliness_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%202%20-%20Timeliness.mp4"
 			If ButtonPressed = sir_exp_flowchart_btn Then resource_URL = "https://www.dhssir.cty.dhs.state.mn.us/MAXIS/Documents/SNAP%20Expedited%20Service%20Flowchart.pdf"

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -2961,7 +2961,7 @@ function display_expedited_dialog()
 	te_02_10_01_btn					= 510
 
 	hsr_manual_expedited_snap_btn 	= 1000
-	hsr_snap_applications_btn		= 1100
+	hsr_applications_btn			= 1100
 	ryb_exp_identity_btn			= 1200
 	ryb_exp_timeliness_btn			= 1300
 	sir_exp_flowchart_btn			= 1400
@@ -3330,7 +3330,7 @@ function display_expedited_dialog()
 			End If
 			GroupBox 5, 315, 470, 60, "If you need support in handling for expedited, please access these resources:"
 			PushButton 15, 325, 150, 13, "HSR Manual - Expedited SNAP", hsr_manual_expedited_snap_btn
-			PushButton 15, 340, 150, 13, "HSR Manual - SNAP Applications", hsr_snap_applications_btn
+			PushButton 15, 340, 150, 13, "HSR Manual - Applications", hsr_applications_btn
 			PushButton 15, 355, 150, 13, "SIR - SNAP Expedited Flowchart", sir_exp_flowchart_btn
 			PushButton 165, 325, 150, 13, "Retrain Your Brain - Expedited - Identity", ryb_exp_identity_btn
 			PushButton 165, 340, 150, 13, "Retrain Your Brain - Expedited - Timeliness", ryb_exp_timeliness_btn
@@ -3469,7 +3469,7 @@ function display_expedited_dialog()
 
 		If ButtonPressed >= 1000 Then
 			If ButtonPressed = hsr_manual_expedited_snap_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Expedited_SNAP.aspx"
-			If ButtonPressed = hsr_snap_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/SNAP_Applications.aspx"
+			If ButtonPressed = hsr_applications_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/Applications.aspx"
 			If ButtonPressed = ryb_exp_identity_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%201%20-%20Identity.mp4"
 			If ButtonPressed = ryb_exp_timeliness_btn Then resource_URL = "https://hennepin.sharepoint.com/teams/hs-es-manual/Retrain_Your_Brain/SNAP%20Expedited%202%20-%20Timeliness.mp4"
 			If ButtonPressed = sir_exp_flowchart_btn Then resource_URL = "https://www.dhssir.cty.dhs.state.mn.us/MAXIS/Documents/SNAP%20Expedited%20Service%20Flowchart.pdf"
@@ -9768,7 +9768,7 @@ te_02_10_01_btn					= 817
 cm_04_12_btn					= 818
 ebt_card_info_btn				= 819
 hsr_manual_expedited_snap_btn	= 820
-hsr_snap_applications_btn		= 821
+hsr_applications_btn		= 821
 sir_exp_flowchart_btn			= 822
 ryb_exp_identity_btn			= 823
 ryb_exp_timeliness_btn			= 824


### PR DESCRIPTION
Updated Snap reference button including: button name, button var, and link to eliminate the word SNAP and use the correct applications link. Also updated instructions sheet to have the correct screenshots. 