### PR TITLE
1458 replace ind digital experience with function

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -6409,7 +6409,7 @@ function digital_experience()
 '--- This function standardizes the digital experience coding information so that we only have to update it in one location.
 '===== Keywords: MAXIS, MEMO, WCOM
 	CALL write_variable_in_SPEC_MEMO("*** Options for Submitting Documents ***")
-	CALL write_variable_in_SPEC_MEMO("- Use InfoKeep online at infokeep.hennepin.us to upload directly to your case.")
+	CALL write_variable_in_SPEC_MEMO("- Upload documents to case with infokeep.hennepin.us.")
 	CALL write_variable_in_SPEC_MEMO("- You can submit documents online at MNBenefits.mn.gov.")
 	CALL write_variable_in_SPEC_MEMO("- Mail, Fax, or Drop Boxes at service centers.")
 end function

--- a/actions/job-change-reported.vbs
+++ b/actions/job-change-reported.vbs
@@ -1332,7 +1332,6 @@ If IsDate(verif_form_date) = TRUE and developer_mode = FALSE Then
     End Select
     CALL write_variable_in_SPEC_MEMO("")
     CALL write_variable_in_SPEC_MEMO("If you have questions about verifications needed, or if your job change requires explanation, please call as much of the clarification can be provided verbally and is our best means to correctly budget your income.")
-	CALL write_variable_in_SPEC_MEMO("")
     Call digital_experience
     PF4
     Call back_to_SELF

--- a/admin/individual-appointment-letter.vbs
+++ b/admin/individual-appointment-letter.vbs
@@ -167,8 +167,8 @@ CALL write_variable_in_SPEC_MEMO(" - 1011 1st St S Hopkins 55343")
 CALL write_variable_in_SPEC_MEMO(" - 1001 Plymouth Ave N Minneapolis 55411")
 CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
 CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
-CALL digital_experience
 Call write_variable_in_SPEC_MEMO(" ")
+CALL digital_experience
 CALL write_variable_in_SPEC_MEMO("Domestic violence brochures are available at this website: https://edocs.dhs.state.mn.us/lfserver/Public/DHS-3477-ENG. You can always request a paper copy via phone.")
 
 

--- a/admin/on-demand-waiver-applications.vbs
+++ b/admin/on-demand-waiver-applications.vbs
@@ -2054,7 +2054,6 @@ For case_entry = 0 to UBOUND(WORKING_LIST_CASES_ARRAY, 2)
 					CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
 					CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
 					CALL digital_experience
-					Call write_variable_in_SPEC_MEMO(" ")
 					CALL write_variable_in_SPEC_MEMO("Domestic violence brochures are available at this website: https://edocs.dhs.state.mn.us/lfserver/Public/DHS-3477-ENG. You can always request a paper copy via phone.")
 
 					PF4
@@ -2142,7 +2141,6 @@ For case_entry = 0 to UBOUND(WORKING_LIST_CASES_ARRAY, 2)
 						CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
 						CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
 						CALL write_variable_in_SPEC_MEMO(" More detail can be found at hennepin.us/economic-supports")
-						CALL write_variable_in_SPEC_MEMO("")
 						CALL digital_experience
 
 						PF4

--- a/admin/review-report.vbs
+++ b/admin/review-report.vbs
@@ -2598,7 +2598,6 @@ ElseIf renewal_option = "Send Appointment Letters" Then
 						If renewal_guidance_needed = False Then CALL write_variable_in_SPEC_MEMO("If you have questions about the type of verifications needed, call 612-596-1300 and someone will assist you.")
 						If renewal_guidance_needed = True Then
 							CALL digital_experience
-							CALL write_variable_in_SPEC_MEMO("")
 							CALL write_variable_in_SPEC_MEMO("Once we receive and process your renewal paperwork, you will receive information BY MAIL with possible follow up or actions taken on your case. Call 612-596-1300 if you have additional questions.")
 						End If
 
@@ -3354,9 +3353,7 @@ If renewal_option = "Send NOMIs" Then
 					CALL write_variable_in_SPEC_MEMO(" - 2215 East Lake Street Minneapolis 55407")
 					CALL write_variable_in_SPEC_MEMO(" (Hours are 8 - 4:30 Monday - Friday)")
 					CALL write_variable_in_SPEC_MEMO(" More detail can be found at hennepin.us/economic-supports")
-					CALL write_variable_in_SPEC_MEMO("")
 					CALL digital_experience
-					CALL write_variable_in_SPEC_MEMO("")
 					CALL write_variable_in_SPEC_MEMO("  ** If we do not hear from you by " & last_day_of_recert & "  **")
 					CALL write_variable_in_SPEC_MEMO("  **   your benefits will end on " & last_day_of_recert & ".   **")
 

--- a/notices/12-month-contact.vbs
+++ b/notices/12-month-contact.vbs
@@ -90,11 +90,7 @@ Call start_a_new_spec_memo(memo_opened, True, forms_to_arep, forms_to_swkr, send
 Call write_variable_in_SPEC_MEMO("************************************************************")
 Call write_variable_in_SPEC_MEMO("This notice is to remind you to report changes to your county worker by the 10th of the month following the month of the change. Changes that must be reported are address, people in your household, income, shelter costs and other changes such as legal obligation to pay child support. If you don't know whether to report a change, contact your county worker.")
 CALL write_variable_in_SPEC_MEMO("")
-CALL write_variable_in_SPEC_MEMO("*** Submitting Documents:")
-CALL write_variable_in_SPEC_MEMO("- Online at infokeep.hennepin.us or MNBenefits.mn.gov")
-CALL write_variable_in_SPEC_MEMO("  Use InfoKeep to upload documents directly to your case.")
-CALL write_variable_in_SPEC_MEMO("- Mail, Fax, or Drop Boxes at Service Centers.")
-CALL write_variable_in_SPEC_MEMO("  More Info: https://www.hennepin.us/economic-supports")
+CALL digital_experience
 Call write_variable_in_SPEC_MEMO("************************************************************")
 PF4
 

--- a/notices/add-wcom.vbs
+++ b/notices/add-wcom.vbs
@@ -445,7 +445,7 @@ Do
         ReDim array_of_msg_lines(0)
         ReDim WCOM_TO_WRITE_ARRAY (0)
 
-		If clt_virtual_dropbox_checkbox = checked Then CALL add_words_to_message("*** Options for Submitting Documents ***; - Use InfoKeep online at infokeep.hennepin.us to upload directly to your case.; - Use InfoKeep to upload documents directly to your case.; - You can submit documents online at MNBenefits.mn.gov.; - Mail, Fax, or Drop Boxes at service centers.")
+		If clt_virtual_dropbox_checkbox = checked Then CALL add_words_to_message("*** Options for Submitting Documents ***; - Upload documents to case with infokeep.hennepin.us.; - You can submit documents online at MNBenefits.mn.gov.; - Mail, Fax, or Drop Boxes at service centers.")
 
         If july_cola_wcom = checked Then
             'code for the dialog for PACT closure (this dialog has the same name in each IF to prevent the over 7 dialog error)


### PR DESCRIPTION
Updates with this commit: 
-Updated Digital Experience function to 4 lines 
-Reviewed all scrips to verify all verbiage fit on spec memo. 


Scripts unable to test: 
- Actions-Job Change Reported (Ilse and I spoke, this script is a little buggy- I removed 5 lines of spec memo and replaced with 4 lines)
- Admin- On Demand Waiver Applications (Need to connect with QI team once this is pushed to see if they receive errors)
- Admin Review Report (connect with Casey when this is run next)
- Notes-Denied Programs (Ilse and I spoke, don't worry about this one)
- Admin DAIL FMED Deduction (tested ind script)
- Admin DAIL 12 Month Contact (tested ind script)