### PR TITLE
#1531 dail scrubber multi member bug

### DIFF
--- a/dail/dail-scrubber.vbs
+++ b/dail/dail-scrubber.vbs
@@ -103,7 +103,7 @@ function bring_correct_message_to_top()
 			PF8
 			EMReadScreen last_page, 9, 24, 14
 			If last_page = "LAST PAGE" Then call go_to_top_of_dail
-			header_row = 5
+			header_row = 4
 		End If
 	Loop until dail_pers_header = dail_pers_indicator and dail_case_header = dail_case_indicator	'stopping when we get to the right header
 


### PR DESCRIPTION
Corrects issues so that scrubber can find the correct DAIL without getting into an endless loop or triggering a mismatch.
To test, just make sure it opens a script on the DAIL.
Case number that was problem is in our inbox. 
