### PR TITLE
1446 remove ltc button from notes main menu and include LTC scripts in alpha categories

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -115,7 +115,7 @@ class script_bowie
 		' "https://dept.hennepin.us/hsphd/sa/ews/BlueZone_Script_Instructions/"			'OLD URL
         ' "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/"		'NEW URL'
 		If category = "NOTES" AND left(script_name, 5) = "LTC -" Then
-            SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/" & UCase(category) & "/LTC%20scripts/" & UCase(category) & "%20-%20" & replace(replace(ucase(script_name) & ".docx", " - ", "%20"), " ", "%20")
+            SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/Notes/" & UCase(category) & "%20-%20" & replace(replace(ucase(script_name) & ".docx", " - ", "%20"), " ", "%20")
 		ElseIf script_name = "Add WCOM" Then
 			SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTICES/NOTICES%20-%20ADD%20WCOM.docx"
 		ElseIf left(script_name, 4) = "REPT" OR script_name = "DAIL Report" OR script_name = "EMPS" OR script_name = "LTC-GRH List Generator" Then

--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -115,7 +115,7 @@ class script_bowie
 		' "https://dept.hennepin.us/hsphd/sa/ews/BlueZone_Script_Instructions/"			'OLD URL
         ' "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/"		'NEW URL'
 		If category = "NOTES" AND left(script_name, 5) = "LTC -" Then
-            SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/Notes/" & UCase(category) & "%20-%20" & replace(replace(ucase(script_name) & ".docx", " - ", "%20"), " ", "%20")
+            SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/" & UCase(category) & "/LTC%20scripts/" & UCase(category) & "%20-%20" & replace(replace(ucase(script_name) & ".docx", " - ", "%20"), " ", "%20")
 		ElseIf script_name = "Add WCOM" Then
 			SharePoint_instructions_URL = "https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTICES/NOTICES%20-%20ADD%20WCOM.docx"
 		ElseIf left(script_name, 4) = "REPT" OR script_name = "DAIL Report" OR script_name = "EMPS" OR script_name = "LTC-GRH List Generator" Then

--- a/notes/main-menu.vbs
+++ b/notes/main-menu.vbs
@@ -40,7 +40,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-call changelog_update("11/20/2023", "The LTC button has been removed from the menu. LTC: 5181, Asset Assessment, Transfer Penalty, and Hospice Form Received are now found under the standard alpha menus with other note scripts.", "Megan Geissler, Hennepin County")
+call changelog_update("11/20/2023", "The LTC button has been removed from the menu. LTC: 5181, Asset Assessment, Hospice Form Received and Transfer Penalty are now found under the standard alpha menus with other note scripts.", "Megan Geissler, Hennepin County")
 call changelog_update("11/07/2023", "Retired the scripts:##~##NOTES - LTC Intake Approval##~## This functionality is now contained in NOTES - HC Evaluation.", "Dave Courtright, Hennepin County")
 call changelog_update("10/16/2023", "Retired the scripts:##~##NOTES - LTC COLA Summary##~##NOTES - LTC MA Approval##~##", "Casey Love, Hennepin County")
 call changelog_update("10/03/2023", "The IMIG button has been removed from the menu. Immigration Status and Sponsor Income scripts are now found under the standard alpha menus with other note scripts.", "Dave Courtright, Hennepin County")

--- a/notes/main-menu.vbs
+++ b/notes/main-menu.vbs
@@ -85,7 +85,6 @@ Function declare_main_menu_dialog(script_category)
 	' 	End if
 	'
 	' Next
-	show_ltc_btn = True
 	show_0_c_btn = True
 	show_d_f_btn = True
 	show_g_l_btn = True
@@ -97,10 +96,7 @@ Function declare_main_menu_dialog(script_category)
     For current_script = 0 to ubound(script_array)
         script_array(current_script).show_script = FALSE
         If ucase(script_array(current_script).category) = ucase(script_category) then
-            If ButtonPressed = menu_ltc_button Then
-                If left(script_array(current_script).script_name, 3) = "LTC" Then script_array(current_script).show_script = TRUE
-				show_ltc_btn = False
-            ElseIf ButtonPressed = menu_0_to_c_button Then
+			If ButtonPressed = menu_0_to_c_button Then
                 If IsNumeric(left(script_array(current_script).script_name, 1)) = TRUE Then script_array(current_script).show_script = TRUE
                 If left(script_array(current_script).script_name, 1) = "A" Then script_array(current_script).show_script = TRUE
                 If left(script_array(current_script).script_name, 1) = "B" Then script_array(current_script).show_script = TRUE
@@ -118,7 +114,6 @@ Function declare_main_menu_dialog(script_category)
                 If left(script_array(current_script).script_name, 1) = "J" Then script_array(current_script).show_script = TRUE
                 If left(script_array(current_script).script_name, 1) = "K" Then script_array(current_script).show_script = TRUE
                 If left(script_array(current_script).script_name, 1) = "L" Then script_array(current_script).show_script = TRUE
-                If left(script_array(current_script).script_name, 3) = "LTC" Then script_array(current_script).show_script = FALSE
 				show_g_l_btn = False
             ElseIf ButtonPressed = menu_M_to_Q_button Then
                 If left(script_array(current_script).script_name, 1) = "M" Then script_array(current_script).show_script = TRUE
@@ -184,12 +179,7 @@ Function declare_main_menu_dialog(script_category)
 		Else
 			Text 			220,                    23, 					40, 		15, 			" R - Z "
 		End If
-		If show_ltc_btn = True Then
-        	PushButton 		255,                    20, 					50, 		15, 			"  LTC  ", 					menu_ltc_button
-		Else
-			Text 			270,                    23, 					40, 		15, 			" LTC  "
-		End If
-
+		
 
 		'SCRIPT LIST HANDLING--------------------------------------------
 
@@ -236,7 +226,6 @@ menu_D_to_F_button          = 120
 menu_G_to_L_button          = 130
 menu_M_to_Q_button          = 140
 menu_R_to_Z_button          = 150
-menu_ltc_button             = 160
 
 'Other pre-loop and pre-function declarations
 subcategory_array = array()

--- a/notes/main-menu.vbs
+++ b/notes/main-menu.vbs
@@ -40,6 +40,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("11/20/2023", "The LTC button has been removed from the menu. LTC: 5181, Asset Assessment, Transfer Penalty, and Hospice Form Received are now found under the standard alpha menus with other note scripts.", "Megan Geissler, Hennepin County")
 call changelog_update("11/07/2023", "Retired the scripts:##~##NOTES - LTC Intake Approval##~## This functionality is now contained in NOTES - HC Evaluation.", "Dave Courtright, Hennepin County")
 call changelog_update("10/16/2023", "Retired the scripts:##~##NOTES - LTC COLA Summary##~##NOTES - LTC MA Approval##~##", "Casey Love, Hennepin County")
 call changelog_update("10/03/2023", "The IMIG button has been removed from the menu. Immigration Status and Sponsor Income scripts are now found under the standard alpha menus with other note scripts.", "Dave Courtright, Hennepin County")


### PR DESCRIPTION
Removed LTC button from Notes Main Menu
Updated ChangeLog to notify users of this change.
No action required for CLOS or ? for sharepoint documents.
Did not rename, left LTC in the naming for now. 