### PR TITLE
#1643 NOTES - HC Eval - BUG in baseline date if not a date

### DIFF
--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -198,7 +198,10 @@ function check_for_errors(eval_questions_clear)
 		If ma_bc_authorization_form_missing_checkbox = unchecked and IsDate(ma_bc_authorization_form_date) = False Then err_msg = err_msg & "~!~" & "1 ^* Date Received (for MA-BC Authorization Form)##~##   - Enter the date the form for MA-BC Authorization was received."
 	End If
 	dlg_last_page_2_digits = left(last_page_numb&" ", 2)		'The dialog page needs to always be 2 digits or the functionality to display the errors has weird formatting
-
+	baseline_date = trim(baseline_date)
+	If baseline_date  <> "" Then
+		If IsDate(baseline_date) = False Then  err_msg = err_msg & "~!~" & dlg_last_page_2_digits & "^* The baseline date should be a date if information is entered. Leave blank if it is not relevant to the case."
+	End If
 	'last page errors
 	If app_sig_status = "Select One..." Then err_msg = err_msg & "~!~" & dlg_last_page_2_digits & "^* Has the Application been correctly Signed and Dated?##~##   - Select if all required signatures are on the application and correctly dated." & ".##~##"
 	If app_sig_status = "No - Some applications or dates are missing" and trim(app_sig_notes) = "" THen err_msg = err_msg & "~!~" & dlg_last_page_2_digits & "^* If not, describe what is missing:##~##   - Since the application is not correctly signed/dated, enter the details of what is missing or incorrect." & ".##~##"
@@ -1878,6 +1881,7 @@ function define_main_dialog()
 
 		ElseIf page_display = ltc_intake_page Then
 			GroupBox 10, 5, 465, 125, "LTC Intake Information"
+			Text 325, 5, 150, 10, "Health Care Application Date: " & hc_application_date
 			Text 20, 20, 60, 10, "Month MA to start:"
 			EditBox 85, 15, 45, 15, month_MA_starts
 			Text 135, 20, 110, 10, "Is the client is in the community?"
@@ -6681,7 +6685,10 @@ Next
 'LTC Cases at application have the possiblity of creating a MA LTC Intake note
 'The variable ltc_app_case_note_option can be used to determine which of the notes (this or the main one) is entered in these situations
 If ltc_waiver_request_yn = "Yes" and processing_an_application = True and InStr(ltc_app_case_note_option, "MA-LTC Intake Info NOTE") <> 0 Then
-	If application_date <> "" then lookback_period = dateadd("d", -1, dateadd("m", -60, cdate(application_date))) & ""
+	If hc_application_date <> "" then
+		lookback_period = dateadd("d", -1, dateadd("m", -60, cdate(hc_application_date))) & ""
+		end_of_lookback = dateadd("d", -1, cdate(hc_application_date)) & ""
+	End If
 	If baseline_date <> "" then
 		lookback_period = dateadd("m", -60, cdate(baseline_date)) & ""
 		end_of_lookback = dateadd("d", -1, cdate(baseline_date)) & ""
@@ -6693,7 +6700,7 @@ If ltc_waiver_request_yn = "Yes" and processing_an_application = True and InStr(
 
 	Call write_variable_in_CASE_NOTE("====================== MA & LTC Date Details =======================")
 
-	call write_bullet_and_variable_in_CASE_NOTE("Application date", application_date)
+	call write_bullet_and_variable_in_CASE_NOTE("Application date", hc_application_date)
 	call write_bullet_and_variable_in_CASE_NOTE("LTCC date", LTCC_date)
 	call write_bullet_and_variable_in_CASE_NOTE("Month MA starts", month_MA_starts)
 	call write_bullet_and_variable_in_CASE_NOTE("Month MA-LTC starts", month_MA_LTC_starts)

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -669,7 +669,7 @@ function define_main_dialog()
 			Next
 
 			If y_pos = 25 Then
-				Text 20, 25, 350, 10, "NO JOBS panels have been entered in the csae file for the selected members."
+				Text 20, 25, 350, 10, "NO JOBS panels have been entered in the case file for the selected members."
 				Text 50, 35, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				Text 20, 50, 350, 20, "If there is income from a job that should be included for these members, CANCEL the Script, UPDATE MAXIS, and then rerun this script."
 				Text 20, 70, 350, 10, "CASE/NOTE will indicate NO JOBS, add any notes here that are relevant:"
@@ -802,7 +802,7 @@ function define_main_dialog()
 			Next
 
 			If y_pos = 25 Then
-				Text 20, 25, 350, 10, "NO BUSI panels have been entered in the csae file for the selected members."
+				Text 20, 25, 350, 10, "NO BUSI panels have been entered in the case file for the selected members."
 				Text 50, 35, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				Text 20, 50, 350, 20, "If there is income from self employment that should be included for these members, CANCEL the Script, UPDATE MAXIS, and then rerun this script."
 				Text 20, 70, 350, 10, "CASE/NOTE will indicate NO SELF EMPLOYMENT, add any notes here that are relevant:"
@@ -935,7 +935,7 @@ function define_main_dialog()
 			Next
 
 			If y_pos = 25 Then
-				Text 20, 25, 350, 10, "NO UNEA panels have been entered in the csae file for the selected members."
+				Text 20, 25, 350, 10, "NO UNEA panels have been entered in the case file for the selected members."
 				Text 50, 35, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				Text 20, 50, 350, 20, "If there is income from an unearned income source that should be included for these members, CANCEL the Script, UPDATE MAXIS, and then rerun this script."
 				Text 20, 70, 350, 10, "CASE/NOTE will indicate NO UNEARNED INCOME, add any notes here that are relevant:"
@@ -1124,7 +1124,7 @@ function define_main_dialog()
 				'TODO - DEAL WITH OTHR panel
 			Next
 			If y_pos = 90 Then
-				Text 20, y_pos, 350, 10, "NO CASH/ACCT/SECU panels have been entered in the csae file for the selected members."
+				Text 20, y_pos, 350, 10, "NO CASH/ACCT/SECU panels have been entered in the case file for the selected members."
 				y_pos = y_pos + 10
 				Text 50, y_pos, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				y_pos = y_pos + 15
@@ -1225,7 +1225,7 @@ function define_main_dialog()
 				End If
 			Next
 			If y_pos = 25 Then
-				Text 20, y_pos, 350, 10, "NO CARS panels have been entered in the csae file for the selected members."
+				Text 20, y_pos, 350, 10, "NO CARS panels have been entered in the case file for the selected members."
 				y_pos = y_pos + 10
 				Text 50, y_pos, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				y_pos = y_pos + 15
@@ -1286,7 +1286,7 @@ function define_main_dialog()
 			Next
 
 			If y_pos = start_y_pos Then
-				Text 20, y_pos, 350, 10, "NO REST panels have been entered in the csae file for the selected members."
+				Text 20, y_pos, 350, 10, "NO REST panels have been entered in the case file for the selected members."
 				y_pos = y_pos + 10
 				Text 50, y_pos, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				y_pos = y_pos + 15
@@ -1463,7 +1463,7 @@ function define_main_dialog()
 			GroupBox 10, 10, 465, grp_len, "Expenses"
 
 			If y_pos = 25 Then
-				Text 20, 25, 350, 10, "NO PDED/COEX/DCEX panels have been entered in the csae file for the selected members."
+				Text 20, 25, 350, 10, "NO PDED/COEX/DCEX panels have been entered in the case file for the selected members."
 				Text 50, 35, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				Text 20, 50, 350, 20, "If there are expenses that should be included for these members, CANCEL the Script, UPDATE MAXIS, and then rerun this script."
 
@@ -1585,7 +1585,7 @@ function define_main_dialog()
 			If acci_exists = False and insa_exists = False and faci_exists = False Then
 				grp_len = grp_len + 75
 
-				Text 20, y_pos, 350, 10, "NO ACCI/INSA/FACI panels have been entered in the csae file for the selected members."
+				Text 20, y_pos, 350, 10, "NO ACCI/INSA/FACI panels have been entered in the case file for the selected members."
 				y_pos = y_pos + 10
 				Text 50, y_pos, 350, 10, "Selected Members for this case: MEMB " & replace(List_of_HH_membs_to_include, " ", "/")
 				y_pos = y_pos + 15

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -51,6 +51,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("01/23/2024", "BUG FIX - updated the handling for LTC Application cases to better handle in dealing with the baseline date and lookback period.", "Casey Love, Hennepin County")
 call changelog_update("12/15/2023", "BUG FIX - previously if the dialog review was 'Complete' but then selected 'No' to return, the script would ask after every button push to 'Complete' updated to stop this from happening until 'Complete' is pressed again.", "Casey Love, Hennepin County")
 call changelog_update("11/28/2023", "Added field to capture member specific HC recertification date.", "Megan Geissler, Hennepin County")
 call changelog_update("10/31/2023", "Fixed inhibiting bug related to IMIG panel for both members on case and/or applying for Health Care.##~##", "Dave Courtright, Hennepin County")


### PR DESCRIPTION
Error had been reported with a cdate error. I believe this is due to handling around the baseline date, particularly needing dialog handling to ensure this is actually a date if it isn't blank. 

Also found an issue with the application date variable.

I selected everyone for review but I think having 2 reviews of the pull would be sufficient.