### PR TITLE
#1650 and #1518 - New usage recording functionality

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -4962,15 +4962,16 @@ function clear_line_of_text(row, start_column)
   EMWaitReady 0, 0
 end function
 
-function collect_script_usage_data(script_to_record, closing_message, reset_timer)
+function collect_script_usage_data(script_to_record, closing_message, timer_begin)
 '--- This function records script runs into the usage log and can be used for functionality runs, not just completed scripts.
 '~~~~~ script_to_record: this would be the 'name_of_script' for completed script runs, but can be adjusted if run on functionality instead of the completed script
 '~~~~~ closing_message: information about the script run should be passed through this variable, for completed script runs, this would be the closing message
+'~~~~~ timer_begin: passes the timer variable through to the data usage to record script run time. This allows for different timers to be set and reset based on the specific script functionality
 '===== Keywords: MAXIS, MMIS, script, statistics
 	stop_time = timer
 	script_run_end_time = time
 	script_run_end_date = date
-	script_run_time = stop_time - start_time
+	script_run_time = stop_time - timer_begin
 
 	'Getting user name
 	Set objNet = CreateObject("WScript.NetWork")
@@ -5001,8 +5002,6 @@ function collect_script_usage_data(script_to_record, closing_message, reset_time
 
 	'Closing the connection
 	objConnection.Close
-
-	If reset_timer = True Then start_time = timer				'possibly need to reset the timer for workflows- for each unique functionality
 end function
 
 function confirm_docs_accepted_in_ecf(closing_msg)
@@ -11741,7 +11740,7 @@ function script_end_procedure(closing_message)
 	script_run_time = stop_time - start_time
 	If is_county_collecting_stats  = True then
 
-		' function collect_script_usage_data(name_of_script, closing_message)		'TODO - uncomment and remove the rest of the information in the if statement when we are ready to use the new functionality
+		' function collect_script_usage_data(name_of_script, closing_message, start_time)		'TODO - uncomment and remove the rest of the information in the if statement when we are ready to use the new functionality
 
 		'Getting user name
 		Set objNet = CreateObject("WScript.NetWork")

--- a/dail/cola-review-and-approve.vbs
+++ b/dail/cola-review-and-approve.vbs
@@ -1,6 +1,7 @@
 'GATHERING STATS----------------------------------------------------------------------------------------------------
 name_of_script = "DAIL - COLA REVIEW AND APPROVE.vbs"
 start_time = timer
+functionality_time = timer
 STATS_counter = 1              'sets the stats counter at 1
 STATS_manualtime = 90          'manual run time in seconds
 STATS_denomination = "C"       'C is for each case
@@ -424,7 +425,8 @@ If unea_count <> 0 Then
 				EMWaitReady 0,0
 				Call write_value_and_transmit("TPQY", 20, 70)
 				STATS_manualtime = STATS_manualtime + 30
-				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), False)		'record script FUNCTIONALITY usage in SQL
+				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), functionality_time)		'record script FUNCTIONALITY usage in SQL
+				functionality_time = timer
 
 				'checking for NON-DISCLOSURE AGREEMENT REQUIRED FOR ACCESS TO IEVS FUNCTIONS'
 				EMReadScreen agreement_check, 9, 2, 24
@@ -435,10 +437,11 @@ If unea_count <> 0 Then
 		If ButtonPressed = cola_summary_note_btn Then
 			functionality_info = ""			'this variable will be used to capture information to pass to the usage log
 			Call cola_summary_note			'Button to create the CASE/NOTE
-			call collect_script_usage_data(name_of_script & " - COLA Summary Note Created", functionality_info, False)		'record script FUNCTIONALITY usage in SQL
+			call collect_script_usage_data(name_of_script & " - COLA Summary Note Created", functionality_info, functionality_time)		'record script FUNCTIONALITY usage in SQL
+			functionality_time = timer
 		End If
 		If ButtonPressed = run_elig_summ_btn Then
-			Call collect_script_usage_data(name_of_script & " - REDIRECT to Elig Summary", "", False)		'record script FUNCTIONALITY usage in SQL
+			Call collect_script_usage_data(name_of_script & " - REDIRECT to Elig Summary", "", functionality_time)		'record script FUNCTIONALITY usage in SQL
 			Call run_from_GitHub(script_repository & "notes/eligibility-summary.vbs")		'Button to run Eligibility Summary
 		End If
 	Loop until err_msg = ""
@@ -488,7 +491,8 @@ Else
 				EMWaitReady 0,0
 				Call write_value_and_transmit("TPQY", 20, 70)
 				STATS_manualtime = STATS_manualtime + 30
-				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), False)		'record script FUNCTIONALITY usage in SQL
+				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), functionality_time)		'record script FUNCTIONALITY usage in SQL
+				functionality_time = timer
 
 				'checking for NON-DISCLOSURE AGREEMENT REQUIRED FOR ACCESS TO IEVS FUNCTIONS'
 				EMReadScreen agreement_check, 9, 2, 24

--- a/dail/cola-review-and-approve.vbs
+++ b/dail/cola-review-and-approve.vbs
@@ -405,8 +405,8 @@ If unea_count <> 0 Then
 			err_msg = ""
 
 			dialog Dialog1
-			If ButtonPressed = finish_script_btn Then ButtonPressed = 0
-			cancel_confirmation
+			If ButtonPressed = finish_script_btn Then call script_end_procedure("")
+			cancel_without_confirmation
 
 			err_msg = "LOOP"										'this is a little weird, we are just always looping
 

--- a/dail/cola-review-and-approve.vbs
+++ b/dail/cola-review-and-approve.vbs
@@ -76,6 +76,7 @@ end function
 
 'CASE/NOTE is in a Function because it is in a loop and looks cleaner in the later script run.
 function cola_summary_note()
+	functionality_info = "UNEA Information: "
 	Call nav_in_DAIL("N")
 
 	call start_a_blank_CASE_NOTE
@@ -83,15 +84,19 @@ function cola_summary_note()
 	Call write_variable_in_CASE_NOTE("--- UNEARNED INCOME ---")
 	For unea_info = 0 to UBound(UNEA_FROM_DAIL_RUN, 2)
 		If UNEA_FROM_DAIL_RUN(unea_checkbox_const, unea_info) = unchecked Then
+			functionality_info = functionality_info &  " ~|~ " & "MEMB " & UNEA_FROM_DAIL_RUN(dail_memb_ref_const, unea_info) & " - " & UNEA_FROM_DAIL_RUN(dail_unea_type_code_const, unea_info) & " - " & UNEA_FROM_DAIL_RUN(dail_unea_type_info_const, unea_info)
 			Call write_variable_in_CASE_NOTE("* MEMB " & UNEA_FROM_DAIL_RUN(dail_memb_ref_const, unea_info) & " - " & UNEA_FROM_DAIL_RUN(dail_memb_name_const, unea_info) & " - UNEA " & UNEA_FROM_DAIL_RUN(dail_memb_ref_const, unea_info) & " " & UNEA_FROM_DAIL_RUN(dail_unea_instance_const, unea_info))
-			Call write_variable_in_CASE_NOTE("  Unearned Income Type: " &UNEA_FROM_DAIL_RUN(dail_unea_type_code_const, unea_info) & " - " & UNEA_FROM_DAIL_RUN(dail_unea_type_info_const, unea_info))
+			Call write_variable_in_CASE_NOTE("  Unearned Income Type: " & UNEA_FROM_DAIL_RUN(dail_unea_type_code_const, unea_info) & " - " & UNEA_FROM_DAIL_RUN(dail_unea_type_info_const, unea_info))
 			Call write_variable_in_CASE_NOTE("  Prospective Amount: $ " & UNEA_FROM_DAIL_RUN(dail_prosp_total_const, unea_info) & "  -  COLA Disregard $ " & UNEA_FROM_DAIL_RUN(dail_cola_disregard_const, unea_info))
 		End If
 	Next
+	functionality_info = functionality_info & " ========= "
 	Call write_bullet_and_variable_in_CASE_NOTE("UNEA Notes", UNEA_notes)
 	If MEDI_exists = True Then
+		functionality_info = functionality_info & "MEDI Information"
 		Call write_variable_in_CASE_NOTE("--- MEDICARE PART B ---")
 		For medi_count = 0 to UBound(HH_member_array)
+			functionality_info = functionality_info & " ~|~ " & "MEMB " & HH_member_array(medi_count)
 			If MEDI_PART_B_ARRAY(medi_count) <> "" Then Call write_variable_in_CASE_NOTE("* MEMB " & HH_member_array(medi_count) & " - " & NAME_ARRAY(medi_count) & ": Medicare - Part B $ " & MEDI_PART_B_ARRAY(medi_count))
 		Next
 		Call write_bullet_and_variable_in_CASE_NOTE("MEDI Notes", MEDI_notes)
@@ -419,6 +424,7 @@ If unea_count <> 0 Then
 				EMWaitReady 0,0
 				Call write_value_and_transmit("TPQY", 20, 70)
 				STATS_manualtime = STATS_manualtime + 30
+				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), False)		'record script FUNCTIONALITY usage in SQL
 
 				'checking for NON-DISCLOSURE AGREEMENT REQUIRED FOR ACCESS TO IEVS FUNCTIONS'
 				EMReadScreen agreement_check, 9, 2, 24
@@ -426,8 +432,15 @@ If unea_count <> 0 Then
 			End If
 		Next
 
-		If ButtonPressed = cola_summary_note_btn Then Call cola_summary_note			'Button to create the CASE/NOTE
-		If ButtonPressed = run_elig_summ_btn Then Call run_from_GitHub(script_repository & "notes/eligibility-summary.vbs")		'Button to run Eligibility Summary
+		If ButtonPressed = cola_summary_note_btn Then
+			functionality_info = ""			'this variable will be used to capture information to pass to the usage log
+			Call cola_summary_note			'Button to create the CASE/NOTE
+			call collect_script_usage_data(name_of_script & " - COLA Summary Note Created", functionality_info, False)		'record script FUNCTIONALITY usage in SQL
+		End If
+		If ButtonPressed = run_elig_summ_btn Then
+			Call collect_script_usage_data(name_of_script & " - REDIRECT to Elig Summary", "", False)		'record script FUNCTIONALITY usage in SQL
+			Call run_from_GitHub(script_repository & "notes/eligibility-summary.vbs")		'Button to run Eligibility Summary
+		End If
 	Loop until err_msg = ""
 Else
 	'This dialog is ONLY for viewing SVES - there was no UNEA found so we do not have a CASE/NOTE option
@@ -475,6 +488,7 @@ Else
 				EMWaitReady 0,0
 				Call write_value_and_transmit("TPQY", 20, 70)
 				STATS_manualtime = STATS_manualtime + 30
+				call collect_script_usage_data(name_of_script & " - INFC-SVES Viewed ", "SVES for " & NAME_ARRAY(i), False)		'record script FUNCTIONALITY usage in SQL
 
 				'checking for NON-DISCLOSURE AGREEMENT REQUIRED FOR ACCESS TO IEVS FUNCTIONS'
 				EMReadScreen agreement_check, 9, 2, 24


### PR DESCRIPTION
Created new function to record usage information outside of the script_end_procedure so that we can record more specific script functionality usage. 

This is an initial phase of this work and we will need to consider how we use the table columns that currently exist.

We might need to change the naming parameters when saving a part of a script run, like add 'FUNCTIONALITY - ' to the beginning or something - or maybe remove the '.vbs' and add something else. 

I also have some questions about resetting the timer. We want to be careful we are not double counting script run time. Currently I have a boolean parameter that will allow us to control resetting the timer.

Here is what the data looks like with my recording the usage in this way:
![image](https://github.com/Hennepin-County/MAXIS-scripts/assets/13418322/e130eceb-d448-4942-8159-a3ec686eee6a)
The last two are from the same script run.

We should probably talk about this in more detail but any update should have minimal impact on scripts other than COLA Review and Approve so we could pull in and discuss later, especially if we need the FuncLib available.