### PR TITLE
#1622 SNAP Waived Interview Return Contact added to Client Contact

### DIFF
--- a/notes/client-contact.vbs
+++ b/notes/client-contact.vbs
@@ -51,6 +51,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+Call changelog_update("01/30/2024", "The Client Contact script has been updated to support gathering additional information about SNAP applications if additional information is needed. ##~## ##~##This update supports processing cases during the SNAP Waived Interview. This will connect NOTES - SNAP Waived Interview script functionality with Client Contact and will pull up specific functionality that will list the application questions with follow up informatation required. This will allow for better SNAP processing and make following up on pending SNAP applications easier.##~##", "Casey Love, Hennepin County")
 Call changelog_update("01/05/2024", "Added initial dialog which contains the MAXIS Case Number and Worker Signature. Removed this information from the main dialog, and moved the 'Display Benefits' button into the space where the 'Case Number' field used to be.", "Ilse Ferris, Hennepin County")
 Call changelog_update("11/20/2023", "Added checkbox to indicate a phone interview was attempted but not completed, which will add a specific CASE/NOTE with this information. Added handling to prevent use of script for interviews.", "Mark Riegel, Hennepin County")
 Call changelog_update("05/15/2023", "Added phone # & name autofilling in 'who was contacted' drop list AREP's and/or SWKR's, & added name for MEMB 01. Removed text opt out option (retired process), updated the Q-flow verbiage from N/A to NO Q-FLOW POPULATION.", "Ilse Ferris, Hennepin County")
@@ -193,6 +194,7 @@ If SNAP_Waived_interview_return_contact_needed = True Then
 							"It appears the application form (" & form_used & ") was reviewed for this case on " & note_date & " and there are some follow up questions we need from the resident." & vbCr & vbCr &_
 							"Are you in contact with the resident now and can address the items we previously determined will need follow-up?", vbQuestion + vbYesNo, "CAF Review Info Note Found")
 
+	'Running SNAP Waived Interview for return contact detail
 	If follow_up_contact = vbYes Then call run_from_GitHub(script_repository & "notes\snap-waived-interview.vbs")
 End If
 

--- a/notes/snap-waived-interview.vbs
+++ b/notes/snap-waived-interview.vbs
@@ -589,7 +589,7 @@ return_to_info_btn = 3704
 
 			BeginDialog Dialog1, 0, 0, 385, 300, "SNAP General Work Rules"
 				 Text 15, 25, 350, 10, "Unless all members of the unit meet an exemption, you must review the SNAP general work rules below."
-				 Text 15, 40, 350, 10, "----------------------------------------------------------------------------------------------------"
+				 Text 15, 40, 350, 10, "		          -------------------------------------------------------------------------------------					"
 				 Text 15, 55, 350, 10, "First, explain to the resident which members of the household are subject to the work rules."
 	     		 Text 15, 70, 350, 10, "To follow the general work rules, these members must:"
 	     		 Text 15, 85, 350, 10, "* Accept any job offer received, unless there is a good reason they can't. "
@@ -597,15 +597,15 @@ return_to_info_btn = 3704
 	     		 Text 15, 125, 350, 10, "* Tell us about your job and how much you are working, if asked."
 	     		 Text 15, 140, 350, 10, "* You may lose your SNAP benefits if you don't follow these work rules without having a good reason."
 	     		 Text 15, 155, 350, 10, "It is important for you to know that there are consequences if you/they don't follow these General Work Rules: "
-	     		 Text 15, 170, 350, 10, "The first time [you/they] don't follow these rules, and you don't have a good reason, you can't get SNAP benefits for 1 month."
-				 Text 15, 185, 350, 10, "The second time [you/they] don't follow these rules, you can't get SNAP benefits for 3 months."
-				 Text 15, 200, 350, 10, "The third time, and any time after that, [you/they] can't get SNAP benefits for 6 months."
-				 Text 15, 215, 350, 10, "		   ------------------------------------------------------------------------------					"
+	     		 Text 15, 170, 350, 20, "The first time [you/they] don't follow these rules, and you don't have a good reason, you can't get SNAP benefits for 1 month."
+				 Text 15, 195, 350, 10, "The second time [you/they] don't follow these rules, you can't get SNAP benefits for 3 months."
+				 Text 15, 210, 350, 10, "The third time, and any time after that, [you/they] can't get SNAP benefits for 6 months."
+				 Text 15, 225, 350, 10, "		          -------------------------------------------------------------------------------------					"
 				ButtonGroup ButtonPressed
-				 PushButton 20, 250, 145, 15, "Press here to review a list of exemptions.", exemptions_button
-  				 PushButton 210, 230, 145, 15, "Press here to continue without reviewing.", continue_button
-  				 PushButton 20, 230, 145, 15, "Press here if you reviewed with resident.", work_rules_reviewed_button
-				 PushButton 210, 250, 145, 15, "Press here to return to the previous dialog.", return_to_info_btn
+				 PushButton 20, 260, 145, 15, "Press here to review a list of exemptions.", exemptions_button
+  				 PushButton 210, 240, 145, 15, "Press here to continue without reviewing.", continue_button
+  				 PushButton 20, 240, 145, 15, "Press here if you reviewed with resident.", work_rules_reviewed_button
+				 PushButton 210, 260, 145, 15, "Press here to return to the previous dialog.", return_to_info_btn
 			EndDialog
 
 

--- a/notes/snap-waived-interview.vbs
+++ b/notes/snap-waived-interview.vbs
@@ -6037,7 +6037,7 @@ function write_interview_question_in_CASE_NOTE(interview_question)
 			CALL write_variable_in_CASE_NOTE("    RSDI - " & interview_question(13)& " " & interview_question(14) & "   UI - " & interview_question(19) & " " & interview_question(20) & " Tribal - " & interview_question(25) & " " & interview_question(26))
 			CALL write_variable_in_CASE_NOTE("     SSI - " & interview_question(15) & " " & interview_question(16) & "   WC - " & interview_question(21) & " " & interview_question(22) & "   CSES - " & interview_question(27) & " " & interview_question(28))
 			CALL write_variable_in_CASE_NOTE("      VA - " & interview_question(17) & " " & interview_question(18) & "  Ret - " & interview_question(23) & " " & interview_question(24) & "  Other - " & interview_question(29) & " " & interview_question(30))
-			If trim(interview_question(4)) <> "" Then CALL write_variable_in_CASE_NOTE("    WriteIn Answer - " & interview_question(5))
+			If trim(interview_question(4)) <> "" Then CALL write_variable_in_CASE_NOTE("    WriteIn Answer - " & interview_question(4))
 		End If
 		If interview_question(6) <> "" Then 'verif_y_n
 			If trim(interview_question(12)) = "" Then CALL write_variable_in_CASE_NOTE("    Verification: " & interview_question(6)) 'Verif y/n
@@ -6060,6 +6060,7 @@ function write_interview_question_in_CASE_NOTE(interview_question)
 					If trim(JOBS_ARRAY(jobs_intv_notes, each_job)) <> "" Then CALL write_variable_in_CASE_NOTE("    INTVW NOTES: " & JOBS_ARRAY(jobs_intv_notes, each_job))
 				End If
 			next
+			If trim(interview_question(4)) <> "" Then CALL write_variable_in_CASE_NOTE("    WriteIn Answer - " & interview_question(4)) 'Main write-in answer, if it was entered here instead of add jobs popup
 		End If
 		If trim(interview_question(5)) <> "" Then CALL write_variable_in_CASE_NOTE("    Detail on what was needed: " & interview_question(5))
 		If trim(interview_question(8)) <> "" Then CALL write_variable_in_CASE_NOTE("    INTVW NOTES: " & interview_question(8)) 'Interview Notes
@@ -9549,10 +9550,14 @@ If run_return_contact = True Then
 												JOBS_ARRAY(jobs_employee_name, info_needed_job_count) = trim(mid(full_note_line, employee_start+4, earnings_start-employee_start-4))
 												JOBS_ARRAY(jobs_gross_monthly_earnings, info_needed_job_count) = trim(mid(full_note_line, earnings_start+18, len(full_note_line)-employeearnings_starte_start-18))
 											End If
+										ElseIf InStr(note_line, "WriteIn Answer:") <> 0 Then
+											reading_write_in = True
+											reading_verif_details = False
+											JOBS_ARRAY(jobs_notes, info_needed_job_count) = trim(replace(note_line, "WriteIn Answer:", ""))
 										ElseIf InStr(note_line, "WriteIn Answer -") <> 0 Then
 											reading_write_in = True
 											reading_verif_details = False
-											JOBS_ARRAY(jobs_notes, info_needed_job_count) = trim(replace(note_line, "WriteIn Answer -", ""))
+											needed_info_array(found_quest)(caf_write_in) = trim(replace(note_line, "WriteIn Answer -", ""))
 										ElseIf InStr(note_line, "Verification:") <> 0 Then
 											reading_write_in = False
 											reading_verif_details = True

--- a/notes/snap-waived-interview.vbs
+++ b/notes/snap-waived-interview.vbs
@@ -8882,79 +8882,84 @@ msg_show_faq_btn = 107
 interpreter_servicves_btn = 108
 
 'Showing the case number dialog
-Do
-	DO
-		err_msg = ""
+If SNAP_Waived_interview_return_contact_needed <> True Then		'if this script was redirected from Client Contact, we do not need the initial dialog, we already have CASE Number, Worker Signature, and can automatically select the form type - skipping the initial dialog
 
-		' EditBox 245, 50, 50, 15, CAF_datestamp
-		' CheckBox 230, 80, 30, 10, "CASH", CASH_on_CAF_checkbox
-		' CheckBox 270, 80, 35, 10, "SNAP", SNAP_on_CAF_checkbox
-		' CheckBox 310, 80, 35, 10, "EMER", EMER_on_CAF_checkbox
-		' Text 155, 55, 90, 10, "Date Application Received:"
-		' GroupBox 225, 70, 125, 25, "Programs marked on CAF"
+	Do
+		DO
+			err_msg = ""
 
-		' PushButton 205, 35, 155, 10, "NOTES - Interview Script Instructions", msg_show_instructions_btn
-		' PushButton 205, 35, 155, 10, "Interview Quick Start Guide", msg_show_quick_start_guide_btn
-		' PushButton 205, 35, 155, 10, "Interview FAQ", msg_show_faq_btn
-		Dialog1 = ""
-		BeginDialog Dialog1, 0, 0, 371, 320, "SNAP Waived Interview Case number dialog"
-		  EditBox 75, 45, 60, 15, MAXIS_case_number
-		  DropListBox 75, 65, 140, 15, "Select One:"+chr(9)+"No Form - Return Contact" +chr(9)+"CAF (DHS-5223)"+chr(9)+"SNAP App for Srs (DHS-5223F)"+chr(9)+"MNbenefits", CAF_form '"HUF (DHS-8107)"+chr(9)++chr(9)+"Combined AR for Certain Pops (DHS-3727)"
-		  EditBox 75, 85, 145, 15, worker_signature
-		  DropListBox 20, 275, 335, 45, "Alert at the time you attempt to save each page of the dialog."+chr(9)+"Alert only once completing and leaving the final dialog.", select_err_msg_handling
-		  ButtonGroup ButtonPressed
-		    OkButton 260, 300, 50, 15
-		    CancelButton 315, 300, 50, 15
-            PushButton 220, 65, 120, 15, "Open Interpreter Services Link", interpreter_servicves_btn
-			PushButton 80, 165, 210, 15, "Press HERE for process documentation.", msg_show_quick_start_guide_btn
-	    	PushButton 80, 245, 210, 15, "Press HERE for more details on script messaging", msg_script_messaging_btn
-		    PushButton 10, 300, 75, 15, "Script Instructions", msg_show_instructions_btn
-		    'PushButton 60, 300, 70, 15, "Complete Application", msg_show_quick_start_guide_btn
-		    'PushButton 130, 300, 30, 15, "FAQ", msg_show_faq_btn
-		  Text 10, 10, 360, 10, "This script is to be used for a SNAP waived interview. Do not use this script to complete a full interview."
-		  Text 20, 50, 50, 10, "Case number:"
-		  Text 10, 70, 60, 10, "Actual CAF Form:"
-		  Text 10, 90, 60, 10, "Worker Signature:"
-		  'Text 145, 105, 105, 10, "*!*!*!*  DID YOU KNOW *!*!*!*"
-		  'Text 110, 120, 185, 10, "This script SAVES the information you enter as it runs!"
-		  'Text 75, 135, 255, 10, "This means that IF the script errors, fails, is cancelled, the network goes down."
-		  'Text 135, 145, 125, 10, "YOU CAN GET YOUR WORK BACK!!!"
-		  Text 45, 105, 300, 10, "Utilize this script to review a SNAP application for complete information and verifications. "
-		  Text 55, 120, 300, 10, "Review ECF and MAXIS for additional information or inconsistent info."
-		  Text 20, 135, 330, 20, "Once completed reviewing, the script will prompt you to contact the resident if more information is needed, and will provide only those questions that need to be asked to complete the SNAP app."
+			' EditBox 245, 50, 50, 15, CAF_datestamp
+			' CheckBox 230, 80, 30, 10, "CASH", CASH_on_CAF_checkbox
+			' CheckBox 270, 80, 35, 10, "SNAP", SNAP_on_CAF_checkbox
+			' CheckBox 310, 80, 35, 10, "EMER", EMER_on_CAF_checkbox
+			' Text 155, 55, 90, 10, "Date Application Received:"
+			' GroupBox 225, 70, 125, 25, "Programs marked on CAF"
 
-		  GroupBox 10, 190, 355, 105, "How to interact with this Script"
-		  Text 25, 205, 330, 35, "This script contains multiple dialogs covering all portions of the application. The script will assist you by checking for errors and missing information on each dialog. Choose below how you would like that error handling to occur."
-		  Text 20, 265, 315, 10, "How do you want to be alerted to updates needed to answers/information in following dialogs?"
-		EndDialog
+			' PushButton 205, 35, 155, 10, "NOTES - Interview Script Instructions", msg_show_instructions_btn
+			' PushButton 205, 35, 155, 10, "Interview Quick Start Guide", msg_show_quick_start_guide_btn
+			' PushButton 205, 35, 155, 10, "Interview FAQ", msg_show_faq_btn
+			Dialog1 = ""
+			BeginDialog Dialog1, 0, 0, 371, 320, "SNAP Waived Interview Case number dialog"
+			EditBox 75, 45, 60, 15, MAXIS_case_number
+			DropListBox 75, 65, 140, 15, "Select One:"+chr(9)+"No Form - Return Contact" +chr(9)+"CAF (DHS-5223)"+chr(9)+"SNAP App for Srs (DHS-5223F)"+chr(9)+"MNbenefits", CAF_form '"HUF (DHS-8107)"+chr(9)++chr(9)+"Combined AR for Certain Pops (DHS-3727)"
+			EditBox 75, 85, 145, 15, worker_signature
+			DropListBox 20, 275, 335, 45, "Alert at the time you attempt to save each page of the dialog."+chr(9)+"Alert only once completing and leaving the final dialog.", select_err_msg_handling
+			ButtonGroup ButtonPressed
+				OkButton 260, 300, 50, 15
+				CancelButton 315, 300, 50, 15
+				PushButton 220, 65, 120, 15, "Open Interpreter Services Link", interpreter_servicves_btn
+				PushButton 80, 165, 210, 15, "Press HERE for process documentation.", msg_show_quick_start_guide_btn
+				PushButton 80, 245, 210, 15, "Press HERE for more details on script messaging", msg_script_messaging_btn
+				PushButton 10, 300, 75, 15, "Script Instructions", msg_show_instructions_btn
+				'PushButton 60, 300, 70, 15, "Complete Application", msg_show_quick_start_guide_btn
+				'PushButton 130, 300, 30, 15, "FAQ", msg_show_faq_btn
+			Text 10, 10, 360, 10, "This script is to be used for a SNAP waived interview. Do not use this script to complete a full interview."
+			Text 20, 50, 50, 10, "Case number:"
+			Text 10, 70, 60, 10, "Actual CAF Form:"
+			Text 10, 90, 60, 10, "Worker Signature:"
+			'Text 145, 105, 105, 10, "*!*!*!*  DID YOU KNOW *!*!*!*"
+			'Text 110, 120, 185, 10, "This script SAVES the information you enter as it runs!"
+			'Text 75, 135, 255, 10, "This means that IF the script errors, fails, is cancelled, the network goes down."
+			'Text 135, 145, 125, 10, "YOU CAN GET YOUR WORK BACK!!!"
+			Text 45, 105, 300, 10, "Utilize this script to review a SNAP application for complete information and verifications. "
+			Text 55, 120, 300, 10, "Review ECF and MAXIS for additional information or inconsistent info."
+			Text 20, 135, 330, 20, "Once completed reviewing, the script will prompt you to contact the resident if more information is needed, and will provide only those questions that need to be asked to complete the SNAP app."
 
-		Dialog Dialog1
-		cancel_without_confirmation
+			GroupBox 10, 190, 355, 105, "How to interact with this Script"
+			Text 25, 205, 330, 35, "This script contains multiple dialogs covering all portions of the application. The script will assist you by checking for errors and missing information on each dialog. Choose below how you would like that error handling to occur."
+			Text 20, 265, 315, 10, "How do you want to be alerted to updates needed to answers/information in following dialogs?"
+			EndDialog
 
-		If ButtonPressed > 100 Then
-			err_msg = "LOOP"
+			Dialog Dialog1
+			cancel_without_confirmation
 
-			If ButtonPressed = msg_what_script_does_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20OVERVIEW.docx"
-			If ButtonPressed = msg_script_interaction_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20HOW%20TO%20USE.docx"
-	        If ButtonPressed = interpreter_servicves_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://itwebpw026/content/forms/af/_internal/hhs/human_services/initial_contact_access/AF10196.html"
-		    If ButtonPressed = msg_save_your_work_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20SAVE%20YOUR%20WORK.docx"
-			If ButtonPressed = msg_script_messaging_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20SCRIPT%20MESSAGING.docx"
+			If ButtonPressed > 100 Then
+				err_msg = "LOOP"
 
-			If ButtonPressed = msg_show_instructions_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20SNAP%20WAIVED%20INTERVIEW.docx"
-			If ButtonPressed = msg_show_quick_start_guide_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/SitePages/Processing-SNAP-Applications-with-Waived-Interviews.aspx"
-			If ButtonPressed = msg_show_faq_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20FAQ.docx"
-		Else
-			Call validate_MAXIS_case_number(err_msg, "*")
-			If no_case_number_checkbox = checked Then err_msg = ""
-			' Call validate_footer_month_entry(MAXIS_footer_month, MAXIS_footer_year, err_msg, "*")
-			If CAF_form = "Select One:" Then err_msg = err_msg & vbCr & "* Select which form that was received that we are using for the interview."
-			' If IsDate(CAF_datestamp) = False Then err_msg = err_msg & vbCr & "* Enter the date of application."
-			IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
-			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
-		End If
-	LOOP UNTIL err_msg = ""
-	call check_for_password(are_we_passworded_out)  'Adding functionality for MAXIS v.6 Passworded Out issue'
-LOOP UNTIL are_we_passworded_out = false
+				If ButtonPressed = msg_what_script_does_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20OVERVIEW.docx"
+				If ButtonPressed = msg_script_interaction_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20HOW%20TO%20USE.docx"
+				If ButtonPressed = interpreter_servicves_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://itwebpw026/content/forms/af/_internal/hhs/human_services/initial_contact_access/AF10196.html"
+				If ButtonPressed = msg_save_your_work_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20SAVE%20YOUR%20WORK.docx"
+				If ButtonPressed = msg_script_messaging_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20SCRIPT%20MESSAGING.docx"
+
+				If ButtonPressed = msg_show_instructions_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20SNAP%20WAIVED%20INTERVIEW.docx"
+				If ButtonPressed = msg_show_quick_start_guide_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/SitePages/Processing-SNAP-Applications-with-Waived-Interviews.aspx"
+				If ButtonPressed = msg_show_faq_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/NOTES/NOTES%20-%20INTERVIEW%20-%20FAQ.docx"
+			Else
+				Call validate_MAXIS_case_number(err_msg, "*")
+				If no_case_number_checkbox = checked Then err_msg = ""
+				' Call validate_footer_month_entry(MAXIS_footer_month, MAXIS_footer_year, err_msg, "*")
+				If CAF_form = "Select One:" Then err_msg = err_msg & vbCr & "* Select which form that was received that we are using for the interview."
+				' If IsDate(CAF_datestamp) = False Then err_msg = err_msg & vbCr & "* Enter the date of application."
+				IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+				IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
+			End If
+		LOOP UNTIL err_msg = ""
+		call check_for_password(are_we_passworded_out)  'Adding functionality for MAXIS v.6 Passworded Out issue'
+	LOOP UNTIL are_we_passworded_out = false
+Else
+	CAF_form = "No Form - Return Contact"		'setting the form type if the script was redirected from Client Contact
+End If
 
 Do
 	Call navigate_to_MAXIS_screen("STAT", "SUMM")

--- a/notes/snap-waived-interview.vbs
+++ b/notes/snap-waived-interview.vbs
@@ -10999,35 +10999,6 @@ prog_snap_intvw_date = ""
 update_prog = False
 If case_pending = True Then
 	Call navigate_to_MAXIS_screen("STAT", "PROG")
-
-	EMReadScreen prog_cash_1_status, 4, 6, 74
-	If prog_cash_1_status = "PEND" Then
-		EMReadScreen prog_cash_1_intvw_date, 8, 6, 55
-		prog_cash_1_intvw_date = replace(prog_cash_1_intvw_date, " ", "/")
-		If prog_cash_1_intvw_date = "__/__/__" Then prog_cash_1_intvw_date = ""
-		If prog_cash_1_intvw_date = "" Then update_prog = True
-	End If
-	EMReadScreen prog_cash_2_status, 4, 7, 74
-	If prog_cash_2_status = "PEND" Then
-		EMReadScreen prog_cash_2_intvw_date, 8, 7, 55
-		prog_cash_2_intvw_date = replace(prog_cash_2_intvw_date, " ", "/")
-		If prog_cash_2_intvw_date = "__/__/__" Then prog_cash_2_intvw_date = ""
-		If prog_cash_2_intvw_date = "" Then update_prog = True
-	End If
-	EMReadScreen prog_emer_status, 4, 8, 74
-	If prog_emer_status = "PEND" Then
-		EMReadScreen prog_emer_intvw_date, 8, 8, 55
-		prog_emer_intvw_date = replace(prog_emer_intvw_date, " ", "/")
-		If prog_emer_intvw_date = "__/__/__" Then prog_emer_intvw_date = ""
-		If prog_emer_intvw_date = "" Then update_prog = True
-	End If
-	EMReadScreen prog_grh_status, 4, 9, 74
-	If prog_grh_status = "PEND" Then
-		EMReadScreen prog_grh_intvw_date, 8, 9, 55
-		prog_grh_intvw_date = replace(prog_grh_intvw_date, " ", "/")
-		If prog_grh_intvw_date = "__/__/__" Then prog_grh_intvw_date = ""
-		If prog_grh_intvw_date = "" Then update_prog = True
-	End If
 	EMReadScreen prog_snap_status, 4, 10, 74
 	If prog_snap_status = "PEND" Then
 		EMReadScreen prog_snap_intvw_date, 8, 10, 55
@@ -11038,43 +11009,43 @@ If case_pending = True Then
 End If
 
 update_revw = False
-If cash_revw_due = True OR snap_revw_due = True Then
-	Call back_to_SELF
-	If cash_revw_due = True Then
-		MAXIS_footer_month = CASH_NEXT_REVW_MONTH
-		MAXIS_footer_year = CASH_NEXT_REVW_YEAR
-		Call navigate_to_MAXIS_screen("STAT", "REVW")
-
-		EMReadScreen cash_revw_status_code, 1, 7, 40
-		If cash_revw_status_code = "N" OR cash_revw_status_code = "I" OR cash_revw_status_code = "U" Then
-			EMReadScreen revw_panel_interview_date, 8, 15, 37
-			revw_panel_interview_date = replace(revw_panel_interview_date, " ", "/")
-			If revw_panel_interview_date = "__/__/__" Then revw_panel_interview_date = ""
-			If revw_panel_interview_date = "" Then update_revw = True
-		End If
-
-		MAXIS_footer_month = original_footer_month
-		MAXIS_footer_year = original_footer_year
-	End If
-
-	Call back_to_SELF
-	If snap_revw_due = True Then
-		MAXIS_footer_month = SNAP_NEXT_REVW_MONTH
-		MAXIS_footer_year = SNAP_NEXT_REVW_YEAR
-		Call navigate_to_MAXIS_screen("STAT", "REVW")
-
-		EMReadScreen snap_revw_status_code, 1, 7, 60
-		If snap_revw_status_code = "N" OR snap_revw_status_code = "I" OR snap_revw_status_code = "U" Then
-			EMReadScreen revw_panel_interview_date, 8, 15, 37
-			revw_panel_interview_date = replace(revw_panel_interview_date, " ", "/")
-			If revw_panel_interview_date = "__/__/__" Then revw_panel_interview_date = ""
-			If revw_panel_interview_date = "" Then update_revw = True
-		End If
-
-		MAXIS_footer_month = original_footer_month
-		MAXIS_footer_year = original_footer_year
-	End If
-End If
+'If cash_revw_due = True OR snap_revw_due = True Then
+'	Call back_to_SELF
+'	If cash_revw_due = True Then
+'		MAXIS_footer_month = CASH_NEXT_REVW_MONTH
+'		MAXIS_footer_year = CASH_NEXT_REVW_YEAR
+'		Call navigate_to_MAXIS_screen("STAT", "REVW")
+'
+'		EMReadScreen cash_revw_status_code, 1, 7, 40
+'		If cash_revw_status_code = "N" OR cash_revw_status_code = "I" OR cash_revw_status_code = "U" Then
+'			EMReadScreen revw_panel_interview_date, 8, 15, 37
+'			revw_panel_interview_date = replace(revw_panel_interview_date, " ", "/")
+'			If revw_panel_interview_date = "__/__/__" Then revw_panel_interview_date = ""
+'			If revw_panel_interview_date = "" Then update_revw = True
+'		End If
+'
+'		MAXIS_footer_month = original_footer_month
+'		MAXIS_footer_year = original_footer_year
+'	End If
+'
+'	Call back_to_SELF
+'	If snap_revw_due = True Then
+'		MAXIS_footer_month = SNAP_NEXT_REVW_MONTH
+'		MAXIS_footer_year = SNAP_NEXT_REVW_YEAR
+'		Call navigate_to_MAXIS_screen("STAT", "REVW")
+'
+'		EMReadScreen snap_revw_status_code, 1, 7, 60
+'		If snap_revw_status_code = "N" OR snap_revw_status_code = "I" OR snap_revw_status_code = "U" Then
+'			EMReadScreen revw_panel_interview_date, 8, 15, 37
+'			revw_panel_interview_date = replace(revw_panel_interview_date, " ", "/")
+'			If revw_panel_interview_date = "__/__/__" Then revw_panel_interview_date = ""
+'			If revw_panel_interview_date = "" Then update_revw = True
+'		End If
+'
+'		MAXIS_footer_month = original_footer_month
+'		MAXIS_footer_year = original_footer_year
+'	End If
+'End If
 Call back_to_SELF
 
 ' 'TESTING CODE - this is inplace so that the script doesn't error trying to update PROG.
@@ -11098,76 +11069,7 @@ Call back_to_SELF
 ' update_revw = False
 ' update_prog = False
 
-If update_revw = True OR update_prog = True Then
-	If update_revw = True OR update_prog = True Then dlg_len = 300
-	If update_revw = False OR update_prog = True Then dlg_len = 170
-	If update_revw = True OR update_prog = False Then dlg_len = 190
-	y_pos = 40
-	confirm_update_revw = 0
-	confirm_update_prog = 0
-
-	If update_revw = True Then confirm_update_revw = 1
-	If update_prog = True Then confirm_update_prog = 1
-	If prog_cash_1_status = "PEND" AND prog_cash_1_intvw_date = "" Then prog_update_cash_1_checkbox = checked
-	If prog_cash_2_status = "PEND" AND prog_cash_2_intvw_date = "" Then prog_update_cash_2_checkbox = checked
-	If prog_emer_status = "PEND" AND prog_emer_intvw_date = "" Then prog_update_emer_checkbox = checked
-	If prog_grh_status = "PEND" AND prog_grh_intvw_date = "" Then prog_update_grh_checkbox = checked
-	If prog_snap_status = "PEND" AND prog_snap_intvw_date = "" Then prog_update_snap_checkbox = checked
-	Dialog1 = ""
-	BeginDialog Dialog1, 0, 0, 251, dlg_len, "Update Interview Date in STAT"
-	  Text 10, 10, 235, 25, "It appears that the interview date needs to be added to STAT panels. Since the interview is now completed, the script can upate the correct panels with the interview date."
-	  If update_revw = True Then
-		  GroupBox 5, y_pos, 240, 125, "STAT/REVW Needs to be Updated"
-		  OptionGroup RadioGroupREVW
-		    RadioButton 10, y_pos + 15, 185, 10, "YES! Update REVW with the Interview Date/CAF Date", confirm_update_revw
-		    RadioButton 10, y_pos + 80, 100, 10, "No, do not update REVW", do_not_update_revw
-		  Text 20, y_pos + 30, 125, 10, "Interview Date: " & interview_date
-		  Text 35, y_pos + 40, 95, 10, "CAF Date: " & CAF_datestamp
-		  Text 20, y_pos + 55, 175, 20, "If the REVW Status has not been updated already, it will be changed to an 'I' when the dates are entered."
-		  Text 20, y_pos + 95, 220, 10, "Reason REVW should not be updated with the Interview/CAF Date:"
-		  EditBox 20, y_pos + 105, 220, 15, no_update_revw_reason
-		  y_pos = 170
-	  End If
-	  If update_prog = True Then
-		  GroupBox 5, y_pos, 240, 105, "STAT/PROG Needs to be Updated"
-		  OptionGroup RadioGroupPROG
-		    RadioButton 10, y_pos + 15, 200, 10, "YES! Update PROG with the Interview Date " & interview_date, confirm_update_prog
-		    RadioButton 10, y_pos + 60, 90, 10, "No, do not update PROG", do_not_update_prog
-		  CheckBox 25, y_pos + 25, 40, 10, "CASH 1", prog_update_cash_1_checkbox
-		  CheckBox 25, y_pos + 35, 40, 10, "CASH 2", prog_update_cash_2_checkbox
-		  CheckBox 25, y_pos + 45, 30, 10, "EMER", prog_update_emer_checkbox
-		  CheckBox 85, y_pos + 25, 30, 10, "GRH", prog_update_grh_checkbox
-		  CheckBox 85, y_pos + 35, 30, 10, "SNAP", prog_update_snap_checkbox
-		  Text 20, y_pos + 75, 200, 10, "Reason PROG should not be updated with the Interview Date:"
-		  EditBox 20, y_pos + 85, 220, 15, no_update_prog_reason
-	  End If
-	  ButtonGroup ButtonPressed
-	    OkButton 195, dlg_len - 20, 50, 15
-	EndDialog
-
-	'Running the dialog
-	Do
-		Do
-			err_msg = ""
-			Dialog Dialog1
-			If update_revw = True Then
-				'Requiring a reason for not updating PROG and making sure if confirm is updated that a program is selected.
-				If do_not_update_revw = 1 AND no_update_revw_reason = "" Then err_msg = err_msg & vbNewLine & "* If REVW is not to be updated, please explain why REVW should not be updated."
-			End If
-
-			If update_prog = True Then
-				'Requiring a reason for not updating PROG and making sure if confirm is updated that a program is selected.
-				If do_not_update_prog = 1 AND no_update_prog_reason = "" Then err_msg = err_msg & vbNewLine & "* If PROG is not to be updated, please explain why PROG should not be updated."
-				IF confirm_update_prog = 1 Then
-					If prog_update_cash_1_checkbox = unchecked AND prog_update_cash_2_checkbox = unchecked AND prog_update_emer_checkbox = unchecked AND prog_update_grh_checkbox = unchecked AND prog_update_snap_checkbox = unchecked Then err_msg = err_msg & vbNewLine & "* Select which program to be updated on PROG."
-				End If
-			End If
-
-			If err_msg <> "" Then MsgBox "Please resolve to continue:" & vbNewLine & err_msg
-		Loop until err_msg = ""
-		Call check_for_password(are_we_passworded_out)
-	Loop until are_we_passworded_out = FALSE
-
+If update_prog = True Then
 	intv_mo = DatePart("m", interview_date)     'Setting the date parts to individual variables for ease of writing
 	intv_day = DatePart("d", interview_date)
 	intv_yr = DatePart("yyyy", interview_date)
@@ -11177,32 +11079,10 @@ If update_revw = True OR update_prog = True Then
 	intv_yr = right(intv_yr, 2)
 	intv_date_to_check = intv_mo & " " & intv_day & " " & intv_yr
 
-	If confirm_update_prog = 1 Then     'If the dialog selects to have PROG updated
-		CALL back_to_SELF               'Need to do this because we need to go to the footer month of the application and we may be in a different month
+	CALL back_to_SELF               'Need to do this because we need to go to the footer month of the application and we may be in a different month
 
 		CALL navigate_to_MAXIS_screen ("STAT", "PROG")  'Now we can navigate to PROG in the application footer month and year
 		PF9                                             'Edit
-
-		If prog_update_cash_1_checkbox = checked Then
-			EMWriteScreen intv_mo, 6, 55               'CASH 1 Row
-			EMWriteScreen intv_day, 6, 58
-			EMWriteScreen intv_yr, 6, 61
-		End If
-		If prog_update_cash_2_checkbox = checked Then
-			EMWriteScreen intv_mo, 7, 55               'CASh 2 Row
-			EMWriteScreen intv_day, 7, 58
-			EMWriteScreen intv_yr, 7, 61
-		End If
-		If prog_update_emer_checkbox = checked Then
-			EMWriteScreen intv_mo, 8, 55               'EMER Row
-			EMWriteScreen intv_day, 8, 58
-			EMWriteScreen intv_yr, 8, 61
-		End If
-		If prog_update_grh_checkbox = checked Then
-			EMWriteScreen intv_mo, 9, 55               'GRH Row
-			EMWriteScreen intv_day, 9, 58
-			EMWriteScreen intv_yr, 9, 61
-		End If
 		If prog_update_snap_checkbox = checked Then
 			EMWriteScreen intv_mo, 10, 55               'SNAP Row
 			EMWriteScreen intv_day, 10, 58
@@ -11214,133 +11094,6 @@ If update_revw = True OR update_prog = True Then
 		Call HCRE_panel_bypass
 		Call back_to_SELF
 		Call MAXIS_background_check
-	End If
-
-	IF confirm_update_revw = 1 Then
-		original_MAXIS_month = MAXIS_footer_month
-		original_MAXIS_year = MAXIS_footer_year
-		cash_revw_intv_date_updated = FALSE
-		snap_revw_intv_date_updated = FALSE
-		If the_process_for_cash = "Renewal" AND the_process_for_snap = "Renewal" AND next_cash_revw_mo = next_snap_revw_mo AND next_cash_revw_yr = next_snap_revw_yr Then
-			Call back_to_SELF
-			MAXIS_footer_month = next_cash_revw_mo
-			MAXIS_footer_year = next_cash_revw_yr
-
-			Call Navigate_to_MAXIS_screen("STAT", "REVW")
-			PF9
-			Call create_mainframe_friendly_date(CAF_datestamp, 13, 37, "YY")
-			Call create_mainframe_friendly_date(interview_date, 15, 37, "YY")
-
-			EMReadScreen cash_revw_status_code, 1, 7, 40
-			EMReadScreen snap_revw_status_code, 1, 7, 60
-			If cash_revw_status_code = "N" Then EMWriteScreen "I", 7, 40
-			If snap_revw_status_code = "N" Then EMWriteScreen "I", 7, 60
-
-			attempt_count = 1
-			Do
-				transmit
-				EMReadScreen actually_saved, 7, 24, 2
-				attempt_count = attempt_count + 1
-				If attempt_count = 20 Then
-					PF10
-					revw_panel_updated = FALSE
-					Exit Do
-				End If
-			Loop until actually_saved = "ENTER A"
-
-			Call back_to_SELF
-			Call Navigate_to_MAXIS_screen("STAT", "REVW")
-
-			EMReadScreen updated_intv_date, 8, 15, 37
-			If IsDate(updated_intv_date) = TRUE Then
-				updated_intv_date = DateAdd("d", 0, updated_intv_date)
-				If updated_intv_date = interview_date Then
-					cash_revw_intv_date_updated = TRUE
-					snap_revw_intv_date_updated = True
-				End If
-			End If
-		Else
-			If the_process_for_cash = "Renewal" Then
-				Call back_to_SELF
-				MAXIS_footer_month = next_cash_revw_mo
-				MAXIS_footer_year = next_cash_revw_yr
-
-				Call Navigate_to_MAXIS_screen("STAT", "REVW")
-				PF9
-				Call create_mainframe_friendly_date(CAF_datestamp, 13, 37, "YY")
-				Call create_mainframe_friendly_date(interview_date, 15, 37, "YY")
-
-				EMReadScreen cash_revw_status_code, 1, 7, 40
-				If cash_revw_status_code = "N" Then EMWriteScreen "I", 7, 40
-
-				attempt_count = 1
-				Do
-					transmit
-					EMReadScreen actually_saved, 7, 24, 2
-					attempt_count = attempt_count + 1
-					If attempt_count = 20 Then
-						PF10
-						revw_panel_updated = FALSE
-						Exit Do
-					End If
-				Loop until actually_saved = "ENTER A"
-
-
-				Call back_to_SELF
-				Call Navigate_to_MAXIS_screen("STAT", "REVW")
-
-				EMReadScreen updated_intv_date, 8, 15, 37
-				If IsDate(updated_intv_date) = TRUE Then
-					updated_intv_date = DateAdd("d", 0, updated_intv_date)
-					If updated_intv_date = interview_date Then cash_revw_intv_date_updated = TRUE
-				End If
-			End If
-			If the_process_for_snap = "Renewal" Then
-				Call back_to_SELF
-				MAXIS_footer_month = next_snap_revw_mo
-				MAXIS_footer_year = next_snap_revw_yr
-
-				Call Navigate_to_MAXIS_screen("STAT", "REVW")
-				PF9
-				Call create_mainframe_friendly_date(CAF_datestamp, 13, 37, "YY")
-				Call create_mainframe_friendly_date(interview_date, 15, 37, "YY")
-
-				EMReadScreen cash_revw_status_code, 1, 7, 40
-				EMReadScreen snap_revw_status_code, 1, 7, 60
-				If cash_revw_status_code = "N" Then EMWriteScreen "I", 7, 40
-				If snap_revw_status_code = "N" Then EMWriteScreen "I", 7, 60
-
-				attempt_count = 1
-				Do
-					transmit
-					EMReadScreen actually_saved, 7, 24, 2
-					attempt_count = attempt_count + 1
-					If attempt_count = 20 Then
-						PF10
-						revw_panel_updated = FALSE
-						Exit Do
-					End If
-				Loop until actually_saved = "ENTER A"
-
-				Call back_to_SELF
-				Call Navigate_to_MAXIS_screen("STAT", "REVW")
-
-				EMReadScreen updated_intv_date, 8, 15, 37
-				If IsDate(updated_intv_date) = TRUE Then
-					updated_intv_date = DateAdd("d", 0, updated_intv_date)
-					If updated_intv_date = interview_date Then snap_revw_intv_date_updated = TRUE
-				End If
-			End If
-		End If
-
-		MAXIS_footer_month = original_footer_month
-		MAXIS_footer_year = original_footer_year
-
-		fail_msg = ""
-		If cash_revw_intv_date_updated = FALSE AND the_process_for_cash = "Renewal" Then fail_msg = fail_msg & vbCr & vbCr & "Interview and App date on REVW for CASH in " & next_cash_revw_mo & "/" & next_cash_revw_yr
-		If snap_revw_intv_date_updated = FALSE AND the_process_for_snap = "Renewal" Then fail_msg = fail_msg & vbCr & vbCr & "Interview and App date on REVW for SNAP in " & next_snap_revw_mo & "/" & next_snap_revw_yr
-		If fail_msg <> "" Then MsgBox "You have requested the script update REVW with the interview date." & vbCr & vbCr & "The script was unable to update REVW completely." & vbCr & vbCr & "FAILED:" & fail_msg & vbCr & vbCr & "The REVW panel will need to be updated manually with the interview information."
-	End If
 End If
 
 interview_time = ((timer - start_time) + add_to_time)/60


### PR DESCRIPTION
Added functionality to Client Contact to review for the 'Info Needed' CASE/NTOE created by SNAP Waived Interview to alert the worker to the questions that info needed has listed. This will allow Client Contact to redirect to SNAP Waived Interview to specifically support the Return Contact information needed. 

Pull request is scheduled to be merged on Tuesday mid day after the HT is released. 

Only additional update will be to CLOS with the HT date in the script array. Will wait until Tuesday to do this, and do it on this pull but if there is a merge issue, we can create a new pull for that specifically. 