### PR TITLE
#1770 Expedited Determination Report - Restrict to BZST and Update Interface

### DIFF
--- a/admin/expedited-determination-report.vbs
+++ b/admin/expedited-determination-report.vbs
@@ -135,6 +135,15 @@ const exch_app_exp_status_col 				= 37
 
 
 'END DECLARATIONS BLOCK ====================================================================================================
+allow_bulk_run_use = False												'At this time the BULK runs can only be completed by AIT due to database access.
+' If user_ID_for_validation = "CALO001" Then allow_bulk_run_use = True
+If user_ID_for_validation = "ILFE001" Then allow_bulk_run_use = True
+If user_ID_for_validation = "MARI001" Then allow_bulk_run_use = True
+If user_ID_for_validation = "MEGE001" Then allow_bulk_run_use = True
+If user_ID_for_validation = "DACO003" Then allow_bulk_run_use = True
+
+'stopping the script run if someone else tries to run the script for the bulk options.
+If allow_bulk_run_use = False Then script_end_procedure("Expedited Determination Report is locked to use by the Automation and Integration Team. The script will now end.")
 
 EMConnect ""
 MAXIS_footer_month = CM_mo
@@ -325,7 +334,7 @@ const hss_email_const 	= 5
 const pm_name_const 	= 6
 const pm_email_const 	= 7
 
-	If run_spotchecks_list = True Then
+If run_spotchecks_list = True Then
 
 	'This is where we get the information about HSRs and HSSs - we need to determine the data source and update this functionality once received - currently it is using a sheet in the HSS report out Excel File
 	Dim WORKER_ARRAY()

--- a/admin/expedited-determination-report.vbs
+++ b/admin/expedited-determination-report.vbs
@@ -639,6 +639,8 @@ If leave_excel_open = "No - Close the file" Then
 	objExcel.Quit
 End If
 
+If total_excel_row > 10001 Then Call create_outlook_email("", "HSPH.EWS.BlueZoneScripts@hennepin.us", "", "", "Expedited Determination Report Out is over 10,000", 1, False, "", "", False, "", "To maintain speed of operation, move the first 10,000 lines to the correct application date list and the archive files.", False, "", True)
+
 If run_spotchecks_list = True Then
 	'This will send an email if HSR information is missing in the data
 	If missing_HSRs <> "" Then
@@ -657,7 +659,7 @@ If run_time_limit_sec <> "" Then
 	If run_time - run_time_start > run_time_limit_sec Then
 		min_running = Int((timer-run_time_start)/60)
 		timer_reached_msg = "Expedited Determination Report has ended since it has been running for " & min_running & " minutes." &vbCr & vbCr & "A timer was set to limit the script run to " & run_time_limit_min & " minutes." & vbcr & vbCr & "It is likely there are still Expedited Determination Case Items to be recorded. Additionally, file clean up was not completed."
-		call script_end_procedure("Expedited ")
+		call script_end_procedure(timer_reached_msg)
 	End If
 End If
 

--- a/admin/expedited-determination-report.vbs
+++ b/admin/expedited-determination-report.vbs
@@ -136,7 +136,7 @@ const exch_app_exp_status_col 				= 37
 
 'END DECLARATIONS BLOCK ====================================================================================================
 allow_bulk_run_use = False												'At this time the BULK runs can only be completed by AIT due to database access.
-' If user_ID_for_validation = "CALO001" Then allow_bulk_run_use = True
+If user_ID_for_validation = "CALO001" Then allow_bulk_run_use = True
 If user_ID_for_validation = "ILFE001" Then allow_bulk_run_use = True
 If user_ID_for_validation = "MARI001" Then allow_bulk_run_use = True
 If user_ID_for_validation = "MEGE001" Then allow_bulk_run_use = True


### PR DESCRIPTION
The Expedited Determination Report has previously used and supported by OS staff but this process ended in Jan. There was significant clean up of the data and Excel files needed. 

I have updated the script to ensure only BZST can run it and also allows the script to limit the run time. 

Currently the output to the Expedited Spot Checks is turned off until additional details can be reviewed.