### PR TITLE
1663 Reported issues with accessing the mhc and deu menu

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -3586,7 +3586,7 @@ script_array(script_num).policy_references		= array("")						'SEE Line 58 for fo
 script_num = script_num + 1						'Increment by one
 ReDim Preserve script_array(script_num)			'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie	'Set this array element to be a new script_bowie. Script details below...
-script_array(script_num).script_name 			= "REPT-IEVC List"																		'Script name
+script_array(script_num).script_name 			= "IEVC List"																		'Script name
 script_array(script_num).category               = "DEU"
 script_array(script_num).workflows              = ""
 script_array(script_num).tags                   = array("SNAP", "MFIP", "DWP", "HS/GRH", "Adult Cash", "EMER", "Health Care")
@@ -3615,7 +3615,7 @@ script_array(script_num).policy_references		= array("")						'SEE Line 58 for fo
 script_num = script_num + 1						'Increment by one
 ReDim Preserve script_array(script_num)			'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie	'Set this array element to be a new script_bowie. Script details below...
-script_array(script_num).script_name 			= "REPT-INTR List"																		'Script name
+script_array(script_num).script_name 			= "INTR List"																		'Script name
 script_array(script_num).category               = "DEU"
 script_array(script_num).workflows              = ""
 script_array(script_num).tags                   = array("SNAP", "MFIP", "DWP", "HS/GRH", "Adult Cash", "EMER", "Health Care")

--- a/deu/deu-main-menu.vbs
+++ b/deu/deu-main-menu.vbs
@@ -125,6 +125,7 @@ End function
 '	to force the value of ButtonPressed to hold in near infinite iterations.
 button_placeholder 			    = 24601
 dlg_len = ""
+Dialog1 = ""
 
 'Displays the dialog
 Do
@@ -156,6 +157,7 @@ Do
 	Next
 
     ' MsgBox script_to_run
+	Dialog1 = ""
 Loop until ready_to_exit_loop = true
 
 call run_from_GitHub(script_to_run)

--- a/deu/deu-main-menu.vbs
+++ b/deu/deu-main-menu.vbs
@@ -100,7 +100,7 @@ Function declare_main_menu_dialog(script_category)
 
 				'Displays the button and text description-----------------------------------------------------------------------------------------------------------------------------
 				'FUNCTION		HORIZ. ITEM POSITION	VERT. ITEM POSITION		ITEM WIDTH	ITEM HEIGHT		ITEM TEXT/LABEL										BUTTON VARIABLE
-				' PushButton 		5, 						vert_button_position, 	10, 		12, 			"?", 												SIR_button_placeholder
+				PushButton 		5, 						vert_button_position, 	10, 		12, 			"?", 												SIR_button_placeholder
 				PushButton 		18,						vert_button_position, 	120, 		12, 			script_array(current_script).script_name, 			button_placeholder
 				Text 			120 + 23, 				vert_button_position+1, 500, 		14, 			"--- " & script_array(current_script).description
 				'----------

--- a/deu/deu-main-menu.vbs
+++ b/deu/deu-main-menu.vbs
@@ -40,6 +40,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("04/22/2024", "Activated links to SharePoint script instructions.", "Mark Riegel, Hennepin County")
 call changelog_update("03/27/2024", "Retired script ATR Received. Please use NOTES - DOCUMENTS RECEIVED. Also retired PARIS MATCH CC CLAIM ENTERED script. Please use NOTES - OVERPAYMENT and DEU - PARIS MATCH CLEARED. PARIS MATCH CLEARED also updated to work from the DAIL as well.", "Ilse Ferris, Hennepin County")
 Call changelog_update("04/24/2023", "MENU format has been updated to align with the menu displays for the primary categories.", "Casey Love, Hennepin County")
 call changelog_update("02/28/2023", "Removed APPEALS button. This was a redirect to the NOTES - APPEALS script. Please use the APPEALS script from the NOTES Main Menu. Thank you!", "Ilse Ferris, Hennepin County")

--- a/managed-care/mc-main-menu.vbs
+++ b/managed-care/mc-main-menu.vbs
@@ -119,6 +119,7 @@ End function
 '	to force the value of ButtonPressed to hold in near infinite iterations.
 button_placeholder 			    = 24601
 dlg_len = ""
+Dialog1 = ""
 
 'Displays the dialog
 Do
@@ -150,6 +151,7 @@ Do
 	Next
 
     ' MsgBox script_to_run
+	Dialog1 = ""
 Loop until ready_to_exit_loop = true
 
 call run_from_GitHub(script_to_run)


### PR DESCRIPTION
Reset dialog1 outside of declare_main_menu_dialog function call which may help to reduce dialog errors that pop up with Managed Care and DEU main menu scripts. Activated the links to script instructions for DEU scripts and updated SharePoint links to fix broken links.