### PR TITLE
#1776 Changes to ex-parte Y/N field on stat/revw and HCMI

### DIFF
--- a/admin/training-case-creator.vbs
+++ b/admin/training-case-creator.vbs
@@ -2253,12 +2253,12 @@ function write_panel_to_MAXIS_TYPE_PROG_REVW(appl_date, type_cash_yn, type_hc_yn
 					EMReadScreen health_care_renewals, 20, 4, 32
 				LOOP UNTIL health_care_renewals = "HEALTH CARE RENEWALS"
 				IF revw_ar_or_ir = "AR" THEN
-					call create_MAXIS_friendly_date((dateadd("M", 6, appl_date)), 0, 7, 71)
+					call create_MAXIS_friendly_date((dateadd("M", 6, appl_date)), 0, 8, 71)
 				ELSEIF revw_ar_or_ir = "IR" THEN
-					call create_MAXIS_friendly_date((dateadd("M", 6, appl_date)), 0, 7, 27)
+					call create_MAXIS_friendly_date((dateadd("M", 6, appl_date)), 0, 8, 27)
 				END IF
-				call create_MAXIS_friendly_date((dateadd("M", 12, appl_date)), 0, 8, 27)
-				EMWriteScreen revw_exempt, 8, 71
+				call create_MAXIS_friendly_date((dateadd("M", 12, appl_date)), 0, 9, 27)
+				EMWriteScreen revw_exempt, 9, 71
 				transmit
 			END IF
 	END IF
@@ -3162,18 +3162,18 @@ For each MAXIS_case_number in case_number_array
 		EMWriteScreen "x", 5, 71
 		transmit
 		If REVW_ar_or_ir = "IR" then
-			EMWriteScreen six_month_month, 7, 27
-			EMWriteScreen six_month_year, 7, 33
+			EMWriteScreen six_month_month, 8, 27
+			EMWriteScreen six_month_year, 8, 33
 		ElseIf REVW_ar_or_ir = "AR" then
-			EMWriteScreen six_month_month, 7, 71
-			EMWriteScreen six_month_year, 7, 77
+			EMWriteScreen six_month_month, 8, 71
+			EMWriteScreen six_month_year, 8, 77
 		ElseIf REVW_ar_or_ir = "ER Only" then
-			EMWriteScreen one_year_month, 7, 27
-			EMWriteScreen one_year_year, 7, 33
+			EMWriteScreen one_year_month, 8, 71
+			EMWriteScreen one_year_year, 8, 77
 		End if
-		EMWriteScreen one_year_month, 8, 27
-		EMWriteScreen one_year_year, 8, 33
-		EMWriteScreen REVW_exempt, 8, 71
+		EMWriteScreen one_year_month, 9, 27
+		EMWriteScreen one_year_year, 9, 33
+		EMWriteScreen REVW_exempt, 9, 71
 		transmit
 		transmit
 	End if

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -221,6 +221,9 @@ end function
 
 Function check_hcmi(hcmi_status, ex_parte_member, check_ex_parte_renewal_month_year)
 	'This function reads through the HCMI panels and returns whether any members are coded Ex Parte
+	'HCMI_status - returns an error message if no HCMI panels exist.
+	'ex_parte_member = boolean that stores whether ANY members are set to ex-parte "Y". False if no member has a "Y" coded on HCMI
+	'check_ex_parte_renewal_month_year - will return the ex_parte renewal month from the last HCMI panel that was marked "Y" for ex parte
 	check_ex_parte_renewal_month_year = "" 
 	Call navigate_to_MAXIS_screen("STAT", "HCMI")
 	EMReadScreen total_panels, 1, 2, 78
@@ -5337,10 +5340,13 @@ If HC_form_name = "No Form - Ex Parte Determination" Then
 						check_income_asset_renewal_date = DateAdd("d", 0, check_income_asset_renewal_date)
 						elig_renewal_date = DateAdd("d", 0, elig_renewal_date)
 						' income_asset_renewal_date = DateAdd("d", 0, income_asset_renewal_date)
-												'Now run through HCMI and check coding
+						'Now run through HCMI and check coding
+						hcmi_status = ""
 						Call check_hcmi(hcmi_status, ex_parte_member, check_ex_parte_renewal_month_year)
 						'Validate that at least one member is set as ex parte "Y"
 						If ex_parte_member = True THEN err_msg = err_msg & vbCr & "* HCMI is coded as ExParte 'Y' for at least 1 member. No members should be coded 'Y' for a case that is not ExParte."
+											
+						If hcmi_status <> "" Then err_msg = err_msg & vbCr & hcmi_status 'This error lets the worker know they don't have any HCMI panels
 						'Validation to ensure that elig renewal date has not changed
 						If check_elig_renewal_date <> elig_renewal_date THEN err_msg = err_msg & vbCr & "* The Elig Renewal Date should not have been changed. It should remain " & elig_renewal_date & "."
 
@@ -5593,10 +5599,10 @@ If HC_form_name = "No Form - Ex Parte Determination" Then
 						If sr_month <> updated_hc_renewal_month Then revw_panel_err = revw_panel_err & vbCr & "* The month for the IR/AR is incorrect, the panel has " & sr_month & " listed as the month."
 						If sr_year <> updated_hc_renewal_year Then revw_panel_err = revw_panel_err & vbCr & "* The month for the IR/AR is incorrect, the panel has " & sr_year & " listed as the month."
 					End If
-					'TODO - Future update needed - removing ex-parte error handling for now, future update needed to read HCMI panel
-					'
-					'Call check_hcmi(hcmi_status, ex_parte_member, check_ex_parte_renewal_month_year) 'this checks coding on HCMI panel(s)
-					'If HC_ex_parte_determination = "Y" Then revw_panel_err = revw_panel_err & vbCr & "* Update the Ex Parte yes/no indicator to 'N', since you are recording that you cannot process as Ex Parte."
+					'TODO - Future update needed - better handling of HCMI panel to check members and dates
+					hcmi_status = ""
+					Call check_hcmi(hcmi_status, ex_parte_member, check_ex_parte_renewal_month_year) 'this checks coding on HCMI panel(s)
+					If hcmi_status <> "" Then revw_panel_err = revw_panel_err & vbCr & hcmi_status 'This error lets the worker know they don't have any HCMI panels
 
 					'If REVW_ex_parte_renewal_month <> ex_parte_renewal_month or REVW_ex_parte_renewal_year <> ex_parte_renewal_year Then
 					'	revw_panel_err = revw_panel_err & vbCr & "* The Ex Parte Renewal month should be left coded with the month that was evaluated (" & ex_parte_renewal_month & "/" & ex_parte_renewal_year & ") for recording the Ex Parte work."

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -5191,7 +5191,7 @@ If HC_form_name = "No Form - Ex Parte Determination" Then
 				Text 25, 45, 290, 20, "- For cases with a spenddown that do not meet an exception listed in EPM 2.3.4.2 MA-ABD Renewals, enter a date six months from the date updated in ELIG Renewal Date"
 				Text 25, 65, 275, 10, "- For all other cases, enter the same date entered in the Elig Renewal Date"
 				Text 10, 80, 145, 10, "- Exempt from 6 Mo IR: Enter N"
-				Text 10, 100, 145, 10, "Update the following on STAT/HCMI for each member renewing HC:"
+				Text 10, 100, 225, 10, "Update the following on STAT/HCMI for each member renewing HC:"
 				Text 10, 115, 255, 10, "- ExParte: Enter Y/N accordingly for each member"
 				Text 10, 130, 255, 10, "- ExParte Renewal Month: Enter month and year of the ex parte renewal month."
 				EndDialog

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -4920,7 +4920,7 @@ If HC_form_name = "No Form - Ex Parte Determination" Then
 			DropListBox 45, 290, 130, 45, ""+chr(9)+"Appears Ex Parte"+chr(9)+"Cannot be Processed as Ex Parte"+chr(9)+"Health Care has been Closed"+chr(9)+"Case Transfered Out of County", ex_parte_determination
 			Text 225, 280, 200, 10, "Identifying a case as NOT Ex Parte requires explanation."
 			Text 180, 295, 45, 10, "Explanation:"
-			ComboBox 225, 290, 315, 45, "Select or Enter Reason for NOT Ex Parte"+chr(9)+"No spenddown currently approved and Income indicates a spenddown may be required."+chr(9)+"Income cannot be verified without resident interaction."+chr(9)+"Not all household members on HC meed an ABD basis."+chr(9)+"Resident is not in compliance with SSA."+chr(9)+"Resident is not in compliance with OMB/PBEN.", ex_parte_denial_select
+			ComboBox 225, 290, 315, 45, "Select or Enter Reason for NOT Ex Parte"+chr(9)+"No spenddown currently approved and Income indicates a spenddown may be required."+chr(9)+"Income cannot be verified without resident interaction."+chr(9)+"Case has assets that cannot be verified without resident interaction."+chr(9)+ "Verified/reported assets are not reasonably compatible."+chr(9)+"Resident is not in compliance with SSA."+chr(9)+"Resident is not in compliance with OMB/PBEN.", ex_parte_denial_select
 			Text 20, 315, 80, 10, "Not Ex Parte Notes:"
 			EditBox 100, 310, 440, 15, ex_parte_denial_notes 'ex_parte_denial_explanation
 			Text 20, 345, 100, 10, "Notes about Mixed Household"

--- a/notes/health-care-evaluation.vbs
+++ b/notes/health-care-evaluation.vbs
@@ -237,7 +237,7 @@ Function check_hcmi(hcmi_status, ex_parte_member, check_ex_parte_renewal_month_y
 			transmit
 		Next
 	End If 
-'TO DO - probably just make this dang thing into an array
+'TO DO - will need to look at a person-based array in order to accurately assess HCMI.
 End Function 
 
 function display_errors(the_err_msg, execute_nav, show_err_msg_during_movement)
@@ -5279,15 +5279,16 @@ If HC_form_name = "No Form - Ex Parte Determination" Then
 
 				Dialog1 = ""
 
-				BeginDialog Dialog1, 0, 0, 331, 120, "Health Care Renewal Updates - Cannot be Processed as Ex Parte"
+				BeginDialog Dialog1, 0, 0, 331, 140, "Health Care Renewal Updates - Cannot be Processed as Ex Parte"
 				ButtonGroup ButtonPressed
-					PushButton 205, 100, 100, 15, "Verify HC Renewal Updates", hc_renewal_button
+					PushButton 205, 115, 100, 15, "Verify HC Renewal Updates", hc_renewal_button
 				Text 5, 5, 320, 10, "Update the following on the Health Care Renewals Screen and then click the button below to verify:"
 				Text 10, 20, 150, 10, "- Elig Renewal Date: Should not be changed"
 				Text 10, 35, 300, 10, "- Income/Asset Renewal Date: Should not be changed and should match Elig Renewal Date."
 				Text 10, 50, 145, 10, "- Exempt from 6 Mo IR: Enter N"
-				Text 10, 65, 145, 10, "- ExParte: Enter N"
-				Text 10, 80, 255, 10, "- ExParte Renewal Month: Enter month and year of the ex parte renewal month"
+				Text 10, 65, 300, 10, "Update the following on STAT/HCMI for each member on HC:"
+				Text 10, 80, 145, 10, "- ExParte: Enter N"
+				Text 10, 95, 255, 10, "- ExParte Renewal Month: Enter month and year of the ex parte renewal month"
 				EndDialog
 
 


### PR DESCRIPTION
Updates NOTES - HC evaluation to read the new locations on STAT/REVW HC popup and check STAT/HCMI for potential errors.

Updates wording in dialogs to guide HSRs with coding of review/HCMI.

Also fixes ADMIN - Training case creator to write into new field locations.

Changes drop-down options and noting for reasons a case will fail phase 1. This is a partial solution while full support of asset policy is created.