### PR TITLE
1782 sundowning snap waived interview process

### DIFF
--- a/notes/client-contact.vbs
+++ b/notes/client-contact.vbs
@@ -87,30 +87,42 @@ CALL MAXIS_case_number_finder(MAXIS_case_number)
 
 when_contact_was_made = date & ", " & time 'updates the "when contact was made" variable to show the current date & time]
 
-'Initial dialog for CLIENT CONTACT, gasp!
-Dialog1 = ""
-BeginDialog Dialog1, 0, 0, 176, 65, "Case Number Dialog"
-  ButtonGroup ButtonPressed
-    OkButton 75, 45, 45, 15
-    CancelButton 125, 45, 45, 15
-  EditBox 75, 5, 45, 15, MAXIS_case_number
-  EditBox 75, 25, 95, 15, worker_signature
-  Text 20, 10, 50, 10, "Case Number:"
-  Text 10, 30, 60, 10, "Worker Signature:"
-EndDialog
+'Temporary: SNAP Waived Interview - presetting certain values 
+'MsgBox "redirect_interview_boolean" & redirect_interview_boolean
+If redirect_interview_boolean = TRUE Then 
+    phone_interview_attempt_checkbox = checked
+    contact_type = "Phone call"
+    contact_direction = "to"
+    contact_reason = "Attempted phone interview- no answer"
+End If
+'Temporary: SNAP Waived Interview 
 
-'Runs the first dialog - which confirms the case number
-Do
-	Do
-		err_msg = ""
-		Dialog Dialog1
-		cancel_without_confirmation
-      	Call validate_MAXIS_case_number(err_msg, "*")
-        If trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Sign your case note."
-        IF err_msg <> "" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
-	Loop until err_msg = ""
-    CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
-Loop until are_we_passworded_out = false					'loops until user passwords back in
+If redirect_interview_boolean = FALSE then  'Temporary: SNAP Waived Interview - skipping initial dialog since we already have the case number
+    'Initial dialog for CLIENT CONTACT, gasp!
+    Dialog1 = ""
+    BeginDialog Dialog1, 0, 0, 176, 65, "Case Number Dialog"
+    ButtonGroup ButtonPressed
+        OkButton 75, 45, 45, 15
+        CancelButton 125, 45, 45, 15
+    EditBox 75, 5, 45, 15, MAXIS_case_number
+    EditBox 75, 25, 95, 15, worker_signature
+    Text 20, 10, 50, 10, "Case Number:"
+    Text 10, 30, 60, 10, "Worker Signature:"
+    EndDialog
+
+    'Runs the first dialog - which confirms the case number
+    Do
+        Do
+            err_msg = ""
+            Dialog Dialog1
+            cancel_without_confirmation
+            Call validate_MAXIS_case_number(err_msg, "*")
+            If trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Sign your case note."
+            IF err_msg <> "" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
+        Loop until err_msg = ""
+        CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+    Loop until are_we_passworded_out = false					'loops until user passwords back in
+End If
 
 Call check_for_MAXIS(False)
 Call navigate_to_MAXIS_screen_review_PRIV("STAT", "ADDR", is_this_priv)
@@ -297,6 +309,10 @@ If basket_number = "X127FB1" then suggested_population = "YET"
 If basket_number = "X127FA9" then suggested_population = "YET"
 
 '-------------------------------------------------------------------------------------------------DIALOG
+
+
+
+
 Dialog1 = "" 'Blanking out previous dialog detail
 Do
     Do

--- a/notes/snap-waived-interview.vbs
+++ b/notes/snap-waived-interview.vbs
@@ -5,8 +5,6 @@ STATS_counter = 1                     	'sets the stats counter at one
 STATS_manualtime = 0                	'manual run time in seconds
 STATS_denomination = "C"       		'C is for each CASE
 'END OF stats block=========================================================================================================
-run_locally = true
-script_repository = "C:\MAXIS-Scripts\"
 
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
@@ -57,8 +55,76 @@ changelog_display
 
 'DECLARATIONS ==============================================================================================================
 
-
-
+const ref_number					= 0
+const access_denied					= 1
+const full_name_const				= 2
+const last_name_const				= 3
+const first_name_const				= 4
+const mid_initial					= 5
+const other_names					= 6
+const age							= 7
+const date_of_birth					= 8
+const ssn							= 9
+const ssn_verif						= 10
+const birthdate_verif				= 11
+const gender						= 12
+const race							= 13
+const spoken_lang					= 14
+const written_lang					= 15
+const interpreter					= 16
+const alias_yn						= 17
+const ethnicity_yn					= 18
+const id_verif						= 19
+const rel_to_applcnt				= 20
+const cash_minor					= 21
+const snap_minor					= 22
+const marital_status				= 23
+const spouse_ref					= 24
+const spouse_name					= 25
+const last_grade_completed 			= 26
+const citizen						= 27
+const other_st_FS_end_date 			= 28
+const in_mn_12_mo					= 29
+const residence_verif				= 30
+const mn_entry_date					= 31
+const former_state					= 32
+const fs_pwe						= 33
+const button_one					= 34
+const button_two					= 35
+const imig_status 					= 36
+const clt_has_sponsor				= 37
+const client_verification			= 38
+const client_verification_details	= 39
+const client_notes					= 40
+const intend_to_reside_in_mn		= 41
+const race_a_checkbox				= 42
+const race_b_checkbox				= 43
+const race_n_checkbox				= 44
+const race_p_checkbox				= 45
+const race_w_checkbox				= 46
+const snap_req_checkbox				= 47
+const cash_req_checkbox				= 48
+const emer_req_checkbox				= 49
+const none_req_checkbox				= 50
+const ssn_no_space					= 51
+const edrs_msg						= 52
+const edrs_match					= 53
+const edrs_notes 					= 54
+const ignore_person                 = 55
+const pers_in_maxis                 = 56
+const memb_is_caregiver             = 57
+const cash_request_const            = 58
+const hours_per_week_const          = 59
+const exempt_from_ed_const          = 60
+const comply_with_ed_const          = 61
+const orientation_needed_const      = 62
+const orientation_done_const        = 63
+const orientation_exempt_const      = 64
+const exemption_reason_const        = 65
+const emps_exemption_code_const     = 66
+const choice_form_done_const        = 67
+const orientation_notes             = 68
+const last_const					= 69
 
 Dim HH_MEMB_ARRAY()
 ReDim HH_MEMB_ARRAY(last_const, 0)
@@ -1151,44 +1217,57 @@ function create_waiver_question_in_dialog(this_question, questions_Array, questi
 		EditBox 140, y_pos - 5, 250, 15, questions_array(question_count)(5)
 		y_pos = y_pos + 20
 	End If
-
-
-
 End Function
 
-function check_application_date()
+function temp_check_application_date()	'Temporary: SNAP Waived Interview - interception dialog to stop workers from using waived interview for cases that required an interview aka those received after 04/30/24
 Call access_ADDR_panel("READ", notes_on_address, resi_line_one, resi_line_two, resi_street_full, resi_city, resi_state, resi_zip, resi_county, addr_verif, addr_homeless, addr_reservation, addr_living_sit, reservation_name, mail_line_one, mail_line_two, mail_street_full, mail_city, mail_state, mail_zip, addr_eff_date, addr_future_date, phone_one, phone_two, phone_three, type_one, type_two, type_three, text_yn_one, text_yn_two, text_yn_three, addr_email, verif_received, original_information, update_attempted)
 
-redirect_constant_boolean = FALSE
-	If CAF_datestamp >= "11/22/2023" Then 
+redirect_interview_boolean = FALSE
+If DateDiff("d", "05/01/24", CAF_datestamp) => 0 Then 
+'MsgBox DateDiff("d", "05/01/24", CAF_datestamp)
+	Do 
 		Do 
-			Do 
-				BeginDialog Dialog1, 0, 0, 356, 105, "SNAP Waived Interview NOT Applicable - INTERVIEW REQUIRED"
-				ButtonGroup ButtonPressed
-					PushButton 245, 15, 100, 15, "SNAP Waived Interview Ends", snap_waived_interview_ends_btn
-					PushButton 5, 85, 140, 15, "Client reached- Run Interview Script", run_interview_btn
-					PushButton 150, 85, 140, 15, "Client NOT reached- Run Client Contact", run_client_contact_btn
-					CancelButton 295, 85, 50, 15
-					Text 45, 50, 80, 10, phone_one
-					Text 45, 60, 80, 10, phone_two
-					Text 45, 70, 80, 10, phone_three
-					Text 10, 5, 200, 25, "Interview is required for case: " & MAXIS_case_number & " with CAF Date:" & CAF_datestamp & " because application/recertification received after 04/30/24."
-					Text 255, 5, 75, 10, "-------RESOURCES-------"
-					Text 15, 40, 150, 10, "-------ATTEMPT TO CONTACT RESIDENT-------"
-				EndDialog
-				Dialog Dialog1
-				If ButtonPressed = run_interview_btn then 
-					redirect_constant_boolean = true 
-					Call run_from_GitHub(script_repository & "notes/interview.vbs")
+			BeginDialog Dialog1, 0, 0, 356, 105, "SNAP Waived Interview NOT Applicable - INTERVIEW REQUIRED"
+			ButtonGroup ButtonPressed
+				PushButton 240, 15, 105, 15, "SNAP Waived Interview Ends", snap_waived_interview_ends_btn
+				PushButton 5, 85, 125, 15, "Client reached- Run Interview Script", run_interview_btn
+				PushButton 140, 85, 155, 15, "Client NOT reached- Redirect to Client Contact", run_client_contact_btn
+				CancelButton 300, 85, 50, 15
+				y_pos = 50
+				If phone_one <> "" Then 
+					Text 45, y_pos, 80, 10, phone_one
+					y_pos = y_pos + 10
 				End If
-				If ButtonPressed = run_client_contact_btn then Call run_from_GitHub(script_repository & "notes/client-contact.vbs")	
-				If ButtonPressed = snap_waived_interview_ends_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/SitePages/Processing-SNAP-Applications-with-Waived-Interviews.aspx"
-			Loop until ButtonPressed = -1 
-			CALL check_for_password(are_we_passworded_out) 'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
-		Loop until are_we_passworded_out = false					 'loops until user passwords back in
-	End if
+				If phone_two <> "" Then 
+					Text 45, y_pos, 80, 10, phone_two
+					y_pos = y_pos + 10
+				End If
+				If phone_three <> "" Then Text 45, y_pos, 80, 10, phone_three
+				Text 10, 5, 200, 25, "Interview is required for case " & MAXIS_case_number & " with CAF Date " & CAF_datestamp & " because application/recertification received after 04/30/24."
+				Text 255, 5, 75, 10, "-------RESOURCES-------"
+				Text 15, 40, 150, 10, "-------ATTEMPT TO CONTACT RESIDENT-------"
+			EndDialog
+			Dialog Dialog1
+			cancel_without_confirmation
+			If ButtonPressed = run_interview_btn then 
+				redirect_interview_boolean = true 
+				'MsgBox "redirect_interview_boolean" & redirect_interview_boolean
+				Call script_end_procedure_with_error_report("           ~~SNAP Waived Interview Script Ending~~" & vbcr & vbcr &  "-------------------------------------------------------------------------" & vbcr & "RUN NOTES-INTERVIEW TO CAPTURE INTERVIEW DETAILS" & vbcr &  "-------------------------------------------------------------------------")
+				'Call run_from_GitHub(script_repository & "notes/interview.vbs")	'TODO: get interview to redirect 
+			End If
+			If ButtonPressed = run_client_contact_btn then 
+				redirect_interview_boolean = TRUE
+				MsgBox "REDIRECTING TO - CLIENT CONTACT"
+				'MsgBox "redirect_interview_boolean" & redirect_interview_boolean
+				Call run_from_GitHub(script_repository & "notes/client-contact.vbs")
+			End If
+			If ButtonPressed = snap_waived_interview_ends_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-economic-supports-hub/SitePages/Processing-SNAP-Applications-with-Waived-Interviews.aspx"		'TODO: Need to update with correct link once we have it
+		Loop until ButtonPressed = -1 
+		CALL check_for_password(are_we_passworded_out) 'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+	Loop until are_we_passworded_out = false					 'loops until user passwords back in
+End if
 end function 
-
+dim redirect_interview_boolean
 
 function define_main_dialog(questions_array)
 
@@ -10701,7 +10780,7 @@ Do
 	Do
 		Do
 			Do
-				call check_application_date
+				call temp_check_application_date
 				call define_main_dialog(questions_array)
 
 				err_msg = ""
@@ -10743,79 +10822,6 @@ Do
 	Loop Until proceed_confirm = vbYes
 	Call check_for_password(are_we_passworded_out)
 Loop until are_we_passworded_out = FALSE
-
-If redirect_constant_boolean = false Then
-	const ref_number					= 0
-	const access_denied					= 1
-	const full_name_const				= 2
-	const last_name_const				= 3
-	const first_name_const				= 4
-	const mid_initial					= 5
-	const other_names					= 6
-	const age							= 7
-	const date_of_birth					= 8
-	const ssn							= 9
-	const ssn_verif						= 10
-	const birthdate_verif				= 11
-	const gender						= 12
-	const race							= 13
-	const spoken_lang					= 14
-	const written_lang					= 15
-	const interpreter					= 16
-	const alias_yn						= 17
-	const ethnicity_yn					= 18
-	const id_verif						= 19
-	const rel_to_applcnt				= 20
-	const cash_minor					= 21
-	const snap_minor					= 22
-	const marital_status				= 23
-	const spouse_ref					= 24
-	const spouse_name					= 25
-	const last_grade_completed 			= 26
-	const citizen						= 27
-	const other_st_FS_end_date 			= 28
-	const in_mn_12_mo					= 29
-	const residence_verif				= 30
-	const mn_entry_date					= 31
-	const former_state					= 32
-	const fs_pwe						= 33
-	const button_one					= 34
-	const button_two					= 35
-	const imig_status 					= 36
-	const clt_has_sponsor				= 37
-	const client_verification			= 38
-	const client_verification_details	= 39
-	const client_notes					= 40
-	const intend_to_reside_in_mn		= 41
-	const race_a_checkbox				= 42
-	const race_b_checkbox				= 43
-	const race_n_checkbox				= 44
-	const race_p_checkbox				= 45
-	const race_w_checkbox				= 46
-	const snap_req_checkbox				= 47
-	const cash_req_checkbox				= 48
-	const emer_req_checkbox				= 49
-	const none_req_checkbox				= 50
-	const ssn_no_space					= 51
-	const edrs_msg						= 52
-	const edrs_match					= 53
-	const edrs_notes 					= 54
-	const ignore_person                 = 55
-	const pers_in_maxis                 = 56
-	const memb_is_caregiver             = 57
-	const cash_request_const            = 58
-	const hours_per_week_const          = 59
-	const exempt_from_ed_const          = 60
-	const comply_with_ed_const          = 61
-	const orientation_needed_const      = 62
-	const orientation_done_const        = 63
-	const orientation_exempt_const      = 64
-	const exemption_reason_const        = 65
-	const emps_exemption_code_const     = 66
-	const choice_form_done_const        = 67
-	const orientation_notes             = 68
-	const last_const					= 69
-End If
 
 call check_for_MAXIS(True)
 If relative_caregiver_yn = "Yes" Then absent_parent_yn = "Yes"


### PR DESCRIPTION
~~Not sure if we want to implement this based on FR's most recent email but wanted to have it ready. 

**Revised SNAP Waived Interview and Client Contact** 
- SNAP Waived Interview: Added dialog to intercept workers trying to process applications/recertifications received after 04/30/2024. Redirects to CC if they are unable to reach the resident. Script end procedures if they reach the resident so they can manually run NOTE-Interview
- CC: Added handling to autofill certain fields if redirected from SNAP Waived Interview 
