### PR TITLE
#1663 Change script file names and script name within script to align with CLOS

### DIFF
--- a/deu/ievc-list.vbs
+++ b/deu/ievc-list.vbs
@@ -1,5 +1,5 @@
 'Required for statistical purposes===============================================================================
-name_of_script = "BULK - REPT-IEVC LIST.vbs"
+name_of_script = "BULK - IEVC LIST.vbs"
 start_time = timer
 STATS_counter = 1                          'sets the stats counter at one
 STATS_manualtime = 300                               'manual run time, per line, in seconds

--- a/deu/intr-list.vbs
+++ b/deu/intr-list.vbs
@@ -1,5 +1,5 @@
 'Required for statistical purposes===============================================================================
-name_of_script = "BULK - REPT-INTR LIST.vbs"
+name_of_script = "BULK - INTR LIST.vbs"
 start_time = timer
 STATS_counter = 1                          'sets the stats counter at one
 STATS_manualtime = 35                               'manual run time, per line, in seconds


### PR DESCRIPTION
Updated CLOS with updated script names but did not change actual script file names. Did this to ensure that DEU main menu links to correct instructions for IEVC and INTR list scripts.