### PR TITLE
1796 notes disaster food replacement, update to reflect new poli/temp guidance

### DIFF
--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("05/07/2024", "Update to align with updated POLI/TEMP.", "Mark Riegel, Hennepin County") '#316
 CALL changelog_update("09/19/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("11/27/2019", "Initial version.", "MiKayla Handley, Hennepin County")
 
@@ -60,11 +61,11 @@ CALL MAXIS_case_number_finder(MAXIS_case_number)
 'Initial dialog to gather case details
 Dialog1 = ""
 BeginDialog Dialog1, 0, 0, 176, 65, "Case Number Dialog"
+  EditBox 75, 5, 45, 15, MAXIS_case_number
+  EditBox 75, 25, 95, 15, worker_signature
   ButtonGroup ButtonPressed
     OkButton 75, 45, 45, 15
     CancelButton 125, 45, 45, 15
-  EditBox 75, 5, 45, 15, MAXIS_case_number
-  EditBox 75, 25, 95, 15, worker_signature
   Text 20, 10, 50, 10, "Case Number:"
   Text 10, 30, 60, 10, "Worker Signature:"
 EndDialog
@@ -87,7 +88,7 @@ Call check_for_MAXIS(False)
 'Initial Dialog Box
 '-------------------------------------------------------------------------------------------------DIALOG
 Dialog1 = "" 'Blanking out previous dialog detail
-BeginDialog Dialog1, 0, 0, 336, 405, "Replacing Food Destroyed in a Disaster"
+BeginDialog Dialog1, 0, 0, 336, 410, "Replacing Food Destroyed in a Disaster"
   EditBox 55, 30, 35, 15, MAXIS_case_number
   DropListBox 150, 30, 120, 15, "Select One:"+chr(9)+"Initial report of loss of food"+chr(9)+"Update on replacement request"+chr(9)+"Decision on replacement request", process_step
   EditBox 110, 60, 45, 15, loss_date
@@ -96,25 +97,27 @@ BeginDialog Dialog1, 0, 0, 336, 405, "Replacing Food Destroyed in a Disaster"
   EditBox 110, 120, 210, 15, disaster_description
   EditBox 110, 140, 120, 15, how_verif
   EditBox 110, 160, 45, 15, loss_verification_date
-  EditBox 110, 180, 45, 15, dhs_1609_due_date
-  CheckBox 160, 185, 95, 10, "Create TIKL for DHS-1609", dhs_1609_tikl
-  EditBox 90, 220, 235, 15, verif_needed
-  DropListBox 90, 240, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
-  DropListBox 90, 255, 180, 15, "Select One:"+chr(9)+"N/A - Pending Complete DHS-1609"+chr(9)+"N/A - Pending Verification(s)"+chr(9)+"Request Approved"+chr(9)+"Request Denied", replacement_status
-  EditBox 90, 270, 235, 15, denial_reason
-  Text 10, 390, 60, 10, "Worker Signature: "
-  EditBox 135, 320, 45, 15, dhs1609_sig_date
-  EditBox 135, 340, 45, 15, dhs1609_rcvd_date
-  EditBox 135, 360, 45, 15, dhs1609_done_date
-  EditBox 75, 385, 165, 15, worker_signature
+  EditBox 90, 195, 235, 15, verif_needed
+  DropListBox 90, 215, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
+  DropListBox 90, 230, 180, 15, "Select One:"+chr(9)+"Pending Complete DHS-1609"+chr(9)+"Pending Verification(s)"+chr(9)+"Request Approved"+chr(9)+"Request Denied", replacement_status
+  EditBox 90, 245, 235, 15, denial_reason
+  CheckBox 10, 270, 135, 10, "Request was sent to TSS BENE Unit", TSS_BENE_sent_checkbox
   ButtonGroup ButtonPressed
-    OkButton 250, 385, 35, 15
-    CancelButton 290, 385, 35, 15
+    PushButton 145, 265, 180, 15, "TSS BENE Unit Webform", TSS_BENE_webform_btn
+  EditBox 135, 305, 45, 15, dhs_1609_due_date
+  CheckBox 190, 305, 95, 10, "Create TIKL for DHS-1609", dhs_1609_tikl
+  EditBox 135, 325, 45, 15, dhs1609_sig_date
+  EditBox 135, 345, 45, 15, dhs1609_rcvd_date
+  EditBox 135, 365, 45, 15, dhs1609_done_date
+  EditBox 75, 390, 165, 15, worker_signature
+  ButtonGroup ButtonPressed
+    OkButton 250, 390, 35, 15
+    CancelButton 290, 390, 35, 15
   Text 5, 5, 265, 10, "When a client reports food destroyed in a disaster and all requirements are met"
   Text 5, 15, 125, 10, "(see CM0024.06.03.15 or TE02.11.18)"
   Text 5, 35, 50, 10, "Case number:"
   Text 100, 35, 50, 10, "Process Step:"
-  GroupBox 5, 50, 325, 150, "Food Loss Details"
+  GroupBox 5, 50, 325, 130, "Food Loss Details"
   Text 10, 65, 45, 10, "Date of Loss:"
   Text 10, 85, 80, 10, "Amount of Food Loss ($): "
   Text 10, 105, 95, 10, "Date loss reported to county:"
@@ -122,17 +125,17 @@ BeginDialog Dialog1, 0, 0, 336, 405, "Replacing Food Destroyed in a Disaster"
   Text 10, 145, 90, 10, "How disaster was verified:"
   Text 240, 140, 80, 20, "(news report, social worker, Red Cross, etc.)"
   Text 10, 165, 65, 10, "Date Loss verified:"
-  Text 10, 185, 80, 10, "Due Date for DHS-1609:"
-  GroupBox 5, 210, 325, 95, "Information for Replacement Request"
-  Text 10, 225, 70, 10, "Verifications Needed: "
-  Text 10, 240, 55, 10, "Replace as REI: "
-  Text 10, 255, 70, 10, "Decision on Request: "
-  Text 10, 275, 65, 10, "Reason for Denial: "
-  CheckBox 10, 290, 135, 10, "Request was sent to TSS BENE Unit", TSS_BENE_sent_checkbox
-  GroupBox 5, 310, 325, 70, "Nonreceipt/Replacement Affidavit (DHS-1609)"
-  Text 10, 325, 120, 10, "Date DHS-1609 signed by the client:"
-  Text 10, 345, 115, 10, "Date DHS-1609 received by county: "
-  Text 10, 365, 125, 10, "Date DHS-1609 completed by county: "
+  Text 10, 310, 95, 10, "Date DHS-1609 is due back:"
+  GroupBox 5, 185, 325, 100, "Information for Replacement Request"
+  Text 10, 200, 70, 10, "Verifications Needed: "
+  Text 10, 215, 55, 10, "Replace as REI: "
+  Text 10, 230, 70, 10, "Decision on Request: "
+  Text 10, 250, 65, 10, "Reason for Denial: "
+  GroupBox 5, 290, 325, 95, "Nonreceipt/Replacement Affidavit (DHS-1609)"
+  Text 10, 330, 120, 10, "Date DHS-1609 signed by the client:"
+  Text 10, 350, 115, 10, "Date DHS-1609 received by county: "
+  Text 10, 370, 125, 10, "Date DHS-1609 completed by county: "
+  Text 10, 395, 60, 10, "Worker Signature: "
 EndDialog
 
 'Info to the user of what this script currently covers
@@ -142,20 +145,24 @@ Do
     DIALOG dialog1
     Cancel_confirmation
     Call validate_MAXIS_case_number(err_msg, "*")
+    If ButtonPressed = TSS_BENE_webform_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://owa.dhssir.cty.dhs.state.mn.us/csedforms/MMR/TSSBENE_BENE_request.asp"
     IF process_step = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the step in the process you are providing an update on."
     IF rei_replacement = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select if the replacement was REI, or select NA."
     IF replacement_status = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the status of the replacement."
-    IF replacement_status = "N/A - Pending Verification(s)" and verif_needed = "" THEN err_msg = err_msg & vbCr & "* Please complete the pending verifications field."
+    IF replacement_status = "Pending Verification(s)" and verif_needed = "" THEN err_msg = err_msg & vbCr & "* Please complete the pending verifications field."
     If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reports the loss occurred."
     If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reported the loss of food to county."
     If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please enter the dollar amount the client reported."
-    If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please descrive the type of disaster. If it was a power outage, please specify what caused the power outage."
+    If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please describe the type of disaster. If it was a power outage, please specify what caused the power outage."
     If how_verif = "" Then err_msg = err_msg & vbCr & "* Please indicate how the disaster was verified - news reports, social worker, Red Cross, utility confirmation, etc."
-    IF replacement_status <> "N/A - Pending Complete DHS-1609" Then
-      If IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the date the county signed the form or enter N/A."
-      IF IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date county received the request or write N/A."
-      IF IsDate(dhs1609_sig_date) <> TRUE or dhs1609_sig_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client signed the form or write N/A."
+    IF replacement_status <> "Pending Complete DHS-1609" Then
+      If IsDate(dhs_1609_due_date) <> TRUE or dhs_1609_due_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the DHS-1609 is due back."
+      If IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the county signed the form."
+      IF IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the county received the request."
+      IF IsDate(dhs1609_sig_date) <> TRUE or dhs1609_sig_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client signed the form."
     End If
+    IF replacement_status = "Request Denied" and trim(denial_reason) = "" THEN err_msg = err_msg & vbCr & "* Please provide a reason for the denial."
+    IF replacement_status <> "Request Denied" and denial_reason <> "" THEN err_msg = err_msg & vbCr & "* The reason for the denial field should be blank if the request is not being denied."
     IF TSS_BENE_sent_checkbox = UNCHECKED and replacement_status = "Request Approved" THEN err_msg = err_msg & vbCr & "* Please check that the TSS BENE Webform has been completed."
     IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
     IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
@@ -163,21 +170,26 @@ Do
   CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 Loop until are_we_passworded_out = false					'loops until user passwords back in
 
+'Create TIKL if selected
+If dhs_1609_tikl = CHECKED Then Call create_TIKL("DHS-1609 was sent 10 days ago and is now due back.", 10, date, False, TIKL_note_text)
+
 'Write CASE/NOTE with information
 start_a_blank_case_note
 CALL write_variable_in_Case_Note("--Food Destroyed in a Disaster Reported - " & replacement_status & "--")
-CALL write_bullet_and_variable_in_Case_Note("Update on Request", process_step)
-CALL write_bullet_and_variable_in_Case_Note("Type of Disaster", disaster_description)
-CALL write_bullet_and_variable_in_Case_Note("How the disaster was verified", how_verif)
-CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)
+CALL write_bullet_and_variable_in_Case_Note("Current Process Step", process_step)
 CALL write_bullet_and_variable_in_Case_Note("Date of Loss", loss_date)
 CALL write_bullet_and_variable_in_Case_Note("Amount of Food Loss", amount_loss)
+CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)
+CALL write_bullet_and_variable_in_Case_Note("Description of Disaster", disaster_description)
+CALL write_bullet_and_variable_in_Case_Note("How the disaster was verified", how_verif)
+CALL write_bullet_and_variable_in_Case_Note("Date Loss Verified", loss_verification_date)
 CALL write_bullet_and_variable_in_Case_Note("Replace as REI", rei_replacement)
 IF TSS_BENE_sent_checkbox <> CHECKED THEN CALL write_bullet_and_variable_in_Case_Note("Status of Request", replacement_status)
-CALL write_bullet_and_variable_in_Case_Note("Reason for Denial", denial_reason)
-CALL write_bullet_and_variable_in_Case_Note("Verifcations Requested", verif_needed)
+IF replacement_status = "Request Denied" Then CALL write_bullet_and_variable_in_Case_Note("Reason for Denial", denial_reason)
+CALL write_bullet_and_variable_in_Case_Note("Verifications Requested", verif_needed)
 IF TSS_BENE_sent_checkbox = CHECKED THEN CALL write_variable_in_Case_Note("* Submitted a TSS BENE request (webform) through SIR")
 CALL write_variable_in_Case_Note("Nonreceipt/Replacement Affidavit (DHS-1609)")
+CALL write_variable_in_Case_Note(" Date DHS-1609 is due back from the client: " & dhs_1609_due_date)
 CALL write_variable_in_Case_Note(" Date DHS-1609 was signed by the client: " & dhs1609_sig_date)
 CALL write_variable_in_Case_Note(" Date DHS-1609 was received by the county: " & dhs1609_rcvd_date)
 CALL write_variable_in_Case_Note(" Date DHS-1609 was completed by the county: " & dhs1609_done_date)
@@ -185,4 +197,4 @@ CALL write_variable_in_Case_Note("----")
 CALL write_variable_in_Case_Note(worker_signature)
 PF3
 
-script_end_procedure_with_error_report("The case note has been created please be sure to send verifications to ECF and submit a TSS BENE request (webform) through SIR.")
+script_end_procedure_with_error_report("The case note has been created. If request has been approved, please be sure to send verifications to ECF and submit a TSS BENE request (webform) through SIR.")

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -87,44 +87,52 @@ Call check_for_MAXIS(False)
 'Initial Dialog Box
 '-------------------------------------------------------------------------------------------------DIALOG
 Dialog1 = "" 'Blanking out previous dialog detail
-BeginDialog Dialog1, 0, 0, 331, 265, "Replacing Food Destroyed in a Disaster"
-  EditBox 65, 25, 35, 15, MAXIS_case_number
-  EditBox 155, 25, 45, 15, loss_date
-  EditBox 280, 25, 45, 15, amount_loss
-  EditBox 65, 45, 135, 15, disaster_type
-  EditBox 110, 65, 60, 15, how_verif
-  EditBox 110, 85, 45, 15, report_date
-  DropListBox 80, 105, 120, 15, "Select One:"+chr(9)+"Pending Complete DHS-1609"+chr(9)+"Pending Verification(s)"+chr(9)+"Submitted Request to TSS BENE", replacement_status
-  DropListBox 275, 105, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
-  EditBox 80, 125, 245, 15, verif_needed
-  EditBox 80, 145, 245, 15, denial_reason
-  EditBox 135, 175, 45, 15, dhs1609_sig_date
-  EditBox 135, 195, 45, 15, dhs1609_rcvd_date
-  EditBox 135, 215, 45, 15, dhs1609_done_date
-  CheckBox 210, 175, 115, 10, "Request was sent to TSS BENE", TSS_BENE_sent_checkbox
-  EditBox 75, 240, 165, 15, worker_signature
+BeginDialog Dialog1, 0, 0, 336, 405, "Replacing Food Destroyed in a Disaster"
+  EditBox 55, 30, 35, 15, MAXIS_case_number
+  DropListBox 150, 30, 120, 15, "Select One:"+chr(9)+"Initial report of loss of food"+chr(9)+"Update on replacement request"+chr(9)+"Decision on replacement request", process_step
+  EditBox 110, 60, 45, 15, loss_date
+  EditBox 110, 80, 45, 15, amount_loss
+  EditBox 110, 100, 45, 15, report_date
+  EditBox 110, 120, 210, 15, disaster_description
+  EditBox 110, 140, 120, 15, how_verif
+  EditBox 110, 160, 45, 15, loss_verification_date
+  EditBox 110, 180, 45, 15, dhs_1609_due_date
+  CheckBox 160, 185, 95, 10, "Create TIKL for DHS-1609", dhs_1609_tikl
+  EditBox 90, 220, 235, 15, verif_needed
+  DropListBox 90, 240, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
+  DropListBox 90, 255, 180, 15, "Select One:"+chr(9)+"N/A - Pending Complete DHS-1609"+chr(9)+"N/A - Pending Verification(s)"+chr(9)+"Request Approved"+chr(9)+"Request Denied", replacement_status
+  EditBox 90, 270, 235, 15, denial_reason
+  Text 10, 390, 60, 10, "Worker Signature: "
+  EditBox 135, 320, 45, 15, dhs1609_sig_date
+  EditBox 135, 340, 45, 15, dhs1609_rcvd_date
+  EditBox 135, 360, 45, 15, dhs1609_done_date
+  EditBox 75, 385, 165, 15, worker_signature
   ButtonGroup ButtonPressed
-    OkButton 250, 240, 35, 15
-    CancelButton 290, 240, 35, 15
-  Text 105, 30, 45, 10, "Date of Loss:"
-  Text 205, 30, 75, 10, "Amount of Food Loss: "
-  Text 5, 50, 60, 10, "Type of Disaster:"
-  Text 205, 50, 115, 10, "(specify the cause of power outage)"
-  Text 175, 70, 150, 10, "(news reports, Social Worker, Red Cross etc.)"
-  Text 5, 110, 60, 10, "Approval Status: "
-  Text 10, 180, 120, 10, "Date DHS-1609 signed by the client:"
-  Text 10, 245, 60, 10, "Worker Signature: "
-  GroupBox 5, 165, 190, 70, "Nonreceipt/Replacement Affidavit (DHS-1609)"
-  Text 215, 110, 55, 10, "Replace as REI: "
-  Text 10, 200, 115, 10, "Date DHS-1609 received by county: "
-  Text 5, 150, 65, 10, "Reason for Denial: "
-  Text 5, 90, 100, 10, "Date client reported to county:"
-  Text 5, 130, 70, 10, "Verifications Needed: "
-  Text 5, 70, 105, 10, "How the disaster was verified:"
-  Text 5, 15, 125, 10, "(see CM0024.06.03.15 or TE02.11.18)"
+    OkButton 250, 385, 35, 15
+    CancelButton 290, 385, 35, 15
   Text 5, 5, 265, 10, "When a client reports food destroyed in a disaster and all requirements are met"
-  Text 5, 30, 50, 10, "Case number:"
-  Text 10, 220, 125, 10, "Date DHS-1609 completed by county: "
+  Text 5, 15, 125, 10, "(see CM0024.06.03.15 or TE02.11.18)"
+  Text 5, 35, 50, 10, "Case number:"
+  Text 100, 35, 50, 10, "Process Step:"
+  GroupBox 5, 50, 325, 150, "Food Loss Details"
+  Text 10, 65, 45, 10, "Date of Loss:"
+  Text 10, 85, 80, 10, "Amount of Food Loss ($): "
+  Text 10, 105, 95, 10, "Date loss reported to county:"
+  Text 10, 125, 75, 10, "Describe the disaster:"
+  Text 10, 145, 90, 10, "How disaster was verified:"
+  Text 240, 140, 80, 20, "(news report, social worker, Red Cross, etc.)"
+  Text 10, 165, 65, 10, "Date Loss verified:"
+  Text 10, 185, 80, 10, "Due Date for DHS-1609:"
+  GroupBox 5, 210, 325, 95, "Information for Replacement Request"
+  Text 10, 225, 70, 10, "Verifications Needed: "
+  Text 10, 240, 55, 10, "Replace as REI: "
+  Text 10, 255, 70, 10, "Decision on Request: "
+  Text 10, 275, 65, 10, "Reason for Denial: "
+  CheckBox 10, 290, 135, 10, "Request was sent to TSS BENE Unit", TSS_BENE_sent_checkbox
+  GroupBox 5, 310, 325, 70, "Nonreceipt/Replacement Affidavit (DHS-1609)"
+  Text 10, 325, 120, 10, "Date DHS-1609 signed by the client:"
+  Text 10, 345, 115, 10, "Date DHS-1609 received by county: "
+  Text 10, 365, 125, 10, "Date DHS-1609 completed by county: "
 EndDialog
 
 'Info to the user of what this script currently covers
@@ -140,7 +148,7 @@ Do
 		If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client reports the loss occured."
 		If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client reported the loss of food to county."
 		If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please complete the amount the client reported."
-		If disaster_type = "" Then err_msg = err_msg & vbCr & "* Please complete the type of disaster if power outage - specify what caused the power outage."
+		If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please complete the type of disaster if power outage - specify what caused the power outage."
 		If how_verif = "" Then err_msg = err_msg & vbCr & "* Please complete how the disaster was verified - news reports, Social Worker, RedCross, Excel confirmation etc."
 		IF replacement_status <> "Pending Complete DHS-1609" and IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the date the county signed the form or enter N/A."
 		IF replacement_status <> "Pending Complete DHS-1609" and IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date county received the request or write N/A."
@@ -156,7 +164,7 @@ Loop until are_we_passworded_out = false					'loops until user passwords back in
 start_a_blank_case_note
 'writes case note for Baby Born
 CALL write_variable_in_Case_Note("--Food Destroyed in a Disaster Reported - " & replacement_status & "--")
-CALL write_bullet_and_variable_in_Case_Note("Type of Disaster", disaster_type)
+CALL write_bullet_and_variable_in_Case_Note("Type of Disaster", disaster_description)
 CALL write_bullet_and_variable_in_Case_Note("How the disaster was verified", how_verif)
 CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)
 CALL write_bullet_and_variable_in_Case_Note("Date of Loss", loss_date)

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -163,9 +163,9 @@ Do
     IF IsDate(dhs1609_sig_date) <> TRUE and trim(dhs1609_sig_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the client signed the form."
     IF IsDate(dhs1609_rcvd_date) <> TRUE and trim(dhs1609_rcvd_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the county received the request."
     If IsDate(dhs1609_done_date) <> TRUE and trim(dhs1609_done_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the county signed the form."
-    IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
+    IF err_msg <> "" and ButtonPressed <> TSS_BENE_webform_btn THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
     IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
-  LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+  LOOP UNTIL err_msg = "" and ButtonPressed <> TSS_BENE_webform_btn									'loops until all errors are resolved
   CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 Loop until are_we_passworded_out = false					'loops until user passwords back in
 

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -137,40 +137,43 @@ EndDialog
 
 'Info to the user of what this script currently covers
 Do
-    Do
-	    err_msg = ""
-	    DIALOG dialog1
-	    Cancel_confirmation
-	    IF MAXIS_case_number = "" OR (MAXIS_case_number <> "" AND len(MAXIS_case_number) > 8) OR (MAXIS_case_number <> "" AND IsNumeric(MAXIS_case_number) = False) THEN err_msg = err_msg & vbCr & "* Please enter a valid case number."
-	    IF rei_replacement = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select if the replacement was REI."
-		IF replacement_status = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the status of the replacement."
-		IF replacement_status = "Pending Verification(s)" and verif_needed = "" THEN err_msg = err_msg & vbCr & "* Please complete the pending verifications field"
-		If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client reports the loss occured."
-		If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client reported the loss of food to county."
-		If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please complete the amount the client reported."
-		If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please complete the type of disaster if power outage - specify what caused the power outage."
-		If how_verif = "" Then err_msg = err_msg & vbCr & "* Please complete how the disaster was verified - news reports, Social Worker, RedCross, Excel confirmation etc."
-		IF replacement_status <> "Pending Complete DHS-1609" and IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the date the county signed the form or enter N/A."
-		IF replacement_status <> "Pending Complete DHS-1609" and IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date county received the request or write N/A."
-		IF replacement_status <> "Pending Complete DHS-1609" and IsDate(dhs1609_sig_date) <> TRUE or dhs1609_sig_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client signed the form or write N/A."
-    	IF TSS_BENE_sent_checkbox = UNCHECKED and replacement_status = "Submitted Request to TSS BENE" THEN err_msg = err_msg & vbCr & "* Please check that the TSS BENE Webform has been completed."
-		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
-		IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
- 	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
-    CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+  Do
+    err_msg = ""
+    DIALOG dialog1
+    Cancel_confirmation
+    Call validate_MAXIS_case_number(err_msg, "*")
+    IF process_step = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the step in the process you are providing an update on."
+    IF rei_replacement = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select if the replacement was REI, or select NA."
+    IF replacement_status = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the status of the replacement."
+    IF replacement_status = "N/A - Pending Verification(s)" and verif_needed = "" THEN err_msg = err_msg & vbCr & "* Please complete the pending verifications field."
+    If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reports the loss occurred."
+    If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reported the loss of food to county."
+    If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please enter the dollar amount the client reported."
+    If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please descrive the type of disaster. If it was a power outage, please specify what caused the power outage."
+    If how_verif = "" Then err_msg = err_msg & vbCr & "* Please indicate how the disaster was verified - news reports, social worker, Red Cross, utility confirmation, etc."
+    IF replacement_status <> "N/A - Pending Complete DHS-1609" Then
+      If IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the date the county signed the form or enter N/A."
+      IF IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date county received the request or write N/A."
+      IF IsDate(dhs1609_sig_date) <> TRUE or dhs1609_sig_date = "" Then err_msg = err_msg & vbCr & "* Please complete the date the client signed the form or write N/A."
+    End If
+    IF TSS_BENE_sent_checkbox = UNCHECKED and replacement_status = "Request Approved" THEN err_msg = err_msg & vbCr & "* Please check that the TSS BENE Webform has been completed."
+    IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
+    IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+  LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+  CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 Loop until are_we_passworded_out = false					'loops until user passwords back in
 
-
+'Write CASE/NOTE with information
 start_a_blank_case_note
-'writes case note for Baby Born
 CALL write_variable_in_Case_Note("--Food Destroyed in a Disaster Reported - " & replacement_status & "--")
+CALL write_bullet_and_variable_in_Case_Note("Update on Request", process_step)
 CALL write_bullet_and_variable_in_Case_Note("Type of Disaster", disaster_description)
 CALL write_bullet_and_variable_in_Case_Note("How the disaster was verified", how_verif)
 CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)
 CALL write_bullet_and_variable_in_Case_Note("Date of Loss", loss_date)
 CALL write_bullet_and_variable_in_Case_Note("Amount of Food Loss", amount_loss)
 CALL write_bullet_and_variable_in_Case_Note("Replace as REI", rei_replacement)
-IF TSS_BENE_sent_checkbox <> CHECKED THEN CALL write_bullet_and_variable_in_Case_Note("Stauts of Request", replacement_status)
+IF TSS_BENE_sent_checkbox <> CHECKED THEN CALL write_bullet_and_variable_in_Case_Note("Status of Request", replacement_status)
 CALL write_bullet_and_variable_in_Case_Note("Reason for Denial", denial_reason)
 CALL write_bullet_and_variable_in_Case_Note("Verifcations Requested", verif_needed)
 IF TSS_BENE_sent_checkbox = CHECKED THEN CALL write_variable_in_Case_Note("* Submitted a TSS BENE request (webform) through SIR")

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -44,7 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-CALL changelog_update("05/07/2024", "Update to align with updated POLI/TEMP.", "Mark Riegel, Hennepin County") '#1796
+CALL changelog_update("05/07/2024", "Update to align with updated 02/2024 POLI/TEMP.", "Mark Riegel, Hennepin County") '#1796
 CALL changelog_update("09/19/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("11/27/2019", "Initial version.", "MiKayla Handley, Hennepin County")
 
@@ -90,18 +90,17 @@ Call check_for_MAXIS(False)
 'Dialog to gather details on the request
 Dialog1 = "" 'Blanking out previous dialog detail
 BeginDialog Dialog1, 0, 0, 336, 410, "Replacing Food Destroyed in a Disaster"
-  EditBox 55, 30, 35, 15, MAXIS_case_number
-  DropListBox 150, 30, 120, 15, "Select One:"+chr(9)+"Initial report of loss of food"+chr(9)+"Update on replacement request"+chr(9)+"Decision on replacement request", process_step
+  EditBox 65, 30, 35, 15, MAXIS_case_number
   EditBox 110, 60, 45, 15, loss_date
   EditBox 110, 80, 45, 15, amount_loss
   EditBox 110, 100, 45, 15, report_date
   EditBox 110, 120, 210, 15, disaster_description
   EditBox 110, 140, 120, 15, how_verif
   EditBox 110, 160, 45, 15, loss_verification_date
-  EditBox 90, 195, 235, 15, verif_needed
-  DropListBox 90, 215, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
-  DropListBox 90, 230, 180, 15, "Select One:"+chr(9)+"Pending Complete DHS-1609"+chr(9)+"Pending Verification(s)"+chr(9)+"Request Approved"+chr(9)+"Request Denied", replacement_status
-  EditBox 90, 245, 235, 15, denial_reason
+  DropListBox 90, 195, 180, 15, "Select One:"+chr(9)+"Pending Complete DHS-1609"+chr(9)+"Pending Verification(s)"+chr(9)+"Request Approved"+chr(9)+"Request Denied", replacement_status
+  DropListBox 90, 210, 50, 15, "Select One:"+chr(9)+"YES"+chr(9)+"NO"+chr(9)+"NA", rei_replacement
+  EditBox 90, 225, 235, 15, denial_reason
+  EditBox 90, 245, 235, 15, verif_needed
   CheckBox 10, 270, 135, 10, "Request was sent to TSS BENE Unit", TSS_BENE_sent_checkbox
   ButtonGroup ButtonPressed
     PushButton 145, 265, 180, 15, "TSS BENE Unit Webform", TSS_BENE_webform_btn
@@ -116,8 +115,7 @@ BeginDialog Dialog1, 0, 0, 336, 410, "Replacing Food Destroyed in a Disaster"
     CancelButton 290, 390, 35, 15
   Text 5, 5, 265, 10, "When a client reports food destroyed in a disaster and all requirements are met"
   Text 5, 15, 125, 10, "(see CM0024.06.03.15 or TE02.11.18)"
-  Text 5, 35, 50, 10, "Case number:"
-  Text 100, 35, 50, 10, "Process Step:"
+  Text 10, 35, 50, 10, "Case number:"
   GroupBox 5, 50, 325, 130, "Food Loss Details"
   Text 10, 65, 45, 10, "Date of Loss:"
   Text 10, 85, 80, 10, "Amount of Food Loss ($): "
@@ -128,10 +126,10 @@ BeginDialog Dialog1, 0, 0, 336, 410, "Replacing Food Destroyed in a Disaster"
   Text 10, 165, 65, 10, "Date Loss verified:"
   Text 10, 310, 95, 10, "Date DHS-1609 is due back:"
   GroupBox 5, 185, 325, 100, "Information for Replacement Request"
-  Text 10, 200, 70, 10, "Verifications Needed: "
-  Text 10, 215, 55, 10, "Replace as REI: "
-  Text 10, 230, 70, 10, "Decision on Request: "
-  Text 10, 250, 65, 10, "Reason for Denial: "
+  Text 10, 250, 70, 10, "Verifications Needed: "
+  Text 10, 210, 55, 10, "Replace as REI: "
+  Text 10, 195, 70, 10, "Status of Request: "
+  Text 10, 230, 65, 10, "Reason for Denial: "
   GroupBox 5, 290, 325, 95, "Nonreceipt/Replacement Affidavit (DHS-1609)"
   Text 10, 330, 120, 10, "Date DHS-1609 signed by the client:"
   Text 10, 350, 115, 10, "Date DHS-1609 received by county: "
@@ -146,27 +144,27 @@ Do
     DIALOG dialog1
     Cancel_confirmation
     Call validate_MAXIS_case_number(err_msg, "*")
-    If ButtonPressed = TSS_BENE_webform_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://owa.dhssir.cty.dhs.state.mn.us/csedforms/MMR/TSSBENE_BENE_request.asp"
-    IF process_step = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the step in the process you are providing an update on."
-    IF rei_replacement = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select if the replacement was REI, or select NA."
+    If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reports the loss occurred."
+    If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please enter the dollar amount the client reported."
+    If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reported the loss of food to county."
+    If trim(disaster_description) = "" Then err_msg = err_msg & vbCr & "* Please describe the type of disaster. If it was a power outage, please specify what caused the power outage."
+    If trim(how_verif) = "" Then err_msg = err_msg & vbCr & "* Please indicate how the disaster was verified - news reports, social worker, Red Cross, utility confirmation, etc."
+    If IsDate(loss_verification_date) <> TRUE or loss_verification_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the county verified the loss of food."
     IF replacement_status = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select the status of the replacement."
     IF replacement_status = "Pending Verification(s)" and verif_needed = "" THEN err_msg = err_msg & vbCr & "* Please complete the pending verifications field."
-    If IsDate(loss_date) <> TRUE or loss_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reports the loss occurred."
-    If IsDate(report_date) <> TRUE or report_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client reported the loss of food to county."
-    If amount_loss = "" Then err_msg = err_msg & vbCr & "* Please enter the dollar amount the client reported."
-    If disaster_description = "" Then err_msg = err_msg & vbCr & "* Please describe the type of disaster. If it was a power outage, please specify what caused the power outage."
-    If how_verif = "" Then err_msg = err_msg & vbCr & "* Please indicate how the disaster was verified - news reports, social worker, Red Cross, utility confirmation, etc."
-    IF replacement_status <> "Pending Complete DHS-1609" Then
-      If IsDate(dhs_1609_due_date) <> TRUE or dhs_1609_due_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the DHS-1609 is due back."
-      If IsDate(dhs1609_done_date) <> TRUE or dhs1609_done_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the county signed the form."
-      IF IsDate(dhs1609_rcvd_date) <> TRUE or dhs1609_rcvd_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the county received the request."
-      IF IsDate(dhs1609_sig_date) <> TRUE or dhs1609_sig_date = "" Then err_msg = err_msg & vbCr & "* Please enter the date the client signed the form."
-    End If
     IF replacement_status = "Request Denied" and trim(denial_reason) = "" THEN err_msg = err_msg & vbCr & "* Please provide a reason for the denial."
     IF replacement_status <> "Request Denied" and denial_reason <> "" THEN err_msg = err_msg & vbCr & "* The reason for the denial field should be blank if the request is not being denied."
+    IF replacement_status <> "Pending Verification(s)" and verif_needed <> "" THEN err_msg = err_msg & vbCr & "* The pending verifications field should be blank unless the 'Pending Verifications' decision on request option is selected."
+    IF rei_replacement = "Select One:" THEN err_msg = err_msg & vbCr & "* Please select if the replacement was REI, or select NA."
     IF TSS_BENE_sent_checkbox = UNCHECKED and replacement_status = "Request Approved" THEN err_msg = err_msg & vbCr & "* Please check that the TSS BENE Webform has been completed."
+    IF TSS_BENE_sent_checkbox = CHECKED and replacement_status <> "Request Approved" THEN err_msg = err_msg & vbCr & "* Please only check the TSS BENE Webform checkbox if you are approving the request."
+    If ButtonPressed = TSS_BENE_webform_btn Then run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://owa.dhssir.cty.dhs.state.mn.us/csedforms/MMR/TSSBENE_BENE_request.asp"
+    If IsDate(dhs_1609_due_date) <> TRUE and trim(dhs_1609_due_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the DHS-1609 is due back."
+    IF IsDate(dhs1609_sig_date) <> TRUE and trim(dhs1609_sig_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the client signed the form."
+    IF IsDate(dhs1609_rcvd_date) <> TRUE and trim(dhs1609_rcvd_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the county received the request."
+    If IsDate(dhs1609_done_date) <> TRUE and trim(dhs1609_done_date) <> "" Then err_msg = err_msg & vbCr & "* Please enter the date the county signed the form."
     IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
-    IF worker_signature = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
+    IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note."
   LOOP UNTIL err_msg = ""									'loops until all errors are resolved
   CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 Loop until are_we_passworded_out = false					'loops until user passwords back in
@@ -177,7 +175,6 @@ If dhs_1609_tikl = CHECKED Then Call create_TIKL("DHS-1609 was sent 10 days ago 
 'Write CASE/NOTE with information
 start_a_blank_case_note
 CALL write_variable_in_Case_Note("--Food Destroyed in a Disaster Reported - " & replacement_status & "--")
-CALL write_bullet_and_variable_in_Case_Note("Current Process Step", process_step)
 CALL write_bullet_and_variable_in_Case_Note("Date of Loss", loss_date)
 CALL write_bullet_and_variable_in_Case_Note("Amount of Food Loss", amount_loss)
 CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)
@@ -185,12 +182,13 @@ CALL write_bullet_and_variable_in_Case_Note("Description of Disaster", disaster_
 CALL write_bullet_and_variable_in_Case_Note("How the disaster was verified", how_verif)
 CALL write_bullet_and_variable_in_Case_Note("Date Loss Verified", loss_verification_date)
 CALL write_bullet_and_variable_in_Case_Note("Replace as REI", rei_replacement)
-IF TSS_BENE_sent_checkbox <> CHECKED THEN CALL write_bullet_and_variable_in_Case_Note("Status of Request", replacement_status)
+CALL write_bullet_and_variable_in_Case_Note("Status of Request", replacement_status)
 IF replacement_status = "Request Denied" Then CALL write_bullet_and_variable_in_Case_Note("Reason for Denial", denial_reason)
 CALL write_bullet_and_variable_in_Case_Note("Verifications Requested", verif_needed)
 IF TSS_BENE_sent_checkbox = CHECKED THEN CALL write_variable_in_Case_Note("* Submitted a TSS BENE request (webform) through SIR")
 CALL write_variable_in_Case_Note("Nonreceipt/Replacement Affidavit (DHS-1609)")
 CALL write_variable_in_Case_Note(" Date DHS-1609 is due back from the client: " & dhs_1609_due_date)
+If dhs_1609_tikl = CHECKED Then write_variable_in_Case_Note(" TIKL created for DHS-1609 due date.")
 CALL write_variable_in_Case_Note(" Date DHS-1609 was signed by the client: " & dhs1609_sig_date)
 CALL write_variable_in_Case_Note(" Date DHS-1609 was received by the county: " & dhs1609_rcvd_date)
 CALL write_variable_in_Case_Note(" Date DHS-1609 was completed by the county: " & dhs1609_done_date)

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -44,16 +44,18 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-CALL changelog_update("05/07/2024", "Update to align with updated POLI/TEMP.", "Mark Riegel, Hennepin County") '#316
+CALL changelog_update("05/07/2024", "Update to align with updated POLI/TEMP.", "Mark Riegel, Hennepin County") '#1796
 CALL changelog_update("09/19/2022", "Update to ensure Worker Signature is in all scripts that CASE/NOTE.", "MiKayla Handley, Hennepin County") '#316
 call changelog_update("11/27/2019", "Initial version.", "MiKayla Handley, Hennepin County")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
+
 'Connecting to BlueZone
 EMConnect ""
 
+'Gather case details as applicable
 get_county_code
 Call check_for_MAXIS(False)
 CALL MAXIS_case_number_finder(MAXIS_case_number)
@@ -85,8 +87,7 @@ Loop until are_we_passworded_out = false					'loops until user passwords back in
 
 Call check_for_MAXIS(False)
 
-'Initial Dialog Box
-'-------------------------------------------------------------------------------------------------DIALOG
+'Dialog to gather details on the request
 Dialog1 = "" 'Blanking out previous dialog detail
 BeginDialog Dialog1, 0, 0, 336, 410, "Replacing Food Destroyed in a Disaster"
   EditBox 55, 30, 35, 15, MAXIS_case_number
@@ -195,6 +196,50 @@ CALL write_variable_in_Case_Note(" Date DHS-1609 was received by the county: " &
 CALL write_variable_in_Case_Note(" Date DHS-1609 was completed by the county: " & dhs1609_done_date)
 CALL write_variable_in_Case_Note("----")
 CALL write_variable_in_Case_Note(worker_signature)
-PF3
 
 script_end_procedure_with_error_report("The case note has been created. If request has been approved, please be sure to send verifications to ECF and submit a TSS BENE request (webform) through SIR.")
+
+'----------------------------------------------------------------------------------------------------Closing Project Documentation - Version date 01/12/2023
+'------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------
+'
+'------Dialogs--------------------------------------------------------------------------------------------------------------------
+'--Dialog1 = "" on all dialogs -------------------------------------------------05/08/2024
+'--Tab orders reviewed & confirmed----------------------------------------------05/08/2024
+'--Mandatory fields all present & Reviewed--------------------------------------05/08/2024
+'--All variables in dialog match mandatory fields-------------------------------05/08/2024
+'Review dialog names for content and content fit in dialog----------------------05/08/2024
+'
+'-----CASE:NOTE-------------------------------------------------------------------------------------------------------------------
+'--All variables are CASE:NOTEing (if required)---------------------------------05/08/2024
+'--CASE:NOTE Header doesn't look funky------------------------------------------05/08/2024
+'--Leave CASE:NOTE in edit mode if applicable-----------------------------------05/08/2024
+'--write_variable_in_CASE_NOTE function: confirm that proper punctuation is used -----------------------------------
+'
+'-----General Supports-------------------------------------------------------------------------------------------------------------
+'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------05/08/2024
+'--MAXIS_background_check reviewed (if applicable)------------------------------05/08/2024
+'--PRIV Case handling reviewed -------------------------------------------------05/08/2024
+'--Out-of-County handling reviewed----------------------------------------------05/08/2024
+'--script_end_procedures (w/ or w/o error messaging)----------------------------05/08/2024
+'--BULK - review output of statistics and run time/count (if applicable)--------N/A
+'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------05/08/2024
+'
+'-----Statistics--------------------------------------------------------------------------------------------------------------------
+'--Manual time study reviewed --------------------------------------------------05/08/2024
+'--Incrementors reviewed (if necessary)-----------------------------------------05/08/2024
+'--Denomination reviewed -------------------------------------------------------05/08/2024
+'--Script name reviewed---------------------------------------------------------05/08/2024
+'--BULK - remove 1 incrementor at end of script reviewed------------------------N/A
+
+'-----Finishing up------------------------------------------------------------------------------------------------------------------
+'--Confirm all GitHub tasks are complete----------------------------------------05/08/2024
+'--comment Code-----------------------------------------------------------------05/08/2024
+'--Update Changelog for release/update------------------------------------------05/08/2024
+'--Remove testing message boxes-------------------------------------------------05/08/2024
+'--Remove testing code/unnecessary code-----------------------------------------05/08/2024
+'--Review/update SharePoint instructions----------------------------------------05/08/2024
+'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------05/08/2024
+'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------05/08/2024
+'--COMPLETE LIST OF SCRIPTS update policy references----------------------------05/08/2024
+'--Complete misc. documentation (if applicable)---------------------------------05/08/2024
+'--Update project team/issue contact (if applicable)----------------------------05/08/2024

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -51,10 +51,38 @@ call changelog_update("11/27/2019", "Initial version.", "MiKayla Handley, Hennep
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
 'Connecting to BlueZone
-
 EMConnect ""
-Call MAXIS_case_number_finder(MAXIS_case_number) 'Finds the case number
-Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
+
+get_county_code
+Call check_for_MAXIS(False)
+CALL MAXIS_case_number_finder(MAXIS_case_number)
+
+'Initial dialog to gather case details
+Dialog1 = ""
+BeginDialog Dialog1, 0, 0, 176, 65, "Case Number Dialog"
+  ButtonGroup ButtonPressed
+    OkButton 75, 45, 45, 15
+    CancelButton 125, 45, 45, 15
+  EditBox 75, 5, 45, 15, MAXIS_case_number
+  EditBox 75, 25, 95, 15, worker_signature
+  Text 20, 10, 50, 10, "Case Number:"
+  Text 10, 30, 60, 10, "Worker Signature:"
+EndDialog
+
+'Runs the first dialog - which confirms the case number
+Do
+	Do
+		err_msg = ""
+		Dialog Dialog1
+		cancel_without_confirmation
+      	Call validate_MAXIS_case_number(err_msg, "*")
+        If trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Sign your case note."
+        IF err_msg <> "" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
+	Loop until err_msg = ""
+    CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+Loop until are_we_passworded_out = false					'loops until user passwords back in
+
+Call check_for_MAXIS(False)
 
 'Initial Dialog Box
 '-------------------------------------------------------------------------------------------------DIALOG

--- a/notes/disaster-food-replacement.vbs
+++ b/notes/disaster-food-replacement.vbs
@@ -174,7 +174,7 @@ If dhs_1609_tikl = CHECKED Then Call create_TIKL("DHS-1609 was sent 10 days ago 
 
 'Write CASE/NOTE with information
 start_a_blank_case_note
-CALL write_variable_in_Case_Note("--Food Destroyed in a Disaster Reported - " & replacement_status & "--")
+CALL write_variable_in_Case_Note("--Food Destroyed in Disaster Reported - " & replacement_status & "--")
 CALL write_bullet_and_variable_in_Case_Note("Date of Loss", loss_date)
 CALL write_bullet_and_variable_in_Case_Note("Amount of Food Loss", amount_loss)
 CALL write_bullet_and_variable_in_Case_Note("Date client reported the loss of food to county", report_date)


### PR DESCRIPTION
Updated to ensure script captures all required details from 02/2024 POLI/TEMP for TE02.11.18 FOOD DESTROYED IN A MISFORTUNE OR DISASTER. Added TIKL functionality for DHS-1609. Updated dialog and validation. Added closing issue documentation and initial county and case number dialogs.