### PR TITLE
1789 notes returned mail, update to reflect unclear info

### DIFF
--- a/notes/returned-mail.vbs
+++ b/notes/returned-mail.vbs
@@ -120,12 +120,16 @@ DO
 		End If
 		IF ADDR_actions = "Select:" THEN err_msg = err_msg & vbCr & "Please chose an action for the returned mail."
 		IF worker_signature = "" THEN err_msg = err_msg & vbCr & "Please sign your case note."
-		IF ButtonPressed = CASH_POLI_TEMP_button THEN CALL view_poli_temp("02", "08", "011", "") 'TE02.08.011' RETURNED MAIL PROCESSING - CASH
-		IF ButtonPressed = SNAP_POLI_TEMP_button THEN CALL view_poli_temp("02", "08", "012", "") 'TE02.08.012' RETURNED MAIL PROCESSING - SNAP
+		IF ButtonPressed = CASH_POLI_TEMP_button THEN 
+			Call back_to_self
+			CALL view_poli_temp("02", "08", "011", "") 'TE02.08.011' RETURNED MAIL PROCESSING - CASH
+		ElseIf ButtonPressed = SNAP_POLI_TEMP_button THEN 
+			Call back_to_self
+			CALL view_poli_temp("02", "08", "012", "") 'TE02.08.012' RETURNED MAIL PROCESSING - SNAP
+		End If
 		IF ButtonPressed = one_source_button THEN run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/cs/login/login.htm"
 		IF ButtonPressed = one_source_button or ButtonPressed = SNAP_POLI_TEMP_button or ButtonPressed = CASH_POLI_TEMP_button THEN
 			err_msg = "LOOP"
-			CALL back_to_self ' this is for if the worker has used the POLI/TEMP navigation'
 		Else                                                'If the instructions button was NOT pressed, we want to display the error message if it exists.
 			IF err_msg <> "" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
 		End If

--- a/notes/returned-mail.vbs
+++ b/notes/returned-mail.vbs
@@ -45,6 +45,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("05/17/2024", "Updated to reflect unclear information for active, SNAP-only 6-month reporting cases where mail is returned without a forwarding address.", "Mark Riegel, Hennepin County")
 call changelog_update("01/26/2023", "Removed term 'ECF' from the case note per DHS guidance, and referencing the case file instead.", "Ilse Ferris, Hennepin County")
 call changelog_update("08/03/2022", "Remove ability to select both residential and mailing address. Created an option for received in error and address HC only handling.", "MiKayla Handley, Hennepin County") '#927 '
 call changelog_update("06/03/2022", "Updates for HC active/pending procedure and added handling for entering PACT panel.", "MiKayla Handley, Hennepin County") '#427 & #365 '


### PR DESCRIPTION
Updated returned mail to reflect findings from FNS audit to properly act on mail returned as undeliverable (mail returned without forwarding address). Per FNS audit: when the county receives returned mail without a forwarding address for simplified reporting households, the county should hold that information and follow-up at the next scheduled certification action or periodic report about the potential change in residence. If mail returned without a forwarding address, then script will determine if case is an active, SNAP-only, 6-month reporting and if so, it will CASE/NOTE that worker should follow up on address change at renewal/recertification and not take negative action.

Will update script instructions once finalized. 