### PR TITLE
#1844 Removed excluded time req for GRH in error handling

### DIFF
--- a/actions/transfer-case.vbs
+++ b/actions/transfer-case.vbs
@@ -271,9 +271,6 @@ Do
         IF excluded_time_dropdown = "Yes" then
             If IsDate(excluded_time_begin_date) = False OR Len(excluded_time_begin_date) <> 10 THEN err_msg = err_msg & vbNewLine & "* Please enter a valid date in the MM/DD/YYYY format for the start of excluded time or double check that the resident's absence is due to excluded time."
         End if
-            IF grh_status = "ACTIVE" or grh_status = "APP OPEN" then
-            IF excluded_time_dropdown = "No" THEN err_msg = err_msg & vbNewLine & "* GRH/Housing Supports is always an excluded time case." 'GRH IS ALWAYS EXCLUDED TIME CASE - ANSWER MUST BE 'Y'
-        END IF
         If mets_status_dropdown = "Select:" then err_msg = err_msg & vbNewLine & "* Select a METS status."
 		IF mets_status_dropdown = "active" or mets_status_dropdown = "pending" then
             If IsNumeric(METS_case_number) = False or len(METS_case_number) <> 8 then err_msg = err_msg & vbNewLine & "* Please enter a valid 8-digit METS case number."


### PR DESCRIPTION
Removed excluded time = yes req for active GRH in error handling in response to JD's email. 

Script will still default exclude time to Yes if GRH = active/app open however it will allow the user to change it to NO for circumstances that are not excluded time such as community settings. 