### PR TITLE
#1194 Approved Programs always Redirects to Elig Summ

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1489,7 +1489,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
         If living_sit_line = "09" Then living_situation = "09 - Declined"
         If living_sit_line = "10" Then living_situation = "10 - Unknown"
         addr_living_sit = living_situation
-		
+
         EMReadScreen addr_eff_date, 8, 4, 43									'reading the dates on the panel
         EMReadScreen addr_future_date, 8, 4, 66
 
@@ -1640,7 +1640,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 							  addr_homeless&"|"&addr_reservation&"|"&addr_living_sit&"|"&mail_line_one&"|"&mail_line_two&"|"&mail_street_full&"|"&mail_city&"|"&_
 							  mail_state&"|"&mail_zip&"|"&addr_eff_date&"|"&addr_future_date&"|"&phone_one&"|"&phone_two&"|"&phone_three&"|"&type_one&"|"&type_two&"|"&type_three&"|"&_
 							  text_yn_one&"|"&text_yn_two&"|"&text_yn_three&"|"&addr_email&"|"&addr_verif
-		
+
 		current_information = UCase(current_information)
 		' MsgBox "THIS" & vbCR & "ORIGINAL" & vbCr & original_information & vbCr & vbCr & "CURRENT" & vbCr & current_information
 		If current_information <> original_information Then						'If the information in the beginning and the information inthe end do not match - we need to update
@@ -1714,11 +1714,11 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 
 			'Now we write all the information
 	        Call create_mainframe_friendly_date(addr_eff_date, 4, 43, "YY")
-			
+
 			'This functionality will write the address word by word so that if it needs to word wrap to the second line, it can move the words to the next line
 			move_to_line_two = FALSE
-			If resi_line_one = "" AND resi_line_two = "" Then 
-				If len(resi_street_full) > 22 Then 
+			If resi_line_one = "" AND resi_line_two = "" Then
+				If len(resi_street_full) > 22 Then
 					resi_words = split(resi_street_full, " ")
 					write_resi_line_one = ""
 					write_resi_line_two = ""
@@ -1742,7 +1742,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 
 			Else
 				resi_street_full = trim(trim(resi_line_one) & " " & trim(resi_line_two))
-				If len(resi_line_one) or len(resi_line_two) > 22 Then 
+				If len(resi_line_one) or len(resi_line_two) > 22 Then
 					resi_words = split(resi_street_full, " ")
 					write_resi_line_one = ""
 					write_resi_line_two = ""
@@ -1779,7 +1779,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 
 			'This functionality will write the address word by word so that if it needs to word wrap to the second line, it can move the words to the next line
 			mail_move_to_line_two = FALSE
-			If mail_line_one = "" AND mail_line_two = "" Then 
+			If mail_line_one = "" AND mail_line_two = "" Then
 				If len(mail_street_full) > 22 Then
 					mail_words = split(mail_street_full, " ")
 					write_mail_line_one = ""
@@ -1801,9 +1801,9 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 				Else
 					write_mail_line_one = mail_street_full
 				End If
-			Else 
+			Else
 				mail_street_full = trim(trim(mail_line_one) & " " & trim(mail_line_two))
-				If len(mail_line_one) or len(mail_line_two) > 22 Then 
+				If len(mail_line_one) or len(mail_line_two) > 22 Then
 					mail_words = split(mail_street_full, " ")
 					write_mail_line_one = ""
 					write_mail_line_two = ""
@@ -4813,6 +4813,10 @@ function changelog_display()
 						script_in_local_changelog = true
 						if local_changelog_item_array(2) <> last_item_added_to_changelog(1) then
 							display_changelog = true
+							If local_changelog_item_array(2) = "* * * THIS SCRIPT IS BEING RETIRED ON 06/01/2024 * * *##~####~##NOTES - Eligibility Summary will be used to document any Approval starting 6/1/24, you will no longer be able to select for Approved Programs to continue with the old functionality.##~## ##~##If you have any concerns about Eligibility Summary, please report them right away so we can review.##~## ##~##                                       \    " Then
+								local_changelog_item_array(2) = "* * * THIS SCRIPT IS BEING RETIRED ON 06/01/2024 * * *##~####~##NOTES - Eligibility Summary will be used to document any Approval starting 6/1/24, you will no longer be able to select for Approved Programs to continue with the old functionality.##~## ##~##If you have any concerns about Eligibility Summary, please report them right away so we can review.##~## ##~##                                       \     |       / ##~##                            \      \    \    |     /    /       / ##~##                       \      \      \   \   |    /   /       /      / ##~##                   \     \      \  \   \  \  |   /  /  /   /      /      / ##~##                     \     \   \  \  \  @@@   /   /      /     / ##~##                 \     \     \   \ @@@@@@  /   /      /   / ##~##                \  \     \      @@@@@@@@    /      /   / ##~##              \   \  \      @@@@@@@@@@  /   /   /  / ##~##                 \  \  \  @@@@@@@@@@@  /  /  / ##~##    ~~ ~ ~ ~ ~ @@@@@@@@@@@@ ~ ~ ~ ~ ~~ ##~##                 /  /  / @@@@@@@@@@@ \  \  \ ##~##------------------------------------------------------------------------ ##~##(Sundown) "
+								' local_changelog_item_array(2) = replace(local_changelog_item_array(2), " | ", "")
+							End If
 							local_changelog_text_of_change = trim(local_changelog_item_array(2))
 							line_in_local_changelog_array_to_delete = i
 						Else
@@ -4849,7 +4853,12 @@ function changelog_display()
 				For each changelog_entry in changelog
 					date_of_change = left(changelog_entry, instr(changelog_entry, " | ") - 1)
 					scriptwriter_of_change = trim(right(changelog_entry, len(changelog_entry) - instrrev(changelog_entry, "|") ))
-					text_of_change = replace(replace(replace(changelog_entry, scriptwriter_of_change, ""), date_of_change, ""), " | ", "")
+					If InStr(changelog_entry, " ##~##                 /  /  / @@@@@@@@@@@ \  \  \ ##~##------------------------------------------------------------------------ ##~##(Sundown)") <> 0 Then
+						scriptwriter_of_change = "| Casey Love, Hennepin County"
+						text_of_change = replace(replace(changelog_entry, scriptwriter_of_change, ""), date_of_change & " |", "")
+					Else
+						text_of_change = replace(replace(replace(changelog_entry, scriptwriter_of_change, ""), date_of_change, ""), " | ", "")
+					End If
 
 					'If the text_of_change is the same as that stored in the local changelog, that means the user is up-to-date to this point, and the script should exit without displaying any more updates. Otherwise, add it to the contents.
 					if trim(text_of_change) = trim(local_changelog_text_of_change) then

--- a/notes/approved-programs.vbs
+++ b/notes/approved-programs.vbs
@@ -66,6 +66,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("06/03/2024", "* * * Approved Programs has been retired. * * *##~####~##NOTES - Eligibility Summary will now run every time you press the button for Approved Programs.##~##", "Casey Love, Hennepin County")
 call changelog_update("05/23/2024", "* * * THIS SCRIPT IS BEING RETIRED ON 06/01/2024 * * *##~####~##NOTES - Eligibility Summary will be used to document any Approval starting 6/1/24, you will no longer be able to select for Approved Programs to continue with the old functionality.##~## ##~##If you have any concerns about Eligibility Summary, please report them right away so we can review.##~## ##~##" & ascii_sundown, "Casey Love, Hennepin County")
 call changelog_update("05/01/2023", "* * * THIS SCRIPT IS BEING RETIRED ON 05/08/2023 * * *##~####~##Be sure to try using NOTES - Eligibility Summary before this retirement date for CASE/NOTEs on denials. This is the time to become accustomeed to the functionality of NOTES - Eligibility Summary.##~##", "Casey Love, Hennepin County")
 call changelog_update("01/13/2021", "Added temporary checkbox to case note 15% food benefit increase. Removed SNAP Banked Months case noting options.", "Ilse Ferris, Hennepin County")
@@ -77,6 +78,11 @@ call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
+
+script_run_lowdown = script_run_lowdown & vbCr & "STARTED FROM APPROVED PROGRAMS"
+script_url = script_repository & "notes\eligibility-summary.vbs"
+Call run_from_GitHub(script_url)
+script_end_procedure("")
 
 get_county_code 'Checks for county info from global variables, or asks if it is not already defined.
 EMConnect "" 'connecting to MAXIS


### PR DESCRIPTION
Updated Approved Programs to always redirect to Eligibility Summary

Func Lib changes are because the ASCII art in Approved Progs has  | - which is used as a delimiter and it is making all of the changlog messages show up. 