### PR TITLE
#123 NOTES - Elig Summ - a number of enhancements and handling for specific situations

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -30707,7 +30707,7 @@ If enter_CNOTE_for_SNAP = True Then
 			email_body = email_body & vbCr & "Email generated from the NOTES - Eligibility Summary Script, run at " & now
 
 			email_recip = "kerry.walsh@hennepin.us; brooke.reilley@hennepin.us"
-			email_recip_CC = "tanya.payne@hennepin.us; hsph.ews.bluezonescripts@hennepin.us"
+			email_recip_CC = "tanya.payne@hennepin.us"
 			Call create_outlook_email("", email_recip, email_recip_CC, email_recip_bcc, email_subject, 1, False, "", "", False, "", email_body, False, "", True)
 		End If
 	End If

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -7802,7 +7802,7 @@ function deny_elig_case_note()
 	End If
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_four_month_limit = "FAILED" Then Call write_variable_in_CASE_NOTE("     * This household has used all 4 DWP months.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_initial_income = "FAILED" Then
-		Call write_variable_in_CASE_NOTE("     * Household Income exceeds the Initial Income Level (Family Wage Level).")
+		Call write_variable_in_CASE_NOTE("     * Household Income exceeds the Initial Income Limit (Family Wage Level of $ " & CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_initial_family_wage_level & ").")
 		Call write_variable_in_CASE_NOTE("       | Counted Earned Inc: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_initial_counted_earned_income, 10) & "                                  |")
 		Call write_variable_in_CASE_NOTE("       | Dependent Care Exp: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_initial_dependent_care_expense, 10) & " (-)                              |")
 		Call write_variable_in_CASE_NOTE("       | Counted UNEA Inc:   $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_initial_counted_unearned_income, 10) & "                                  |")
@@ -7868,7 +7868,7 @@ function deny_elig_case_note()
 	End If
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_appl_withdraw = "FAILED" Then Call write_variable_in_CASE_NOTE("     * The Cash request has been Withdrawn.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_asset = "FAILED" Then
-		Call write_variable_in_CASE_NOTE("     * The household is over the asset limit for DWP (and all Cash Programs).")
+		Call write_variable_in_CASE_NOTE("     * The household is over the asset limit for MFIP (and all Cash Programs).")
 		Call write_variable_in_CASE_NOTE("       | CASH Assets: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_counted_asset_CASH, 10) & "                              |")
 		Call write_variable_in_CASE_NOTE("       | ACCT Assets: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_counted_asset_ACCT, 10) & "                              |")
 		Call write_variable_in_CASE_NOTE("       | SECU Assets: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_counted_asset_SECU, 10) & "                              |")
@@ -7883,7 +7883,7 @@ function deny_elig_case_note()
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_fail_coop = "FAILED" Then Call write_variable_in_CASE_NOTE("     * This household has not complied with all requirements for Family Cash Assistance.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_fail_file = "FAILED" Then Call write_variable_in_CASE_NOTE("     * This case has failed to complete a required report process.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_initial_income = "FAILED" Then
-		Call write_variable_in_CASE_NOTE("     * Household Income exceeds the Initial Income Level (Family Wage Level).")
+		Call write_variable_in_CASE_NOTE("     * Household Income exceeds the Initial Income Limit  (Family Wage Level of $ " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_initial_income_family_wage_level & ").")
 		Call write_variable_in_CASE_NOTE("       | Counted Earned Inc: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_initial_income_earned, 10) & "                                  |")
 		Call write_variable_in_CASE_NOTE("       | Dependent Care Exp: $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_initial_income_deoendant_care, 10) & " (-)                              |")
 		Call write_variable_in_CASE_NOTE("       | Counted UNEA Inc:   $ " & right("          " & CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_initial_income_unearned, 10) & "                                  |")

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -18932,6 +18932,7 @@ class stat_detail
 	public footer_month
 	public footer_year
 	public children_on_case
+	public panels_not_verif_string
 
 	public stat_addr_homeless_yn
 	public stat_addr_residence_county
@@ -19694,6 +19695,8 @@ class stat_detail
 		EMReadScreen stat_addr_homeless_yn, 1, 10, 43
 		EMReadScreen stat_addr_residence_county, 2, 9, 66
 		EMReadScreen stat_addr_living_situation, 2, 11, 43
+		EMReadScreen addr_verif, 2, 9, 74
+		If addr_verif = "NO" Then panels_not_verif_string = panels_not_verif_string & "Residence not verified.; "
 
 		current_month = footer_month & "/1/" & footer_year
 		current_month = DateAdd("d", 0, current_month)
@@ -21161,6 +21164,9 @@ class stat_detail
 			EMReadScreen stat_memb_age(memb_count), 3, 8, 76
 			EMReadScreen stat_memb_id_verif_code(memb_count), 2, 9, 68
 			EMReadScreen stat_memb_rel_to_applct_code(memb_count), 2, 10, 42
+			EMReadScreen ssn_prov, 1, 7, 68
+			If stat_memb_id_verif_code(memb_count) = "NO" Then panels_not_verif_string = panels_not_verif_string & "Identidy of Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
+			If ssn_prov = "N" Then panels_not_verif_string = panels_not_verif_string & "Social Sec Number of Memb " & stat_memb_ref_numb(memb_count) & " not provided.; "
 
 			stat_memb_age(memb_count) = trim(stat_memb_age(memb_count))
 			If stat_memb_age(memb_count) = "" Then stat_memb_age(memb_count) = 0
@@ -21222,6 +21228,8 @@ class stat_detail
 			If stat_memi_citizenship_verif_code(each_memb) = "PV" Then stat_memi_citizenship_verif_info(each_memb) = "Passport/Visa"
 			If stat_memi_citizenship_verif_code(each_memb) = "OT" Then stat_memi_citizenship_verif_info(each_memb) = "Other Document"
 			If stat_memi_citizenship_verif_code(each_memb) = "NO" Then stat_memi_citizenship_verif_info(each_memb) = "No Verif Provided"
+			' If stat_memi_citizenship_verif_code(each_memb) = "NO" Then panels_not_verif_string = panels_not_verif_string & "Proof of Citizenship of Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
+
 		Next
 
 		Call navigate_to_MAXIS_screen("STAT", "HCMI")
@@ -21242,7 +21250,9 @@ class stat_detail
 			EMReadScreen version_exists, 1, 2, 78
 			If version_exists = "1" Then
 				EMReadScreen end_date, 8, 12, 53
+				EMReadScreen preg_verf, 1, 6, 75
 				If end_date = "__ __ __" Then children_on_case = True
+				If preg_verf = "N" Then panels_not_verif_string = panels_not_verif_string & "Pregnancy of Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 		Next
 
@@ -21341,6 +21351,7 @@ class stat_detail
 				stat_jobs_one_grh_pic_ave_inc_per_pay(each_memb) = trim(stat_jobs_one_grh_pic_ave_inc_per_pay(each_memb))
 				stat_jobs_one_grh_pic_prosp_monthly_inc(each_memb) = trim(stat_jobs_one_grh_pic_prosp_monthly_inc(each_memb))
 				If stat_jobs_one_grh_pic_prosp_monthly_inc(each_memb) = "" Then stat_jobs_one_grh_pic_prosp_monthly_inc(each_memb) = "0.00"
+				If stat_jobs_one_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Memb " & stat_memb_ref_numb(memb_count) & " employment at " & stat_jobs_one_employer_name(each_memb) & " not verified.; "
 				PF3
 			End If
 
@@ -21434,6 +21445,7 @@ class stat_detail
 
 				stat_jobs_two_grh_pic_ave_inc_per_pay(each_memb) = trim(stat_jobs_two_grh_pic_ave_inc_per_pay(each_memb))
 				stat_jobs_two_grh_pic_prosp_monthly_inc(each_memb) = trim(stat_jobs_two_grh_pic_prosp_monthly_inc(each_memb))
+				If stat_jobs_two_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Memb " & stat_memb_ref_numb(memb_count) & " employment at " & stat_jobs_two_employer_name(each_memb) & " not verified.; "
 				PF3
 			End If
 
@@ -21527,6 +21539,7 @@ class stat_detail
 
 				stat_jobs_three_grh_pic_ave_inc_per_pay(each_memb) = trim(stat_jobs_three_grh_pic_ave_inc_per_pay(each_memb))
 				stat_jobs_three_grh_pic_prosp_monthly_inc(each_memb) = trim(stat_jobs_three_grh_pic_prosp_monthly_inc(each_memb))
+				If stat_jobs_three_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Memb " & stat_memb_ref_numb(memb_count) & " employment at " & stat_jobs_three_employer_name(each_memb) & " not verified.; "
 				PF3
 			End If
 
@@ -21620,6 +21633,7 @@ class stat_detail
 
 				stat_jobs_four_grh_pic_ave_inc_per_pay(each_memb) = trim(stat_jobs_four_grh_pic_ave_inc_per_pay(each_memb))
 				stat_jobs_four_grh_pic_prosp_monthly_inc(each_memb) = trim(stat_jobs_four_grh_pic_prosp_monthly_inc(each_memb))
+				If stat_jobs_four_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Memb " & stat_memb_ref_numb(memb_count) & " employment at " & stat_jobs_four_employer_name(each_memb) & " not verified.; "
 				PF3
 			End If
 
@@ -21713,6 +21727,7 @@ class stat_detail
 
 				stat_jobs_five_grh_pic_ave_inc_per_pay(each_memb) = trim(stat_jobs_five_grh_pic_ave_inc_per_pay(each_memb))
 				stat_jobs_five_grh_pic_prosp_monthly_inc(each_memb) = trim(stat_jobs_five_grh_pic_prosp_monthly_inc(each_memb))
+				If stat_jobs_five_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Memb " & stat_memb_ref_numb(memb_count) & " employment at " & stat_jobs_five_employer_name(each_memb) & " not verified.; "
 				PF3
 			End If
 		Next
@@ -21813,6 +21828,8 @@ class stat_detail
 				If stat_busi_one_snap_expense_verif_code(each_memb) = "4" Then stat_busi_one_snap_expense_verif_info(each_memb) = "Pending Out of Stat Verifs"
 				If stat_busi_one_snap_expense_verif_code(each_memb) = "6" Then stat_busi_one_snap_expense_verif_info(each_memb) = "Other Document"
 				If stat_busi_one_snap_expense_verif_code(each_memb) = "N" Then stat_busi_one_snap_expense_verif_info(each_memb) = "No Verif Provided"
+
+				If stat_busi_one_snap_expense_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Self Employment for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -21910,6 +21927,10 @@ class stat_detail
 				If stat_busi_two_snap_expense_verif_code(each_memb) = "4" Then stat_busi_two_snap_expense_verif_info(each_memb) = "Pending Out of Stat Verifs"
 				If stat_busi_two_snap_expense_verif_code(each_memb) = "6" Then stat_busi_two_snap_expense_verif_info(each_memb) = "Other Document"
 				If stat_busi_two_snap_expense_verif_code(each_memb) = "N" Then stat_busi_two_snap_expense_verif_info(each_memb) = "No Verif Provided"
+
+				If stat_busi_two_snap_expense_verif_code(each_memb) = "N" Then
+					If InStr(panels_not_verif_string, "Self Employment for Memb " & stat_memb_ref_numb(memb_count)) = 0 Then panels_not_verif_string = panels_not_verif_string & "Self Employment for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
+				End If
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22007,6 +22028,10 @@ class stat_detail
 				If stat_busi_three_snap_expense_verif_code(each_memb) = "4" Then stat_busi_three_snap_expense_verif_info(each_memb) = "Pending Out of Stat Verifs"
 				If stat_busi_three_snap_expense_verif_code(each_memb) = "6" Then stat_busi_three_snap_expense_verif_info(each_memb) = "Other Document"
 				If stat_busi_three_snap_expense_verif_code(each_memb) = "N" Then stat_busi_three_snap_expense_verif_info(each_memb) = "No Verif Provided"
+
+				If stat_busi_three_snap_expense_verif_code(each_memb) = "N" Then
+					If InStr(panels_not_verif_string, "Self Employment for Memb " & stat_memb_ref_numb(memb_count)) = 0 Then panels_not_verif_string = panels_not_verif_string & "Self Employment for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
+				End If
 			End If
 
 		Next
@@ -22114,6 +22139,7 @@ class stat_detail
 				stat_unea_one_snap_pic_prosp_monthly_inc(each_memb) = trim(stat_unea_one_snap_pic_prosp_monthly_inc(each_memb))
 				PF3
 
+				If stat_unea_one_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Income from " & stat_unea_one_type_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -29105,7 +29131,6 @@ If enter_CNOTE_for_EMER = True Then
 
 	'Identifies if the approval amount in ELIG/EMER is different from the total of MONY/CHCKs issued.
 	'We are prioritizing the amount in MONY/CHCK as that is the amount that will actually issue on the behalf of the resident.
-
 	If EMER_ELIG_APPROVAL.emer_elig_summ_eligibility_result = "ELIGIBLE" and EMER_ELIG_APPROVAL.bus_ticket_approval = False Then
 		total_payment = 0
 		For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -24856,6 +24856,27 @@ For each footer_month in MONTHS_ARRAY
 			approval_found_for_this_month = True
 			ineligible_approval_exists = True
 			SPECIAL_PROCESSES_BY_MONTH(DENY_app_const, month_count) = "INELIGIBLE"
+			If numb_GA_versions <> " " Then
+				If GA_ELIG_APPROVALS(ga_elig_months_count).approved_today = True Then
+					If first_GA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_GA_approval = ""
+				End If
+			End If
+			If numb_MSA_versions <> " " Then
+				If MSA_ELIG_APPROVALS(msa_elig_months_count).approved_today = True Then
+					If first_MSA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MSA_approval = ""
+				End If
+			End If
+			If numb_MFIP_versions <> " " Then
+				If MFIP_ELIG_APPROVALS(mfip_elig_months_count).approved_today = True Then
+					If first_MFIP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MFIP_approval = ""
+				End If
+			End If
+			If numb_DWP_versions <> " " Then
+				If DWP_ELIG_APPROVALS(dwp_elig_months_count).approved_today = True and DWP_ELIG_APPROVALS(dwp_elig_months_count).dwp_case_eligibility_result = "INELIGIBLE" Then
+					If first_DWP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_DWP_approval = ""
+				End If
+			End If
+
 		ElseIf CASH_DENIAL_APPROVALS(cash_deny_months_count).approved_version_found = True Then
 			If DateDiff("d", date, CASH_DENIAL_APPROVALS(cash_deny_months_count).approval_date) = 0 Then
 				approvals_not_created_today = approvals_not_created_today & MAXIS_footer_month & "/" & MAXIS_footer_year & " CASH DENY approved today." & vbCr

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -24886,22 +24886,38 @@ For each footer_month in MONTHS_ARRAY
 			SPECIAL_PROCESSES_BY_MONTH(DENY_app_const, month_count) = "INELIGIBLE"
 			If numb_GA_versions <> " " Then
 				If GA_ELIG_APPROVALS(ga_elig_months_count).approved_today = True Then
-					If first_GA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_GA_approval = ""
+					If GA_ELIG_APPROVALS(ga_elig_months_count).ga_elig_summ_eligibility_result = "INELIGIBLE" Then
+						If first_GA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_GA_approval = ""
+					ElseIf If GA_ELIG_APPROVALS(ga_elig_months_count).ga_elig_summ_eligibility_result = "ELIGIBLE" Then
+						If first_DENY_approval = MAXIS_footer_month & "/" & MAXIS_footer_year then first_DENY_approval = ""
+					End If
 				End If
 			End If
 			If numb_MSA_versions <> " " Then
 				If MSA_ELIG_APPROVALS(msa_elig_months_count).approved_today = True Then
-					If first_MSA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MSA_approval = ""
+					If MSA_ELIG_APPROVALS(msa_elig_months_count).msa_elig_summ_eligibility_result = "INELIGIBLE" Then
+						If first_MSA_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MSA_approval = ""
+					ElseIf MSA_ELIG_APPROVALS(msa_elig_months_count).msa_elig_summ_eligibility_result = "ELIGIBLE" Then
+						If first_DENY_approval = MAXIS_footer_month & "/" & MAXIS_footer_year then first_DENY_approval = ""
+					End If
 				End If
 			End If
 			If numb_MFIP_versions <> " " Then
 				If MFIP_ELIG_APPROVALS(mfip_elig_months_count).approved_today = True Then
-					If first_MFIP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MFIP_approval = ""
+					If MFIP_ELIG_APPROVALS(mfip_elig_months_count).mfip_case_eligibility_result = "INELIGIBLE" Then
+						If first_MFIP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_MFIP_approval = ""
+					ElseIf MFIP_ELIG_APPROVALS(mfip_elig_months_count).mfip_case_eligibility_result = "ELIGIBLE" Then
+						If first_DENY_approval = MAXIS_footer_month & "/" & MAXIS_footer_year then first_DENY_approval = ""
+					End If
 				End If
 			End If
 			If numb_DWP_versions <> " " Then
-				If DWP_ELIG_APPROVALS(dwp_elig_months_count).approved_today = True and DWP_ELIG_APPROVALS(dwp_elig_months_count).dwp_case_eligibility_result = "INELIGIBLE" Then
-					If first_DWP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_DWP_approval = ""
+				If DWP_ELIG_APPROVALS(dwp_elig_months_count).approved_today = True Then
+					If DWP_ELIG_APPROVALS(dwp_elig_months_count).dwp_case_eligibility_result = "INELIGIBLE" Then
+						If first_DWP_approval = MAXIS_footer_month & "/" & MAXIS_footer_year Then first_DWP_approval = ""
+					ElseIf DWP_ELIG_APPROVALS(dwp_elig_months_count).dwp_case_eligibility_result = "ELIGIBLE" Then
+						If first_DENY_approval = MAXIS_footer_month & "/" & MAXIS_footer_year then first_DENY_approval = ""
+					End If
 				End If
 			End If
 

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -7755,11 +7755,18 @@ function deny_elig_case_note()
 
 	Call start_a_blank_case_note
 
-	Call write_variable_in_CASE_NOTE("APPROVAL - CASH INELIGIBLE - Denied eff " & first_month)
+	If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+		Call write_variable_in_CASE_NOTE("APPROVAL - CASH WITHDRAWN - Denied eff " & first_month)
+	Else
+		Call write_variable_in_CASE_NOTE("APPROVAL - CASH INELIGIBLE - Denied eff " & first_month)
+	End If
 
 	Call write_bullet_and_variable_in_CASE_NOTE("Approval completed", CASH_DENIAL_APPROVALS(elig_ind).elig_version_date)
 
 	If add_new_note_for_DENY = "Yes - Eligiblity has changed - Enter a new NOTE" Then Call write_variable_in_CASE_NOTE("* This CASE/NOTE detail replaces info from today's previous approval NOTES.")
+	If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+		Call write_variable_in_CASE_NOTE("* Request for CASH Program has been WITHDRAWN.")
+	End If
 	Call write_variable_in_CASE_NOTE("* Case has no eligibility for any CASH Program.")
 
 	Call write_variable_in_CASE_NOTE("============================= CASH PROGRAMS DETAIL ==========================")
@@ -8090,24 +8097,28 @@ function deny_elig_case_note()
 	If DENY_UNIQUE_APPROVALS(pact_wcom_sent, unique_app) = True Then
 		Call write_variable_in_CASE_NOTE("======================= WCOM of DENIAL INFORMATION ADDED ====================")
 		Call write_variable_in_CASE_NOTE("* WCOM added to Denial Notice to detail Denial Information.")
-		Call write_variable_in_CASE_NOTE("Information added:")
-		CALL write_variable_in_CASE_NOTE("RCA: Refugee Cash apply at your resettlement agency.")
-		' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Adult" Then
-		If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
-			CALL write_variable_in_CASE_NOTE("DWP/MFIP: Family cash programs.")
-			CALL write_variable_in_CASE_NOTE("    Requires an eligible child/pregnant person to be elig.")
+		If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+
 		Else
-			CALL write_variable_in_CASE_NOTE("DWP: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_info)
-			CALL write_variable_in_CASE_NOTE("MFIP: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_info)
+			Call write_variable_in_CASE_NOTE("Information added:")
+			CALL write_variable_in_CASE_NOTE("RCA: Refugee Cash apply at your resettlement agency.")
+			' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Adult" Then
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
+				CALL write_variable_in_CASE_NOTE("DWP/MFIP: Family cash programs.")
+				CALL write_variable_in_CASE_NOTE("    Requires an eligible child/pregnant person to be elig.")
+			Else
+				CALL write_variable_in_CASE_NOTE("DWP: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_info)
+				CALL write_variable_in_CASE_NOTE("MFIP: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_info)
+			End If
+			' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
+				CALL write_variable_in_CASE_NOTE("GA/MSA: Adult cash programs.")
+				CALL write_variable_in_CASE_NOTE("    Available only for households without children.")
+			Else
+				CALL write_variable_in_CASE_NOTE("GA: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_info)
+				CALL write_variable_in_CASE_NOTE("MSA: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_info)
+			End if
 		End If
-		' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
-		If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
-			CALL write_variable_in_CASE_NOTE("GA/MSA: Adult cash programs.")
-			CALL write_variable_in_CASE_NOTE("    Available only for households without children.")
-		Else
-			CALL write_variable_in_CASE_NOTE("GA: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_info)
-			CALL write_variable_in_CASE_NOTE("MSA: " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_info)
-		End if
 
 		If DENY_UNIQUE_APPROVALS(wcom_details_one, unique_app) <> "" or DENY_UNIQUE_APPROVALS(wcom_details_two, unique_app) <> "" or DENY_UNIQUE_APPROVALS(wcom_details_three, unique_app) <> "" Then
 			CALL write_variable_in_CASE_NOTE("Reasons for Cash Denial:")
@@ -28271,6 +28282,12 @@ If enter_CNOTE_for_DENY = True Then
 			For approval = 0 to UBound(CASH_DENIAL_APPROVALS)
 				If CASH_DENIAL_APPROVALS(approval).elig_footer_month & "/" & CASH_DENIAL_APPROVALS(approval).elig_footer_year = DENY_UNIQUE_APPROVALS(first_mo_const, unique_app) Then elig_ind = approval
 			Next
+			For each_month = 0 to UBound(STAT_INFORMATION)
+				If STAT_INFORMATION(each_month).footer_month & "/" & STAT_INFORMATION(each_month).footer_year = first_month Then month_ind = each_month
+			Next
+			If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+				If deny_wcom_info_one = "" Then deny_wcom_info_one = "The application for cash has been withdrawn, which means you requested to not be assessed for cash assistance."
+			End If
 
 			Do
 				Do
@@ -28286,16 +28303,22 @@ If enter_CNOTE_for_DENY = True Then
 					  If DENY_UNIQUE_APPROVALS(last_mo_const, unique_app) <> "" Then Text 10, 10, 460, 10, "WCOM is needed for all CASH DENIALS to explain the reason for denial. Detail information for " & DENY_UNIQUE_APPROVALS(first_mo_const, unique_app) & " - " & DENY_UNIQUE_APPROVALS(last_mo_const, unique_app) & " ELIG/DENY Approval"
 					  If DENY_UNIQUE_APPROVALS(last_mo_const, unique_app) = "" Then Text 10, 10, 460, 10, "WCOM is needed for all CASH DENIALS to explain the reason for denial. Detail information for " & DENY_UNIQUE_APPROVALS(first_mo_const, unique_app) & " ELIG/DENY Approval"
 			    	  ' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Adult" Then
-					  If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
-						  Text 15, 25, 130, 10, "Case is Adult. Script will add detail:"
-						  Text 20, 40, 230, 10, "MFIP/DWP are Family Cash Programs."
-						  Text 20, 50, 230, 10, "They require an eligible child/pregnant person to be eligible."
-					  End If
-					  ' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
-					  If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
-						  Text 15, 25, 130, 10, "Case is Family. Script will add detail:"
-						  Text 20, 40, 230, 10, "GA/MSA are Adult Cash programs."
-						  Text 20, 50, 230, 10, "Available only for households without children."
+					  If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+						Text 15, 25, 200, 10, "Cash request has been withdrawn. Script will add detial"
+						Text 20, 40, 230, 10, "All cash programs have been denied because you have withdrawn the request."
+						Text 20, 50, 230, 10, "You can reapply at any time if your situation changes or want to be reassessed."
+					  Else
+						If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
+							Text 15, 25, 130, 10, "Case is Adult. Script will add detail:"
+							Text 20, 40, 230, 10, "MFIP/DWP are Family Cash Programs."
+							Text 20, 50, 230, 10, "They require an eligible child/pregnant person to be eligible."
+						End If
+						' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
+						If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
+							Text 15, 25, 130, 10, "Case is Family. Script will add detail:"
+							Text 20, 40, 230, 10, "GA/MSA are Adult Cash programs."
+							Text 20, 50, 230, 10, "Available only for households without children."
+						End If
 					  End If
 					  Text 10, 70, 185, 10, "Detail the information about the denial for the WCOM:"
 					  Text 10, 100, 185, 10, "Second Reason for denial for the WCOM:"
@@ -30159,17 +30182,22 @@ If enter_CNOTE_for_DENY = True Then
 						If trim(wcom_line) = "" Then
 							DENY_UNIQUE_APPROVALS(pact_wcom_sent, unique_app) = True
 							CALL write_variable_in_SPEC_MEMO("Explanation of CASH DENIALS:")
-							CALL write_variable_in_SPEC_MEMO("RCA: Refugee Cash apply at your resettlement agency.")
-							' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Adult" Then
-							If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
-								CALL write_variable_in_SPEC_MEMO("DWP/MFIP: These are Family Cash programs.")
-								CALL write_variable_in_SPEC_MEMO("    Requires an eligible child/pregnant person to be elig.")
+					  		If STAT_INFORMATION(month_ind).stat_pact_cash_one_code = "1" or STAT_INFORMATION(month_ind).stat_pact_cash_two_code = "1" Then
+								CALL write_variable_in_SPEC_MEMO("All cash programs have been denied because you have withdrawn the request.")
+								CALL write_variable_in_SPEC_MEMO("    You can reapply at any time if your situation changes or want to be reassessed.")
+							Else
+								CALL write_variable_in_SPEC_MEMO("RCA: Refugee Cash apply at your resettlement agency.")
+								' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Adult" Then
+								If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_code = "01" Then
+									CALL write_variable_in_SPEC_MEMO("DWP/MFIP: These are Family Cash programs.")
+									CALL write_variable_in_SPEC_MEMO("    Requires an eligible child/pregnant person to be elig.")
+								End If
+								' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
+								If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
+									CALL write_variable_in_SPEC_MEMO("GA/MSA: These are Adult Cash programs.")
+									CALL write_variable_in_SPEC_MEMO("    Available only for households without children.")
+								End if
 							End If
-							' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" Then
-							If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_msa_reason_code = "01" and CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_code = "01" Then
-								CALL write_variable_in_SPEC_MEMO("GA/MSA: These are Adult Cash programs.")
-								CALL write_variable_in_SPEC_MEMO("    Available only for households without children.")
-							End if
 
 							If DENY_UNIQUE_APPROVALS(wcom_details_one, unique_app) <> "" or DENY_UNIQUE_APPROVALS(wcom_details_two, unique_app) <> "" or DENY_UNIQUE_APPROVALS(wcom_details_three, unique_app) <> "" Then
 								CALL write_variable_in_SPEC_MEMO("Reasons for Cash Denial:")

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -28068,6 +28068,25 @@ If enter_CNOTE_for_DENY = True Then
 
 					dialog Dialog1
 					cancel_confirmation
+
+					duplicate_info_deleted = False
+					deny_wcom_info_one = trim(deny_wcom_info_one)
+					deny_wcom_info_two = trim(deny_wcom_info_two)
+					deny_wcom_info_three = trim(deny_wcom_info_three)
+					If deny_wcom_info_three = deny_wcom_info_two Then
+						If deny_wcom_info_three <> "" Then duplicate_info_deleted = True
+						deny_wcom_info_three = ""
+					End If
+					If deny_wcom_info_one = deny_wcom_info_two Then
+						If deny_wcom_info_two <> "" Then duplicate_info_deleted = True
+						deny_wcom_info_two = ""
+					End If
+					If deny_wcom_info_one = deny_wcom_info_three Then
+						If deny_wcom_info_three <> "" Then duplicate_info_deleted = True
+						deny_wcom_info_three = ""
+					End If
+					If duplicate_info_deleted = True then err_msg = err_msg & vbCr & "* The information entered in each line should not be duplicated as it creates a repeditive notice and CASE/NOTE."
+
 					If trim(deny_wcom_info_one) = "" and trim(deny_wcom_info_two) = "" and trim(deny_wcom_info_three) = "" Then
 						err_msg = err_msg & vbCr & "* WCOMs are required for all Cash DENY Approvals. Enter information into the dialog to explain cleearly to the resident why the Cash Request has been denied."
 					ElseIf len(deny_wcom_info_one) < 30 and len(deny_wcom_info_two) < 30 and len(deny_wcom_info_three) < 30 and (len(deny_wcom_info_one)+len(deny_wcom_info_two)+len(deny_wcom_info_three)) < 30 Then

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -29105,7 +29105,8 @@ If enter_CNOTE_for_EMER = True Then
 
 	'Identifies if the approval amount in ELIG/EMER is different from the total of MONY/CHCKs issued.
 	'We are prioritizing the amount in MONY/CHCK as that is the amount that will actually issue on the behalf of the resident.
-	If EMER_ELIG_APPROVAL.emer_elig_summ_eligibility_result = "ELIGIBLE" Then
+
+	If EMER_ELIG_APPROVAL.emer_elig_summ_eligibility_result = "ELIGIBLE" and EMER_ELIG_APPROVAL.bus_ticket_approval = False Then
 		total_payment = 0
 		For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)
 			If IsNumeric(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)) = True then
@@ -29137,7 +29138,9 @@ If enter_CNOTE_for_EMER = True Then
 
 		End If
 	End If
-
+	If EMER_ELIG_APPROVAL.bus_ticket_approval = True Then
+		EMER_ELIG_APPROVAL.emer_elig_summ_payment = EMER_ELIG_APPROVAL.emer_elig_summ_need_other
+	End If
 
 	Do
 		Do

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -90,8 +90,8 @@ QCR_SNAP_Homeless_SHELTER_Expense_All = True
 
 function determine_thrifty_food_plan(footer_month, footer_year, hh_size, thrifty_food_plan)
 '--- This function outputs the dollar amount (as a number) of the Thrifty Food Plan on HH Size as needed by SNAP. Info Source: CM0022.12.01 HOW TO CALCULATE BENEFIT LEVEL - SNAP/MSA/GRH - https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=CM_00221201
-'~~~~~ footer_month: relevant footer month - the calculation changes every Ocotber and we need to ensure we are pulling the correct amount
-'~~~~~ footer_year: relevant footer year - the calculation changes every Ocotber and we need to ensure we are pulling the correct amount
+'~~~~~ footer_month: relevant footer month - the calculation changes every October and we need to ensure we are pulling the correct amount
+'~~~~~ footer_year: relevant footer year - the calculation changes every October and we need to ensure we are pulling the correct amount
 '~~~~~ hh_size: NUMBER - the number of people in the SNAP unit
 '~~~~~ thrifty_food_plan: NUMBER - this will output a number with the amount of the thrifty food plan based on footer month and HH Size
 '===== Keywords: SNAP, calculation, Income Test
@@ -210,7 +210,7 @@ function detail_action_that_led_to_approval(current_prog, process_completed, cha
 	ButtonGroup ButtonPressed
 		PushButton 230, 215, 115, 15, "Return to Approval Detail", return_btn
 	Text 10, 10, 180, 10, "You have completed an approval for " & current_prog & " today."
-	Text 10, 25, 335, 30, "Details of the information used to make an eligibility determination should be entered in a seperate CASE/NOTE with full detail and explanation. NOTES - Eligibility Summary is only intended to document the details of the approval, not why the approval was necessary."
+	Text 10, 25, 335, 30, "Details of the information used to make an eligibility determination should be entered in a separate CASE/NOTE with full detail and explanation. NOTES - Eligibility Summary is only intended to document the details of the approval, not why the approval was necessary."
 	Text 10, 60, 210, 20, "To create cohesiveness with previous CASE/NOTEs, you can indicate why you are processing the approval today."
 	Text 10, 90, 105, 10, "Reason Approval was needed:"
 	GroupBox 10, 110, 335, 85, "Information Changed"
@@ -384,7 +384,7 @@ function display_approval_packages_dialog()
 	  Text 35, 85, 70, 10, "Eligibility Result"
 	  Text 35, 95, 70, 10, "Budget Cycle"
 	  Text 35, 105, 70, 10, "Income"
-	  Text 35, 115, 95, 10, "Houshold Composition"
+	  Text 35, 115, 95, 10, "Household Composition"
 	  Text 35, 125, 95, 10, "Entitlement "
 	  Text 25, 140, 205, 20, "If these are the same from month to month, the script groups these approval months together as an 'Approval Package'."
 	  GroupBox 10, 165, 370, 10, ""
@@ -419,7 +419,7 @@ function display_snap_deductions_dialog()
 	  Text 25, 150, 245, 10, "All details of FMED should be reviewed in the CM."
 	  GroupBox 10, 175, 370, 40, "Dependent Care . . . $ " & SNAP_ELIG_APPROVALS(elig_ind).snap_budg_deduct_depndt_care
 	  Text 25, 190, 180, 10, "Care of a dependent can be used a SNAP deduction."
-	  Text 25, 200, 180, 10, "Dependent Care Expeses are declaratory."
+	  Text 25, 200, 180, 10, "Dependent Care Expenses are declaratory."
 	  GroupBox 10, 225, 370, 30, " Child Support . . . $ " & SNAP_ELIG_APPROVALS(elig_ind).snap_budg_deduct_cses
 	  Text 25, 240, 245, 10, "Court Ordered Child Support Expense can be allowed as a deduction."
 	  ButtonGroup ButtonPressed

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -19462,22 +19462,37 @@ class stat_detail
 	public stat_acct_one_type()
 	public stat_acct_one_balence()
 	public stat_acct_one_count_snap_yn()
+	public stat_acct_one_info()
+	public stat_acct_one_count_cash_yn()
+	public stat_acct_one_verif()
 	public stat_acct_two_exists()
 	public stat_acct_two_type()
 	public stat_acct_two_balence()
 	public stat_acct_two_count_snap_yn()
+	public stat_acct_two_info()
+	public stat_acct_two_count_cash_yn()
+	public stat_acct_two_verif()
 	public stat_acct_three_exists()
 	public stat_acct_three_type()
 	public stat_acct_three_balence()
 	public stat_acct_three_count_snap_yn()
+	public stat_acct_three_info()
+	public stat_acct_three_count_cash_yn()
+	public stat_acct_three_verif()
 	public stat_acct_four_exists()
 	public stat_acct_four_type()
 	public stat_acct_four_balence()
 	public stat_acct_four_count_snap_yn()
+	public stat_acct_four_info()
+	public stat_acct_four_count_cash_yn()
+	public stat_acct_four_verif()
 	public stat_acct_five_exists()
 	public stat_acct_five_type()
 	public stat_acct_five_balence()
 	public stat_acct_five_count_snap_yn()
+	public stat_acct_five_info()
+	public stat_acct_five_count_cash_yn()
+	public stat_acct_five_verif()
 	public stat_shel_exists()
 	public stat_shel_subsidized_yn()
 	public stat_shel_shared_yn()
@@ -20259,22 +20274,37 @@ class stat_detail
 		ReDim stat_acct_one_type(0)
 		ReDim stat_acct_one_balence(0)
 		ReDim stat_acct_one_count_snap_yn(0)
+		ReDim stat_acct_one_info(0)
+		ReDim stat_acct_one_count_cash_yn(0)
+		ReDim stat_acct_one_verif(0)
 		ReDim stat_acct_two_exists(0)
 		ReDim stat_acct_two_type(0)
 		ReDim stat_acct_two_balence(0)
 		ReDim stat_acct_two_count_snap_yn(0)
+		ReDim stat_acct_two_info(0)
+		ReDim stat_acct_two_count_cash_yn(0)
+		ReDim stat_acct_two_verif(0)
 		ReDim stat_acct_three_exists(0)
 		ReDim stat_acct_three_type(0)
 		ReDim stat_acct_three_balence(0)
 		ReDim stat_acct_three_count_snap_yn(0)
+		ReDim stat_acct_three_info(0)
+		ReDim stat_acct_three_count_cash_yn(0)
+		ReDim stat_acct_three_verif(0)
 		ReDim stat_acct_four_exists(0)
 		ReDim stat_acct_four_type(0)
 		ReDim stat_acct_four_balence(0)
 		ReDim stat_acct_four_count_snap_yn(0)
+		ReDim stat_acct_four_info(0)
+		ReDim stat_acct_four_count_cash_yn(0)
+		ReDim stat_acct_four_verif(0)
 		ReDim stat_acct_five_exists(0)
 		ReDim stat_acct_five_type(0)
 		ReDim stat_acct_five_balence(0)
 		ReDim stat_acct_five_count_snap_yn(0)
+		ReDim stat_acct_five_info(0)
+		ReDim stat_acct_five_count_cash_yn(0)
+		ReDim stat_acct_five_verif(0)
 		ReDim stat_shel_exists(0)
 		ReDim stat_shel_subsidized_yn(0)
 		ReDim stat_shel_shared_yn(0)
@@ -20921,22 +20951,37 @@ class stat_detail
 			ReDim preserve stat_acct_one_type(memb_count)
 			ReDim preserve stat_acct_one_balence(memb_count)
 			ReDim preserve stat_acct_one_count_snap_yn(memb_count)
+			ReDim preserve stat_acct_one_info(memb_count)
+			ReDim preserve stat_acct_one_count_cash_yn(memb_count)
+			ReDim preserve stat_acct_one_verif(memb_count)
 			ReDim preserve stat_acct_two_exists(memb_count)
 			ReDim preserve stat_acct_two_type(memb_count)
 			ReDim preserve stat_acct_two_balence(memb_count)
 			ReDim preserve stat_acct_two_count_snap_yn(memb_count)
+			ReDim preserve stat_acct_two_info(memb_count)
+			ReDim preserve stat_acct_two_count_cash_yn(memb_count)
+			ReDim preserve stat_acct_two_verif(memb_count)
 			ReDim preserve stat_acct_three_exists(memb_count)
 			ReDim preserve stat_acct_three_type(memb_count)
 			ReDim preserve stat_acct_three_balence(memb_count)
 			ReDim preserve stat_acct_three_count_snap_yn(memb_count)
+			ReDim preserve stat_acct_three_info(memb_count)
+			ReDim preserve stat_acct_three_count_cash_yn(memb_count)
+			ReDim preserve stat_acct_three_verif(memb_count)
 			ReDim preserve stat_acct_four_exists(memb_count)
 			ReDim preserve stat_acct_four_type(memb_count)
 			ReDim preserve stat_acct_four_balence(memb_count)
 			ReDim preserve stat_acct_four_count_snap_yn(memb_count)
+			ReDim preserve stat_acct_four_info(memb_count)
+			ReDim preserve stat_acct_four_count_cash_yn(memb_count)
+			ReDim preserve stat_acct_four_verif(memb_count)
 			ReDim preserve stat_acct_five_exists(memb_count)
 			ReDim preserve stat_acct_five_type(memb_count)
 			ReDim preserve stat_acct_five_balence(memb_count)
 			ReDim preserve stat_acct_five_count_snap_yn(memb_count)
+			ReDim preserve stat_acct_five_info(memb_count)
+			ReDim preserve stat_acct_five_count_cash_yn(memb_count)
+			ReDim preserve stat_acct_five_verif(memb_count)
 			ReDim preserve stat_shel_exists(memb_count)
 			ReDim preserve stat_shel_subsidized_yn(memb_count)
 			ReDim preserve stat_shel_shared_yn(memb_count)
@@ -22243,6 +22288,7 @@ class stat_detail
 				stat_unea_two_snap_pic_prosp_monthly_inc(each_memb) = trim(stat_unea_two_snap_pic_prosp_monthly_inc(each_memb))
 				PF3
 
+				If stat_unea_two_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Income from " & stat_unea_two_type_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22347,6 +22393,7 @@ class stat_detail
 				stat_unea_three_snap_pic_prosp_monthly_inc(each_memb) = trim(stat_unea_three_snap_pic_prosp_monthly_inc(each_memb))
 				PF3
 
+				If stat_unea_three_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Income from " & stat_unea_three_type_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22450,6 +22497,7 @@ class stat_detail
 				stat_unea_four_snap_pic_prosp_monthly_inc(each_memb) = trim(stat_unea_four_snap_pic_prosp_monthly_inc(each_memb))
 				PF3
 
+				If stat_unea_four_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Income from " & stat_unea_four_type_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22553,6 +22601,7 @@ class stat_detail
 				stat_unea_five_snap_pic_prosp_monthly_inc(each_memb) = trim(stat_unea_five_snap_pic_prosp_monthly_inc(each_memb))
 				PF3
 
+				If stat_unea_five_verif_code(each_memb) = "N" Then panels_not_verif_string = panels_not_verif_string & "Income from " & stat_unea_five_type_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not verified.; "
 			End If
 
 		Next
@@ -22570,6 +22619,31 @@ class stat_detail
 				EMReadScreen stat_acct_one_type(each_memb), 2, 6, 44
 				EMReadScreen stat_acct_one_balence(each_memb), 8, 10, 46
 				EMReadScreen stat_acct_one_count_snap_yn(each_memb), 1, 14, 57
+
+				If stat_acct_one_type(each_memb) = "__" Then stat_acct_one_info(each_memb) = ""
+				If stat_acct_one_type(each_memb) = "SV" Then stat_acct_one_info(each_memb) = "Savings Account"
+				If stat_acct_one_type(each_memb) = "CK" Then stat_acct_one_info(each_memb) = "Checking Account"
+				If stat_acct_one_type(each_memb) = "CE" Then stat_acct_one_info(each_memb) = "Certificate Of Deposit"
+				If stat_acct_one_type(each_memb) = "MM" Then stat_acct_one_info(each_memb) = "Money Market"
+				If stat_acct_one_type(each_memb) = "DC" Then stat_acct_one_info(each_memb) = "Debit Card"
+				If stat_acct_one_type(each_memb) = "KO" Then stat_acct_one_info(each_memb) = "Keogh Account"
+				If stat_acct_one_type(each_memb) = "FT" Then stat_acct_one_info(each_memb) = "Federal Thrift Savings Plan"
+				If stat_acct_one_type(each_memb) = "SL" Then stat_acct_one_info(each_memb) = "Government Retirement"
+				If stat_acct_one_type(each_memb) = "RA" Then stat_acct_one_info(each_memb) = "Employee Retirement Annuities"
+				If stat_acct_one_type(each_memb) = "NP" Then stat_acct_one_info(each_memb) = "Non-Profit Employer Retirement Plans"
+				If stat_acct_one_type(each_memb) = "IR" Then stat_acct_one_info(each_memb) = "Individual Retirement Acct"
+				If stat_acct_one_type(each_memb) = "RH" Then stat_acct_one_info(each_memb) = "Roth IRA"
+				If stat_acct_one_type(each_memb) = "FR" Then stat_acct_one_info(each_memb) = "Governement Retirement"
+				If stat_acct_one_type(each_memb) = "CT" Then stat_acct_one_info(each_memb) = "Corporate Retirement Trust"
+				If stat_acct_one_type(each_memb) = "RT" Then stat_acct_one_info(each_memb) = "Retirement Fund"
+				If stat_acct_one_type(each_memb) = "QT" Then stat_acct_one_info(each_memb) = "Qualified Tuition"
+				If stat_acct_one_type(each_memb) = "CA" Then stat_acct_one_info(each_memb) = "Coverdell Savings"
+				If stat_acct_one_type(each_memb) = "OE" Then stat_acct_one_info(each_memb) = "Other Educational"
+				If stat_acct_one_type(each_memb) = "OT" Then stat_acct_one_info(each_memb) = "Other Account"
+
+				EMReadScreen stat_acct_one_count_cash_yn(each_memb), 1, 14, 50
+				EMReadScreen stat_acct_one_verif(each_memb), 1, 10, 64
+				If stat_acct_one_verif(each_memb) = "N" and stat_acct_one_count_cash_yn(each_memb) = "Y" Then panels_not_verif_string = panels_not_verif_string & "Verification of " & stat_acct_one_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22583,6 +22657,31 @@ class stat_detail
 				EMReadScreen stat_acct_two_type(each_memb), 2, 6, 44
 				EMReadScreen stat_acct_two_balence(each_memb), 8, 10, 46
 				EMReadScreen stat_acct_two_count_snap_yn(each_memb), 1, 14, 57
+
+				If stat_acct_two_type(each_memb) = "__" Then stat_acct_two_info(each_memb) = ""
+				If stat_acct_two_type(each_memb) = "SV" Then stat_acct_two_info(each_memb) = "Savings Account"
+				If stat_acct_two_type(each_memb) = "CK" Then stat_acct_two_info(each_memb) = "Checking Account"
+				If stat_acct_two_type(each_memb) = "CE" Then stat_acct_two_info(each_memb) = "Certificate Of Deposit"
+				If stat_acct_two_type(each_memb) = "MM" Then stat_acct_two_info(each_memb) = "Money Market"
+				If stat_acct_two_type(each_memb) = "DC" Then stat_acct_two_info(each_memb) = "Debit Card"
+				If stat_acct_two_type(each_memb) = "KO" Then stat_acct_two_info(each_memb) = "Keogh Account"
+				If stat_acct_two_type(each_memb) = "FT" Then stat_acct_two_info(each_memb) = "Federal Thrift Savings Plan"
+				If stat_acct_two_type(each_memb) = "SL" Then stat_acct_two_info(each_memb) = "Government Retirement"
+				If stat_acct_two_type(each_memb) = "RA" Then stat_acct_two_info(each_memb) = "Employee Retirement Annuities"
+				If stat_acct_two_type(each_memb) = "NP" Then stat_acct_two_info(each_memb) = "Non-Profit Employer Retirement Plans"
+				If stat_acct_two_type(each_memb) = "IR" Then stat_acct_two_info(each_memb) = "Individual Retirement Acct"
+				If stat_acct_two_type(each_memb) = "RH" Then stat_acct_two_info(each_memb) = "Roth IRA"
+				If stat_acct_two_type(each_memb) = "FR" Then stat_acct_two_info(each_memb) = "Governement Retirement"
+				If stat_acct_two_type(each_memb) = "CT" Then stat_acct_two_info(each_memb) = "Corporate Retirement Trust"
+				If stat_acct_two_type(each_memb) = "RT" Then stat_acct_two_info(each_memb) = "Retirement Fund"
+				If stat_acct_two_type(each_memb) = "QT" Then stat_acct_two_info(each_memb) = "Qualified Tuition"
+				If stat_acct_two_type(each_memb) = "CA" Then stat_acct_two_info(each_memb) = "Coverdell Savings"
+				If stat_acct_two_type(each_memb) = "OE" Then stat_acct_two_info(each_memb) = "Other Educational"
+				If stat_acct_two_type(each_memb) = "OT" Then stat_acct_two_info(each_memb) = "Other Account"
+
+				EMReadScreen stat_acct_two_count_cash_yn(each_memb), 1, 14, 50
+				EMReadScreen stat_acct_two_verif(each_memb), 1, 10, 64
+				If stat_acct_two_verif(each_memb) = "N" and stat_acct_two_count_cash_yn(each_memb) = "Y" Then panels_not_verif_string = panels_not_verif_string & "Verification of " & stat_acct_two_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22596,6 +22695,31 @@ class stat_detail
 				EMReadScreen stat_acct_three_type(each_memb), 2, 6, 44
 				EMReadScreen stat_acct_three_balence(each_memb), 8, 10, 46
 				EMReadScreen stat_acct_three_count_snap_yn(each_memb), 1, 14, 57
+
+				If stat_acct_three_type(each_memb) = "__" Then stat_acct_three_info(each_memb) = ""
+				If stat_acct_three_type(each_memb) = "SV" Then stat_acct_three_info(each_memb) = "Savings Account"
+				If stat_acct_three_type(each_memb) = "CK" Then stat_acct_three_info(each_memb) = "Checking Account"
+				If stat_acct_three_type(each_memb) = "CE" Then stat_acct_three_info(each_memb) = "Certificate Of Deposit"
+				If stat_acct_three_type(each_memb) = "MM" Then stat_acct_three_info(each_memb) = "Money Market"
+				If stat_acct_three_type(each_memb) = "DC" Then stat_acct_three_info(each_memb) = "Debit Card"
+				If stat_acct_three_type(each_memb) = "KO" Then stat_acct_three_info(each_memb) = "Keogh Account"
+				If stat_acct_three_type(each_memb) = "FT" Then stat_acct_three_info(each_memb) = "Federal Thrift Savings Plan"
+				If stat_acct_three_type(each_memb) = "SL" Then stat_acct_three_info(each_memb) = "Government Retirement"
+				If stat_acct_three_type(each_memb) = "RA" Then stat_acct_three_info(each_memb) = "Employee Retirement Annuities"
+				If stat_acct_three_type(each_memb) = "NP" Then stat_acct_three_info(each_memb) = "Non-Profit Employer Retirement Plans"
+				If stat_acct_three_type(each_memb) = "IR" Then stat_acct_three_info(each_memb) = "Individual Retirement Acct"
+				If stat_acct_three_type(each_memb) = "RH" Then stat_acct_three_info(each_memb) = "Roth IRA"
+				If stat_acct_three_type(each_memb) = "FR" Then stat_acct_three_info(each_memb) = "Governement Retirement"
+				If stat_acct_three_type(each_memb) = "CT" Then stat_acct_three_info(each_memb) = "Corporate Retirement Trust"
+				If stat_acct_three_type(each_memb) = "RT" Then stat_acct_three_info(each_memb) = "Retirement Fund"
+				If stat_acct_three_type(each_memb) = "QT" Then stat_acct_three_info(each_memb) = "Qualified Tuition"
+				If stat_acct_three_type(each_memb) = "CA" Then stat_acct_three_info(each_memb) = "Coverdell Savings"
+				If stat_acct_three_type(each_memb) = "OE" Then stat_acct_three_info(each_memb) = "Other Educational"
+				If stat_acct_three_type(each_memb) = "OT" Then stat_acct_three_info(each_memb) = "Other Account"
+
+				EMReadScreen stat_acct_three_count_cash_yn(each_memb), 1, 14, 50
+				EMReadScreen stat_acct_three_verif(each_memb), 1, 10, 64
+				If stat_acct_three_verif(each_memb) = "N" and stat_acct_three_count_cash_yn(each_memb) = "Y" Then panels_not_verif_string = panels_not_verif_string & "Verification of " & stat_acct_three_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22609,6 +22733,31 @@ class stat_detail
 				EMReadScreen stat_acct_four_type(each_memb), 2, 6, 44
 				EMReadScreen stat_acct_four_balence(each_memb), 8, 10, 46
 				EMReadScreen stat_acct_four_count_snap_yn(each_memb), 1, 14, 57
+
+				If stat_acct_four_type(each_memb) = "__" Then stat_acct_four_info(each_memb) = ""
+				If stat_acct_four_type(each_memb) = "SV" Then stat_acct_four_info(each_memb) = "Savings Account"
+				If stat_acct_four_type(each_memb) = "CK" Then stat_acct_four_info(each_memb) = "Checking Account"
+				If stat_acct_four_type(each_memb) = "CE" Then stat_acct_four_info(each_memb) = "Certificate Of Deposit"
+				If stat_acct_four_type(each_memb) = "MM" Then stat_acct_four_info(each_memb) = "Money Market"
+				If stat_acct_four_type(each_memb) = "DC" Then stat_acct_four_info(each_memb) = "Debit Card"
+				If stat_acct_four_type(each_memb) = "KO" Then stat_acct_four_info(each_memb) = "Keogh Account"
+				If stat_acct_four_type(each_memb) = "FT" Then stat_acct_four_info(each_memb) = "Federal Thrift Savings Plan"
+				If stat_acct_four_type(each_memb) = "SL" Then stat_acct_four_info(each_memb) = "Government Retirement"
+				If stat_acct_four_type(each_memb) = "RA" Then stat_acct_four_info(each_memb) = "Employee Retirement Annuities"
+				If stat_acct_four_type(each_memb) = "NP" Then stat_acct_four_info(each_memb) = "Non-Profit Employer Retirement Plans"
+				If stat_acct_four_type(each_memb) = "IR" Then stat_acct_four_info(each_memb) = "Individual Retirement Acct"
+				If stat_acct_four_type(each_memb) = "RH" Then stat_acct_four_info(each_memb) = "Roth IRA"
+				If stat_acct_four_type(each_memb) = "FR" Then stat_acct_four_info(each_memb) = "Governement Retirement"
+				If stat_acct_four_type(each_memb) = "CT" Then stat_acct_four_info(each_memb) = "Corporate Retirement Trust"
+				If stat_acct_four_type(each_memb) = "RT" Then stat_acct_four_info(each_memb) = "Retirement Fund"
+				If stat_acct_four_type(each_memb) = "QT" Then stat_acct_four_info(each_memb) = "Qualified Tuition"
+				If stat_acct_four_type(each_memb) = "CA" Then stat_acct_four_info(each_memb) = "Coverdell Savings"
+				If stat_acct_four_type(each_memb) = "OE" Then stat_acct_four_info(each_memb) = "Other Educational"
+				If stat_acct_four_type(each_memb) = "OT" Then stat_acct_four_info(each_memb) = "Other Account"
+
+				EMReadScreen stat_acct_four_count_cash_yn(each_memb), 1, 14, 50
+				EMReadScreen stat_acct_four_verif(each_memb), 1, 10, 64
+				If stat_acct_four_verif(each_memb) = "N" and stat_acct_four_count_cash_yn(each_memb) = "Y" Then panels_not_verif_string = panels_not_verif_string & "Verification of " & stat_acct_four_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
 			End If
 
 			EMWriteScreen stat_memb_ref_numb(each_memb), 20, 76
@@ -22622,6 +22771,31 @@ class stat_detail
 				EMReadScreen stat_acct_five_type(each_memb), 2, 6, 44
 				EMReadScreen stat_acct_five_balence(each_memb), 8, 10, 46
 				EMReadScreen stat_acct_five_count_snap_yn(each_memb), 1, 14, 57
+
+				If stat_acct_five_type(each_memb) = "__" Then stat_acct_five_info(each_memb) = ""
+				If stat_acct_five_type(each_memb) = "SV" Then stat_acct_five_info(each_memb) = "Savings Account"
+				If stat_acct_five_type(each_memb) = "CK" Then stat_acct_five_info(each_memb) = "Checking Account"
+				If stat_acct_five_type(each_memb) = "CE" Then stat_acct_five_info(each_memb) = "Certificate Of Deposit"
+				If stat_acct_five_type(each_memb) = "MM" Then stat_acct_five_info(each_memb) = "Money Market"
+				If stat_acct_five_type(each_memb) = "DC" Then stat_acct_five_info(each_memb) = "Debit Card"
+				If stat_acct_five_type(each_memb) = "KO" Then stat_acct_five_info(each_memb) = "Keogh Account"
+				If stat_acct_five_type(each_memb) = "FT" Then stat_acct_five_info(each_memb) = "Federal Thrift Savings Plan"
+				If stat_acct_five_type(each_memb) = "SL" Then stat_acct_five_info(each_memb) = "Government Retirement"
+				If stat_acct_five_type(each_memb) = "RA" Then stat_acct_five_info(each_memb) = "Employee Retirement Annuities"
+				If stat_acct_five_type(each_memb) = "NP" Then stat_acct_five_info(each_memb) = "Non-Profit Employer Retirement Plans"
+				If stat_acct_five_type(each_memb) = "IR" Then stat_acct_five_info(each_memb) = "Individual Retirement Acct"
+				If stat_acct_five_type(each_memb) = "RH" Then stat_acct_five_info(each_memb) = "Roth IRA"
+				If stat_acct_five_type(each_memb) = "FR" Then stat_acct_five_info(each_memb) = "Governement Retirement"
+				If stat_acct_five_type(each_memb) = "CT" Then stat_acct_five_info(each_memb) = "Corporate Retirement Trust"
+				If stat_acct_five_type(each_memb) = "RT" Then stat_acct_five_info(each_memb) = "Retirement Fund"
+				If stat_acct_five_type(each_memb) = "QT" Then stat_acct_five_info(each_memb) = "Qualified Tuition"
+				If stat_acct_five_type(each_memb) = "CA" Then stat_acct_five_info(each_memb) = "Coverdell Savings"
+				If stat_acct_five_type(each_memb) = "OE" Then stat_acct_five_info(each_memb) = "Other Educational"
+				If stat_acct_five_type(each_memb) = "OT" Then stat_acct_five_info(each_memb) = "Other Account"
+
+				EMReadScreen stat_acct_five_count_cash_yn(each_memb), 1, 14, 50
+				EMReadScreen stat_acct_five_verif(each_memb), 1, 10, 64
+				If stat_acct_five_verif(each_memb) = "N" and stat_acct_five_count_cash_yn(each_memb) = "Y" Then panels_not_verif_string = panels_not_verif_string & "Verification of " & stat_acct_five_info(each_memb) & " for Memb " & stat_memb_ref_numb(memb_count) & " not received.; "
 			End If
 		Next
 
@@ -24022,6 +24196,9 @@ class stat_detail
 		If stat_mont_form_recvd_date = "__/__/__" Then stat_mont_form_recvd_date = ""
 
 		Call back_to_SELF
+
+		panels_not_verif_string = trim(panels_not_verif_string)
+		If right(panels_not_verif_string, 1) = ";" Then panels_not_verif_string = left(panels_not_verif_string, len(panels_not_verif_string)-1)
 	end sub
 end class
 curr_month_plus_one = CM_plus_1_mo & "/" & CM_plus_1_yr
@@ -27940,6 +28117,19 @@ If enter_CNOTE_for_DENY = True Then
 			TEMP_VAR_deny_ga_elig_explanation = CASH_DENIAL_APPROVALS(elig_ind).deny_ga_elig_explanation
 			TEMP_VAR_deny_msa_elig_explanation = CASH_DENIAL_APPROVALS(elig_ind).deny_msa_elig_explanation
 
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_verif = "FAILED" Then
+				If TEMP_VAR_deny_dwp_elig_explanation = "" Then TEMP_VAR_deny_dwp_elig_explanation = STAT_INFORMATION(month_ind).panels_not_verif_string
+			End If
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_verif = "FAILED" Then
+				If TEMP_VAR_deny_mfip_elig_explanation = "" Then TEMP_VAR_deny_mfip_elig_explanation = STAT_INFORMATION(month_ind).panels_not_verif_string
+			End If
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_ga_reason_info = "Verification" Then
+				If TEMP_VAR_deny_ga_elig_explanation = "" Then TEMP_VAR_deny_ga_elig_explanation = STAT_INFORMATION(month_ind).panels_not_verif_string
+			End If
+			If CASH_DENIAL_APPROVALS(elig_ind).deny_msa_elig_case_test_verif = "FAILED" Then
+				If TEMP_VAR_deny_msa_elig_explanation = "" Then TEMP_VAR_deny_msa_elig_explanation = STAT_INFORMATION(month_ind).panels_not_verif_string
+			End If
+
 			call define_deny_elig_dialog
 
 			dialog Dialog1
@@ -30521,7 +30711,6 @@ If enter_CNOTE_for_SNAP = True Then
 			Call create_outlook_email("", email_recip, email_recip_CC, email_recip_bcc, email_subject, 1, False, "", "", False, "", email_body, False, "", True)
 		End If
 	End If
-
 End If
 
 If denials_found_on_pnd2 = True Then

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -1813,7 +1813,8 @@ function define_deny_elig_dialog()
 				y_pos = y_pos + 10
 			End If
 			If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_eligible_child = "FAILED" Then
-				Text 20, y_pos, 425, 10, "This household does not have a child that meets the requirements for family cash benefits."
+				If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp = "MFIP" Then Text 20, y_pos, 425, 10, "This household was assessed for MFIP as the Family Cash Program."
+				If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp <> "MFIP" Then Text 20, y_pos, 425, 10, "This household does not have a child that meets the requirements for family cash benefits."
 				y_pos = y_pos + 10
 			End If
 			If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_ES_disqualification = "FAILED" Then
@@ -1982,7 +1983,8 @@ function define_deny_elig_dialog()
 				y_pos = y_pos + 10
 			End If
 			If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_elig_child = "FAILED" Then
-				Text 20, y_pos, 425, 10, "This household does not have a child that meets the requirements for family cash benefits."
+				If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp = "DWP" Then Text 20, y_pos, 425, 10, "This household was assessed for DWP as the Family Cash Program."
+				If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp <> "DWP" Then Text 20, y_pos, 425, 10, "This household does not have a child that meets the requirements for family cash benefits."
 				y_pos = y_pos + 10
 			End If
 			If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_case_test_fail_coop = "FAILED" Then
@@ -7773,7 +7775,8 @@ function deny_elig_case_note()
 	Call write_variable_in_CASE_NOTE("RCA Denial Info  : Processed by Contracted Agency for Residents of Hennepin.")
 	'DWP
 	Call write_variable_in_CASE_NOTE("DWP Denial Info  : " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_dwp_reason_info)
-	If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" and CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_explanation <> "" Then
+	' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" and
+	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_explanation <> "" Then
 		' Call write_long_variable_in_DENY_note(CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_explanation)
 		Call write_long_variable_with_indent("    DENY Reason  : ", CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_explanation)
 	End If
@@ -7791,7 +7794,10 @@ function deny_elig_case_note()
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_CS_disqualification = "FAILED" Then Call write_variable_in_CASE_NOTE("     * The household has not complied with Child Support Requirements.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_death_of_applicant = "FAILED" Then Call write_variable_in_CASE_NOTE("     * Applicant on this case has died (" & STAT_INFORMATION(month_ind).stat_memb_date_of_death(0) & ").")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_dupl_assistance = "FAILED" Then Call write_variable_in_CASE_NOTE("     * The members of this household are receiving Cash Assistance on another case.")
-	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_eligible_child = "FAILED" Then Call write_variable_in_CASE_NOTE("     * This household does not have a child that meets the requirements for family cash benefits.")
+	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_eligible_child = "FAILED" Then
+		If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp = "MFIP" Then Call write_variable_in_CASE_NOTE("     * This household was assessed for MFIP as the Family Cash Program..")
+		If CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_or_dwp <> "MFIP" Then Call write_variable_in_CASE_NOTE("     * This household does not have a child that meets the requirements for family cash benefits.")
+	End If
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_ES_disqualification = "FAILED" Then Call write_variable_in_CASE_NOTE("     * The household has not complied with the Employment Services Requirements.")
 	If CASH_DENIAL_APPROVALS(elig_ind).deny_dwp_elig_case_test_fail_coop = "FAILED" Then
 		Call write_variable_in_CASE_NOTE("     * This household has not complied with all requirements for Family Cash Assistance.")
@@ -7862,7 +7868,8 @@ function deny_elig_case_note()
 
 	'MFIP
 	Call write_variable_in_CASE_NOTE("MFIP Denial Info : " & CASH_DENIAL_APPROVALS(elig_ind).deny_cash_mfip_reason_info)
-	If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" and CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_elig_explanation <> "" Then
+	' If CASH_DENIAL_APPROVALS(elig_ind).cash_family_or_adult = "Family" and
+	If CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_elig_explanation <> "" Then
 		' Call write_long_variable_in_DENY_note(CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_elig_explanation)
 		Call write_long_variable_with_indent("    DENY Reason  : ", CASH_DENIAL_APPROVALS(elig_ind).deny_mfip_elig_explanation)
 	End If
@@ -13265,6 +13272,7 @@ class deny_eligibility_detail
 	public deny_cash_mfip_details_exists
 	public deny_cash_msa_details_exists
 	public deny_cash_ga_details_exists
+	public deny_cash_mfip_or_dwp
 
 	public deny_dwp_elig_case_test_application_withdrawn
 	public deny_dwp_elig_case_test_assets
@@ -13613,9 +13621,15 @@ class deny_eligibility_detail
 			EMReadScreen deny_cash_mfip_reason_code, 2, 9, 46
 			EMReadScreen deny_cash_msa_reason_code, 2, 12, 46
 			EMReadScreen deny_cash_ga_reason_code, 2, 13, 46
+			deny_cash_mfip_or_dwp = ""
+			If deny_cash_dwp_reason_code = "01" and deny_cash_mfip_reason_code <> "01" Then deny_cash_mfip_or_dwp = "MFIP"
+			If deny_cash_dwp_reason_code <> "01" and deny_cash_mfip_reason_code = "01" Then deny_cash_mfip_or_dwp = "DWP"
 
 			If deny_cash_dwp_reason_code = "" Then deny_cash_dwp_reason_info = ""
-			If deny_cash_dwp_reason_code = "01" Then deny_cash_dwp_reason_info = "No Eligible Child"
+			If deny_cash_dwp_reason_code = "01" Then
+				deny_cash_dwp_reason_info = "No Eligible Child"
+				If deny_cash_mfip_or_dwp = "MFIP" Then deny_cash_dwp_reason_info = "Assessed for MFIP"
+			End If
 			If deny_cash_dwp_reason_code = "02" Then deny_cash_dwp_reason_info = "Application Withdrawn"
 			If deny_cash_dwp_reason_code = "03" Then deny_cash_dwp_reason_info = "Initial Income"
 			If deny_cash_dwp_reason_code = "04" Then deny_cash_dwp_reason_info = "Assets"
@@ -13654,7 +13668,10 @@ class deny_eligibility_detail
 			If deny_cash_dwp_reason_code = "TL" Then deny_cash_dwp_memo_info = "you have used all 60 TANF months available."
 
 			If deny_cash_mfip_reason_code = "" Then deny_cash_mfip_reason_info = ""
-			If deny_cash_mfip_reason_code = "01" Then deny_cash_mfip_reason_info = "No Eligible Child"
+			If deny_cash_mfip_reason_code = "01" Then
+				deny_cash_mfip_reason_info = "No Eligible Child"
+				If deny_cash_mfip_or_dwp = "DWP" Then deny_cash_mfip_reason_info = "Assessed for DWP"
+			End If
 			If deny_cash_mfip_reason_code = "02" Then deny_cash_mfip_reason_info = "Application Withdrawn"
 			If deny_cash_mfip_reason_code = "03" Then deny_cash_mfip_reason_info = "Initial Income"
 			If deny_cash_mfip_reason_code = "04" Then deny_cash_mfip_reason_info = "Monthly Income"


### PR DESCRIPTION
These updates for strengthen the functionality and handling of Eligibility Summary.

- Only make sure that we are entering the right case notes for cash cases, there have been instances of case notes that are in disagreement or duplicate notes.
- Add family wage level amount to the cash deny note.
- Better phrasing the cash withdraws when processed with PACT. 
- Read verifs from STAT to autofill information for Cash Deny
- Keep from duplicating WCOM lines. 

Next update will include additional edit boxes to explain case actions (FIAT, Proration, MFIP Vendor)