### PR TITLE
#1923 & #1924 Elig Summ - overlap/missing diets verbiage & msp verifs fail

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -5412,7 +5412,7 @@ function mfip_special_diet_case_note()
 	If MFIP_ELIG_APPROVALS(elig_select).MFSD_diet_info_missing = True Then
 		Call write_variable_in_CASE_NOTE("* Not all diet details are listed on STAT/DIET.")
 		If MFIP_ELIG_APPROVALS(elig_select).MFSD_missing_diet_note <> "" Then
-			Call write_variable_in_CASE_NOTE("  Additional DIET Detials: " & MFIP_ELIG_APPROVALS(elig_select).MFSD_missing_diet_note)
+			Call write_variable_in_CASE_NOTE("  Additional DIET Details: " & MFIP_ELIG_APPROVALS(elig_select).MFSD_missing_diet_note)
 		End If
 	End If
 

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -24467,7 +24467,7 @@ If (user_ID_for_validation = "CALO001" or user_ID_for_validation = "ILFE001" or 
 ' developer_mode = True
 
 Call MAXIS_background_check				'we are adding a background check to make sure the case is through background before attempting to read ELIG.
-If MAXIS_case_number = "756989" Then allow_late_note = True
+If MAXIS_case_number = "493723" Then allow_late_note = True
 Call date_array_generator(first_footer_month, first_footer_year, MONTHS_ARRAY)
 
 ex_parte_approval = False


### PR DESCRIPTION
The Elig Summ updates here are for:
1. Formatting of MFIP Special Diet NOTE - there are some oddities with diet overlap vs diet information that does not fit on the panel. 
2. There is a missing field for Medicare Savings Programs for verifications failed date and explanation.

There will be an additional pull for supporting MFIP Special Diets for multiple members on a single case but I want to get these out here quickly