### PR TITLE
#1967 ADMIN - On Demand Dashboard - remove single quote from strings

### DIFF
--- a/admin/on-demand-dashboard.vbs
+++ b/admin/on-demand-dashboard.vbs
@@ -388,6 +388,7 @@ function assign_a_case()
         case_review_notes                 = "TrackingNotes"
     End If
     end_msg = end_msg & vbCr & vbCr & "You have a case selected for review: " & MAXIS_case_number		'saving and formatting the information
+	case_review_notes = replace(case_review_notes, "'", "")								'remove any single quote from the string because it is a reserved character in SQL
     assigned_tracking_notes = "STS-IP-"&user_ID_for_validation & " " & case_review_notes
 
 	'if not a demo case, the updated information should be saved to SQL
@@ -618,7 +619,8 @@ function complete_admin_functions()
                                 case_tracking_notes = replace(case_tracking_notes, "STS-HD-"&worker_number_to_resolve, "")
                                 case_tracking_notes = replace(case_tracking_notes, "STS-RC-"&worker_number_to_resolve, "")
                                 case_tracking_notes = replace(case_tracking_notes, "STS-RC", "")
-                                case_tracking_notescase_tracking_notescase_tracking_notes = trim(case_tracking_notes)
+                                case_tracking_notes = trim(case_tracking_notes)
+								case_tracking_notes = replace(case_tracking_notes, "'", "")								'remove any single quote from the string because it is a reserved character in SQL
                                 case_tracking_notes = "STS-NR " & case_tracking_notes
                                 case_tracking_notes = trim(case_tracking_notes)
                                 Exit Do
@@ -750,6 +752,7 @@ function create_assignment_report()
 			case_review_notes = replace(case_review_notes, "STS-HD-"&user_ID_for_validation, "")
 			case_review_notes = replace(case_review_notes, "STS-RC-"&user_ID_for_validation, "")
 			case_review_notes = replace(case_review_notes, "STS-RC", "")
+			case_review_notes = replace(case_review_notes, "'", "")								'remove any single quote from the string because it is a reserved character in SQL
 			case_review_notes = trim(case_review_notes)
 
 			ObjExcel.Cells(excel_row, Worker_col).value = assigned_worker
@@ -2033,6 +2036,7 @@ If worker_on_task = True Then
         case_review_notes = replace(case_review_notes, "STS-RC-"&user_ID_for_validation, "")
         case_review_notes = replace(case_review_notes, "STS-RC", "")
         case_review_notes = trim(case_review_notes)
+		case_review_notes = replace(case_review_notes, "'", "")								'remove any single quote from the string because it is a reserved character in SQL
         case_review_notes = "STS-HD-"&user_ID_for_validation & " " & case_review_notes
         Call update_tracking_cookie("HOLD")
 	End If


### PR DESCRIPTION
When information is entered into SQL from the Dashboard - there is only one field were workers enter text free form - the tracking notes. Other string SQL fields are managed by text hard coded in the script. 

Testing ability is limited for this script as it functions on live cases from the On Demand list. No syntax errors were found. JH is scheduled for On Demand this week, I have sent her an email of the changes and to let us know any issues that arise this week. 