### PR TITLE
#1901, #43, #1942, #1971 & #1937 - LID Updates in Eligibility Summary

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -29500,23 +29500,23 @@ If enter_CNOTE_for_EMER = True Then
 		Next
 		elig_pymt = EMER_ELIG_APPROVAL.emer_elig_summ_payment *1
 		If elig_pymt <> total_payment Then
-			email_subject = "EMER Case with where EMER and CHCK do not match - Case: " & MAXIS_case_number
-			email_body = "The ELIG/EMER amount in the approval does not match the checks issued for Emergency."
-			email_body = email_body & vbCr & vbCr &"Worker: " & script_run_worker & " - " & windows_user_ID
-			email_body = email_body & vbCr & "Case Number: " & MAXIS_case_number
-			email_body = email_body & vbCr & "EMER Amount: " & EMER_ELIG_APPROVAL.emer_elig_summ_payment
-			For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)
-				If IsNumeric(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)) = True then
-					email_body = email_body & vbCr & "Check: $ " & EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck)
-				End If
-			Next
-			email_body = email_body & vbCr & "EMER Eligible"
-			email_body = email_body & vbCr & ""
-			email_body = email_body & vbCr & "Email generated from the NOTES - Eligibility Summary Script, run at " & now
+			' email_subject = "EMER Case with where EMER and CHCK do not match - Case: " & MAXIS_case_number
+			' email_body = "The ELIG/EMER amount in the approval does not match the checks issued for Emergency."
+			' email_body = email_body & vbCr & vbCr &"Worker: " & script_run_worker & " - " & windows_user_ID
+			' email_body = email_body & vbCr & "Case Number: " & MAXIS_case_number
+			' email_body = email_body & vbCr & "EMER Amount: " & EMER_ELIG_APPROVAL.emer_elig_summ_payment
+			' For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)
+			' 	If IsNumeric(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)) = True then
+			' 		email_body = email_body & vbCr & "Check: $ " & EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck)
+			' 	End If
+			' Next
+			' email_body = email_body & vbCr & "EMER Eligible"
+			' email_body = email_body & vbCr & ""
+			' email_body = email_body & vbCr & "Email generated from the NOTES - Eligibility Summary Script, run at " & now
 
-			email_recip = "hsph.ews.bluezonescripts@hennepin.us"
-			email_recip_CC = ""
-			Call create_outlook_email("", email_recip, email_recip_CC, email_recip_bcc, email_subject, 1, False, "", "", False, "", email_body, False, "", True)
+			' email_recip = "hsph.ews.bluezonescripts@hennepin.us"
+			' email_recip_CC = ""
+			' Call create_outlook_email("", email_recip, email_recip_CC, email_recip_bcc, email_subject, 1, False, "", "", False, "", email_body, False, "", True)
 
 			EMER_ELIG_APPROVAL.emer_elig_summ_payment = total_payment
 

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -28920,6 +28920,29 @@ If enter_CNOTE_for_HC = True Then		'HC DIALOG
 
 												If budget_without_remedial_care = "No, stop the script so ELIG can be updated and ReApproved." Then
 													If QCR_HC_Remedial_Care_Review_Needed = True Then
+														If MX_region <> "TRAINING" Then
+															'RECORD QCR Cookie here
+															txt_file_name = "HC_Remedial_Care_" & MAXIS_case_number & "_" & windows_user_ID & "_" & replace(replace(replace(now, "/", "_"),":", "_")," ", "_") & ".txt"
+															qcr_file_path = t_drive & "\Eligibility Support\Assignments\QCR Logs\" & txt_file_name
+
+															'CREATING THE TESTING REPORT
+															With (CreateObject("Scripting.FileSystemObject"))
+																'Creating an object for the stream of text which we'll use frequently
+																Set objTextStream = .OpenTextFile(qcr_file_path, ForWriting, true)
+
+																objTextStream.WriteLine "WorkerNumber^&*^&*" & windows_user_ID
+																objTextStream.WriteLine "WorkerName^&*^&*" & script_run_worker
+																objTextStream.WriteLine "RunDateTime^&*^&*" & now
+																objTextStream.WriteLine "Case Number^&*^&*" & MAXIS_case_number
+																objTextStream.WriteLine "ELIGProgram^&*^&*HC"
+																objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(HC_UNIQUE_APPROVALS(months_in_approval, 0), 5)
+																objTextStream.WriteLine "HCBudgNoRemedialCareInput^&*^&*MEMB " & budget_without_remedial_care
+																objTextStream.WriteLine "POLICY^&*^&*EPM 2.4.2.5.1"
+
+																objTextStream.Close
+															End With
+														End If
+
 														email_subject = "TEST - HC Case in FACI Type (55 or 56): " & MAXIS_case_number
 														email_body = "A case was processed that appears to have Health Care and an OPEN FACI of Type 55 or 56."
 														email_body = email_body & vbCr & "budget_without_remedial_care: " & budget_without_remedial_care
@@ -30237,7 +30260,7 @@ if enter_CNOTE_for_MSA = True Then
 				objTextStream.WriteLine "RunDateTime^&*^&*" & now
 				objTextStream.WriteLine "Case Number^&*^&*" & MAXIS_case_number
 				objTextStream.WriteLine "ELIGProgram^&*^&*MSA with Shelter Needy"
-				objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(SNAP_UNIQUE_APPROVALS(months_in_approval, 0), 5)
+				objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(MSA_UNIQUE_APPROVALS(months_in_approval, 0), 5)
 				objTextStream.WriteLine "ShelterNeedyAmount^&*^&*" & trim(QCR_MSA_Shelter_Needy_Amount)
 
 				objTextStream.Close
@@ -30260,7 +30283,7 @@ if enter_CNOTE_for_MSA = True Then
 				objTextStream.WriteLine "RunDateTime^&*^&*" & now
 				objTextStream.WriteLine "Case Number^&*^&*" & MAXIS_case_number
 				objTextStream.WriteLine "ELIGProgram^&*^&*MSA with UNEA 44"
-				objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(SNAP_UNIQUE_APPROVALS(months_in_approval, 0), 5)
+				objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(MSA_UNIQUE_APPROVALS(months_in_approval, 0), 5)
 				objTextStream.WriteLine "UNEA44Membs^&*^&*MEMB " & replace(trim(QCR_MSA_SSI_Ended_String), " ", ", MEMB ")
 
 				objTextStream.Close
@@ -31413,6 +31436,29 @@ If list_active_programs = "" and list_pending_programs = "" Then end_msg_info = 
 end_msg_info = end_msg_info & "Eligibility Approvals review and documentation script run is complete."
 
 If QCR_HC_Remedial_Care_Review_Needed = True Then
+	If MX_region <> "TRAINING" Then
+		'RECORD QCR Cookie here
+		txt_file_name = "HC_Remedial_Care_" & MAXIS_case_number & "_" & windows_user_ID & "_" & replace(replace(replace(now, "/", "_"),":", "_")," ", "_") & ".txt"
+		qcr_file_path = t_drive & "\Eligibility Support\Assignments\QCR Logs\" & txt_file_name
+
+		'CREATING THE TESTING REPORT
+		With (CreateObject("Scripting.FileSystemObject"))
+			'Creating an object for the stream of text which we'll use frequently
+			Set objTextStream = .OpenTextFile(qcr_file_path, ForWriting, true)
+
+			objTextStream.WriteLine "WorkerNumber^&*^&*" & windows_user_ID
+			objTextStream.WriteLine "WorkerName^&*^&*" & script_run_worker
+			objTextStream.WriteLine "RunDateTime^&*^&*" & now
+			objTextStream.WriteLine "Case Number^&*^&*" & MAXIS_case_number
+			objTextStream.WriteLine "ELIGProgram^&*^&*HC"
+			objTextStream.WriteLine "InitialELIGMonthInPackage^&*^&*" & left(HC_UNIQUE_APPROVALS(months_in_approval, 0), 5)
+			objTextStream.WriteLine "HCBudgNoRemedialCareInput^&*^&*MEMB " & budget_without_remedial_care
+			objTextStream.WriteLine "POLICY^&*^&*EPM 2.4.2.5.1"
+
+			objTextStream.Close
+		End With
+	End If
+
 	email_subject = "TEST - HC Case in FACI Type (55 or 56): " & MAXIS_case_number
 	email_body = "A case was processed that appears to have Health Care and an OPEN FACI of Type 55 or 56."
 	email_body = email_body & vbCr & "budget_without_remedial_care: " & budget_without_remedial_care

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -3684,16 +3684,24 @@ function define_emer_elig_dialog()
 	Dialog1 = ""
 	BeginDialog Dialog1, 0, 0, 555, 385, "EMER Approval"
 		If EMER_ELIG_APPROVAL.emer_elig_summ_eligibility_result = "ELIGIBLE" Then
-			GroupBox 5, 10, 425, 105, "Approval Detail for " & EMER_ELIG_APPROVAL.emer_program & " - ELIGIBLE for $ " & EMER_ELIG_APPROVAL.emer_elig_summ_payment
-			y_pos = 40
+			GroupBox 5, 10, 425, 110, "Approval Detail for " & EMER_ELIG_APPROVAL.emer_program & " - ELIGIBLE for $ " & EMER_ELIG_APPROVAL.emer_elig_summ_payment
+			y_pos = 35
 			If EMER_ELIG_APPROVAL.mony_check_found = True Then
 				Text 15, 25, 250, 10, "MONY/CHCK Issued for Emergency Assistance:"
 				For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)
 					Text 20, y_pos, 400, 10, "$ " & EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck) & " to " & EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck) & " for " & EMER_ELIG_APPROVAL.emer_check_payment_reason(each_chck) & " - EMER Program: " & EMER_ELIG_APPROVAL.emer_check_program(each_chck)
 					y_pos = y_pos + 10
-					If Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "XCEL") <> 0 OR Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "NSP") <> 0 Then
-						Text 30, y_pos+5, 85, 10, "XCEL Account Number:"
-						EditBox 115, y_pos, 75, 15, emer_excel_account_number
+					If Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "XCEL") <> 0 OR Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "NSP") <> 0 OR Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "CENTER POINT ENERGY") <> 0 Then
+						acct_numb_labels = " Account Number:"
+						If Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "XCEL") <> 0 Then
+							acct_numb_labels = "XCEL" & acct_numb_labels
+						ElseIf Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "NSP") <> 0 Then
+							acct_numb_labels = "NSP" & acct_numb_labels
+						ElseIf Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "CENTER POINT ENERGY") <> 0 Then
+							acct_numb_labels = "CP" & acct_numb_labels
+						End If
+						Text 30, y_pos+5, 85, 10, acct_numb_labels
+						EditBox 115, y_pos, 75, 15, emer_excel_account_number(each_chck)
 						y_pos = y_pos + 20
 
 					End If
@@ -3707,10 +3715,10 @@ function define_emer_elig_dialog()
 				EditBox 95, y_pos, 325, 15, TEMP_bus_ticket_info
 				y_pos = y_pos + 20
 			End If
-			Text 15, 80, 250, 10, "Emergency Begin Date: " & EMER_ELIG_APPROVAL.emer_elig_summ_begin_date & " - Emergency End Date: " & EMER_ELIG_APPROVAL.emer_elig_summ_end_date
-			Text 15, 90, 150, 10, "Household: Adults - " & EMER_ELIG_APPROVAL.emer_elig_summ_adults_in_unit & ", Children - " & EMER_ELIG_APPROVAL.emer_elig_summ_children_in_unit
-			If EMER_ELIG_APPROVAL.emer_elig_summ_last_used <> "" Then Text 15, 100, 150, 10, EMER_ELIG_APPROVAL.emer_program & " last used: " & EMER_ELIG_APPROVAL.emer_elig_summ_last_used
-			If EMER_ELIG_APPROVAL.emer_elig_summ_last_used = "" Then Text 15, 100, 150, 10, EMER_ELIG_APPROVAL.emer_program & " last used: Never"
+			Text 15, y_pos, 250, 10, "Emergency Begin Date: " & EMER_ELIG_APPROVAL.emer_elig_summ_begin_date & " - Emergency End Date: " & EMER_ELIG_APPROVAL.emer_elig_summ_end_date
+			Text 15, y_pos+10, 150, 10, "Household: Adults - " & EMER_ELIG_APPROVAL.emer_elig_summ_adults_in_unit & ", Children - " & EMER_ELIG_APPROVAL.emer_elig_summ_children_in_unit
+			If EMER_ELIG_APPROVAL.emer_elig_summ_last_used <> "" Then Text 285, y_pos, 100, 10, EMER_ELIG_APPROVAL.emer_program & " last used: " & EMER_ELIG_APPROVAL.emer_elig_summ_last_used
+			If EMER_ELIG_APPROVAL.emer_elig_summ_last_used = "" Then Text 285, y_pos, 100, 10, EMER_ELIG_APPROVAL.emer_program & " last used: Never"
 
 			GroupBox 5, 125, 535, 90, "Emergency"
 			Text 15, 140, 85, 10, "Emergency to Resolve:"
@@ -7472,8 +7480,8 @@ function emer_elig_case_note()
 		If EMER_ELIG_APPROVAL.mony_check_found = True Then
 			Call write_variable_in_CASE_NOTE("============================= MONY/CHCK ISSUED ==============================")
 			For each_chck = 0 to UBound(EMER_ELIG_APPROVAL.emer_check_program)
-				If Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "XCEL") = 0 AND Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "NSP") = 0 Then Call write_variable_in_CASE_NOTE("$ " & left(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)&"        ", 8) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck) & " to " & EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck))
-				If Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "XCEL") <> 0 OR Instr(EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck), "NSP") <> 0 Then Call write_variable_in_CASE_NOTE("$ " & left(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)&"        ", 8) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck) & " to " & EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck) & " for " & emer_excel_account_number)
+				If emer_excel_account_number(each_chck) = "" Then Call write_variable_in_CASE_NOTE("$ " & left(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)&"        ", 8) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck) & " to " & EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck))
+				If emer_excel_account_number(each_chck) <> "" Then Call write_variable_in_CASE_NOTE("$ " & left(EMER_ELIG_APPROVAL.emer_check_transaction_amount(each_chck)&"        ", 8) & " issued on " & EMER_ELIG_APPROVAL.emer_check_issue_date(each_chck) & " to " & EMER_ELIG_APPROVAL.emer_check_payment_to_name(each_chck) & " for " & emer_excel_account_number(each_chck))
 				Call write_variable_in_CASE_NOTE("           for " & EMER_ELIG_APPROVAL.emer_check_payment_reason(each_chck) & " - PROGRAM: " & EMER_ELIG_APPROVAL.emer_check_program(each_chck))
 			Next
 		End If
@@ -29452,7 +29460,7 @@ If enter_CNOTE_for_EMER = True Then
 	emer_ongoing_shelter_expense = ""
 	emer_ongoing_utility_expense = ""
 	emer_past_30_days_income = ""
-	emer_excel_account_number = ""
+	Dim emer_excel_account_number()
 	emer_available_assets = ""
 	emer_emer_resolve_notes = ""
 
@@ -29466,6 +29474,9 @@ If enter_CNOTE_for_EMER = True Then
 	TEMP_bus_ticket_info = EMER_ELIG_APPROVAL.bus_ticket_detail
 	If EMER_ELIG_APPROVAL.bus_ticket_approval = True Then emer_bus_checkbox = checked
 	If EMER_ELIG_APPROVAL.emer_elig_case_test_verif = "FAILED" Then emer_test_verif_detail = verifs_in_case_note
+
+	check_numb_ubound = UBound(EMER_ELIG_APPROVAL.emer_check_program)
+	ReDim emer_excel_account_number(check_numb_ubound)
 
 	'Identifies if the approval amount in ELIG/EMER is different from the total of MONY/CHCKs issued.
 	'We are prioritizing the amount in MONY/CHCK as that is the amount that will actually issue on the behalf of the resident.

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -29500,6 +29500,8 @@ If enter_CNOTE_for_EMER = True Then
 		Next
 		elig_pymt = EMER_ELIG_APPROVAL.emer_elig_summ_payment *1
 		If elig_pymt <> total_payment Then
+			'This functionality checks to see if the payment amount listed in EMER matches the total from the checks - if it does not, an email is sent.
+			'Currently commented out as process analysis is on pause.
 			' email_subject = "EMER Case with where EMER and CHCK do not match - Case: " & MAXIS_case_number
 			' email_body = "The ELIG/EMER amount in the approval does not match the checks issued for Emergency."
 			' email_body = email_body & vbCr & vbCr &"Worker: " & script_run_worker & " - " & windows_user_ID

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -19145,6 +19145,7 @@ class stat_detail
 	public stat_memb_rel_to_applct_info()
 	public stat_memb_date_of_death()
 	public stat_memi_spouse_ref_numb()
+	public stat_memi_military_service_yn()
 	public stat_memi_citizenship_yn()
 	public stat_memi_citizenship_verif_code()
 	public stat_memi_citizenship_verif_info()
@@ -19958,6 +19959,7 @@ class stat_detail
 		ReDim stat_memb_rel_to_applct_info(0)
 		ReDim stat_memb_date_of_death(0)
 		ReDim stat_memi_spouse_ref_numb(0)
+		ReDim stat_memi_military_service_yn(0)
 		ReDim stat_memi_citizenship_yn(0)
 		ReDim stat_memi_citizenship_verif_code(0)
 		ReDim stat_memi_citizenship_verif_info(0)
@@ -20636,6 +20638,7 @@ class stat_detail
 			ReDim preserve stat_memb_rel_to_applct_info(memb_count)
 			ReDim preserve stat_memb_date_of_death(memb_count)
 			ReDim preserve stat_memi_spouse_ref_numb(memb_count)
+			ReDim preserve stat_memi_military_service_yn(memb_count)
 			ReDim preserve stat_memi_citizenship_yn(memb_count)
 			ReDim preserve stat_memi_citizenship_verif_code(memb_count)
 			ReDim preserve stat_memi_citizenship_verif_info(memb_count)
@@ -21365,6 +21368,7 @@ class stat_detail
 
 			EMReadScreen stat_memi_citizenship_yn(each_memb), 1, 11, 49
 			EMReadScreen stat_memi_citizenship_verif_code(each_memb), 2, 11, 78
+			EMReadScreen stat_memi_military_service_yn(memb_count), 1, 12, 78
 
 			If stat_memi_citizenship_verif_code(each_memb) = "BC" Then stat_memi_citizenship_verif_info(each_memb) = "Birth Certificate"
 			If stat_memi_citizenship_verif_code(each_memb) = "RE" Then stat_memi_citizenship_verif_info(each_memb) = "Religious Record"
@@ -30773,7 +30777,7 @@ If enter_CNOTE_for_SNAP = True Then
 					If SNAP_ELIG_APPROVALS(each_month).elig_footer_month & "/" & SNAP_ELIG_APPROVALS(each_month).elig_footer_year = STAT_INFORMATION(stat_month).footer_month & "/" & STAT_INFORMATION(stat_month).footer_year Then
 						For each_memb = 0 to UBound(STAT_INFORMATION(month_ind).stat_memb_ref_numb)
 							If InStr(SNAP_ELIG_APPROVALS(elig_ind).elig_membs_list, STAT_INFORMATION(month_ind).stat_memb_ref_numb(each_memb)) <> 0 Then
-								If STAT_INFORMATION(month_ind).stat_wreg_fset_status_code(each_memb) = "30" and STAT_INFORMATION(month_ind).stat_wreg_abawd_status_code(each_memb) = "09" Then
+								If STAT_INFORMATION(month_ind).stat_wreg_fset_status_code(each_memb) = "30" and STAT_INFORMATION(month_ind).stat_wreg_abawd_status_code(each_memb) = "09" and STAT_INFORMATION(month_ind).stat_memi_military_service_yn(each_memb) <> "Y" Then
 									If InStr(QCR_SNAP_ABAWD_30_09_String, STAT_INFORMATION(month_ind).stat_memb_ref_numb(each_memb)) = 0 Then
 										QCR_SNAP_ABAWD_30_09_String = QCR_SNAP_ABAWD_30_09_String & STAT_INFORMATION(month_ind).stat_memb_ref_numb(each_memb) & " "
 									End If


### PR DESCRIPTION
Updates:
- Read Military Service field in STAT and add to logic for WREG 30/09 Reviews
- Include an EditBox in MFIP Ineligible processing to address SNAP assessment
- Include the ability to add energy account number for vendor 44
- Add a QCR for UHFS Shelter Expense issue
- Add QCR for MSA UNEA 44 and Shelter Needy

Most of these updates will happen in the background and workers will not notice the differences. Additional functionality to assess the QCR reports. 