### PR TITLE
#2064 function start_a_blank_case_note - Check if case note already open and open a new case note if needed

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -13212,6 +13212,12 @@ function start_a_blank_CASE_NOTE()
 	call navigate_to_MAXIS_screen("CASE", "NOTE")
 	DO
 		PF9
+		EMReadScreen case_note_opened_already, 31, 24, 2
+		If case_note_opened_already = "PF9 IS NOT IN USE ON THIS PANEL" Then
+			'PF3 back to case note and then open a new CASE/NOTE
+			PF3
+			PF9
+		End If
 		EMReadScreen case_note_open_check, 8, 1, 72
 		If case_note_open_check <> "FMCAMAM2" then
 			'Check MAXIS mode


### PR DESCRIPTION
Add functionality to start_a_blank_case_note to check if already on new or existing case note. If already on case note then it PF3s and then PF9s to open a blank case note. User had reported issues with scripts not correctly creating a case note when they were already in a case note.