### PR TITLE
#2017 DAIL SCRUBBER - DAIL Reference Script, handling for SDX MATCH 

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -5235,7 +5235,7 @@ script_array(script_num).usage_eval				= ""
 script_num = script_num + 1						'Increment by one
 ReDim Preserve script_array(script_num)			'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie		'Set this array element to be a new script_bowie. Script details below...
-script_array(script_num).script_name 			= "SDX MATCH"																		'Script name
+script_array(script_num).script_name 			= "SDX Match"																		'Script name
 ' script_array(script_num).description 			= "Opens a dialog with links to policy information for processing DAIL messages."
 script_array(script_num).category               = "DAIL"
 script_array(script_num).workflows              = ""

--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -5235,6 +5235,22 @@ script_array(script_num).usage_eval				= ""
 script_num = script_num + 1						'Increment by one
 ReDim Preserve script_array(script_num)			'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie		'Set this array element to be a new script_bowie. Script details below...
+script_array(script_num).script_name 			= "SDX MATCH"																		'Script name
+' script_array(script_num).description 			= "Opens a dialog with links to policy information for processing DAIL messages."
+script_array(script_num).category               = "DAIL"
+script_array(script_num).workflows              = ""
+script_array(script_num).tags                   = array("Adult Cash", "Health Care", "HS/GRH", "Income", "LTC", "SNAP")
+script_array(script_num).dlg_keys               = array("")
+script_array(script_num).subcategory            = array("")
+script_array(script_num).release_date           = #11/06/2024#
+script_array(script_num).hot_topic_link			= ""
+script_array(script_num).used_for_elig			= False
+script_array(script_num).policy_references		= array("CM Interim_Assistance_Agreements 12.12.03", "Interim_Assistance_Reimbursement_Interface 02.12.14")						'SEE Line 58 for format'
+script_array(script_num).usage_eval				= ""
+
+script_num = script_num + 1						'Increment by one
+ReDim Preserve script_array(script_num)			'Resets the array to add one more element to it
+Set script_array(script_num) = new script_bowie		'Set this array element to be a new script_bowie. Script details below...
 script_array(script_num).script_name 			= "TPQY Response"																		'Script name
 ' script_array(script_num).description 			= "Jumps to SVES/TPQY for the case which has received a response."
 script_array(script_num).category               = "DAIL"

--- a/dail/dail-scrubber.vbs
+++ b/dail/dail-scrubber.vbs
@@ -340,6 +340,11 @@ If instr(full_message, "SDX INFORMATION HAS BEEN STORED - CHECK INFC") then
 	call run_from_GitHub(script_repository & "dail/sdx-info-has-been-stored.vbs")
 END IF
 
+'SDX match (provides reference information for properly processing message)
+If instr(full_message, "SDX MATCH - SSI PENDING - MAXIS CREATED PBEN - IAA NEEDED") or instr(full_message, "SDX MATCH - SSI PENDING - IAA NEEDED") then
+	call run_from_GitHub(script_repository & "dail/sdx-match.vbs")
+END IF
+
 'SSA info received by agency (loads TPQY RESPONSE)
 If instr(full_message, "TPQY RESPONSE RECEIVED FROM SSA") or instr(full_message, "COVERED QTRS RESPONSE RECEIVED FROM SSA") then
     call run_from_GitHub(script_repository & "dail/tpqy-response.vbs")

--- a/dail/sdx-match.vbs
+++ b/dail/sdx-match.vbs
@@ -1,5 +1,5 @@
 'STATS GATHERING=============================================================================================================
-name_of_script = "TYPE - NEW SCRIPT TEMPLATE.vbs"       'REPLACE TYPE with either ACTIONS, BULK, DAIL, NAV, NOTES, NOTICES, or UTILITIES. The name of the script should be all caps. The ".vbs" should be all lower case.
+name_of_script = "DAIL - SDX Match.vbs"
 start_time = timer
 STATS_counter = 1               'sets the stats counter at one
 STATS_manualtime = 1            'manual run time in seconds  -----REPLACE STATS_MANUALTIME = 1 with the anctual manualtime based on time study
@@ -58,19 +58,21 @@ full_message = trim(full_message)
 
 Dialog1 = "" 'blanking out dialog name
 
-BeginDialog Dialog1, 0, 0, 281, 135, "DAIL - SDX Match"
+BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - SDX Match"
   ButtonGroup ButtonPressed
-    PushButton 5, 45, 55, 15, "CM 0012.12.03", combined_manual_btn
-    PushButton 5, 65, 55, 15, "TE 02.12.14", poli_temp_btn
-    PushButton 5, 85, 55, 15, "HSR Manual", hsr_manual_btn
-    OkButton 170, 115, 50, 15
-    CancelButton 225, 115, 50, 15
+    PushButton 5, 45, 65, 15, "CM 0012.12.03", combined_manual_btn
+    PushButton 5, 65, 65, 15, "TE 02.12.14", poli_temp_btn
+    PushButton 5, 85, 65, 15, "HSR Manual", hsr_manual_btn
+    PushButton 5, 105, 65, 15, "Script Instructions", script_instructions_btn
+    OkButton 205, 135, 50, 15
+    CancelButton 255, 135, 50, 15
   Text 5, 5, 55, 10, "DAIL Message - "
-  Text 60, 5, 210, 10, full_message
-  Text 5, 20, 270, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/procedures for information on how to process:"
-  Text 65, 50, 95, 10, "Link to Combined Manual"
-  Text 65, 70, 75, 10, "Link to POLI/TEMP"
-  Text 65, 90, 85, 10, "Link to HSR Manual"
+  Text 60, 5, 245, 10, full_message
+  Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
+  Text 75, 50, 95, 10, "Link to Combined Manual"
+  Text 75, 70, 75, 10, "Link to POLI/TEMP"
+  Text 75, 90, 85, 10, "Link to HSR Manual"
+  Text 75, 110, 85, 10, "Link to Script Instructions"
 EndDialog
 
 DO
@@ -90,6 +92,10 @@ DO
 			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/INFO.aspx#sdx-match-ssi-pending-maxis-created-pben-iaa-needed-*"
 			err_msg = "LOOP"
 		End If
+		If ButtonPressed = script_instructions_btn Then 
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/_layouts/15/Doc.aspx?sourcedoc=%7B7D2E3349-1333-4628-B572-754EED31AFB4%7D&file=DAIL%20-%20SDX%20MATCH.docx"
+			err_msg = "LOOP"
+		End If
     Loop until err_msg = ""
     CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
@@ -97,3 +103,51 @@ LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 
 'End the script.
 script_end_procedure("Please follow the instructions provided in the Combined Manual, POLI/TEMP, and/or HSR Manual. The script will now end.")
+
+'----------------------------------------------------------------------------------------------------Closing Project Documentation - Version date 05/23/2024
+'------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------
+'
+'------Dialogs--------------------------------------------------------------------------------------------------------------------
+'--Dialog1 = "" on all dialogs -------------------------------------------------11/06/2024
+'--Tab orders reviewed & confirmed----------------------------------------------11/06/2024
+'--Mandatory fields all present & Reviewed--------------------------------------11/06/2024
+'--All variables in dialog match mandatory fields-------------------------------11/06/2024
+'Review dialog names for content and content fit in dialog----------------------11/06/2024
+'--FIRST DIALOG--NEW EFF 5/23/2024----------------------------------------------11/06/2024
+'--Include script category and name somewhere on first dialog-------------------11/06/2024
+'--Create a button to reference instructions------------------------------------11/06/2024
+'
+'-----CASE:NOTE-------------------------------------------------------------------------------------------------------------------
+'--All variables are CASE:NOTEing (if required)---------------------------------N/A
+'--CASE:NOTE Header doesn't look funky------------------------------------------N/A
+'--Leave CASE:NOTE in edit mode if applicable-----------------------------------N/A
+'--write_variable_in_CASE_NOTE function: confirm that proper punctuation is used -----------------------------------
+'
+'-----General Supports-------------------------------------------------------------------------------------------------------------
+'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------11/06/2024
+'--MAXIS_background_check reviewed (if applicable)------------------------------11/06/2024
+'--PRIV Case handling reviewed -------------------------------------------------11/06/2024
+'--Out-of-County handling reviewed----------------------------------------------11/06/2024
+'--script_end_procedures (w/ or w/o error messaging)----------------------------11/06/2024
+'--BULK - review output of statistics and run time/count (if applicable)--------N/A
+'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------11/06/2024
+'
+'-----Statistics--------------------------------------------------------------------------------------------------------------------
+'--Manual time study reviewed --------------------------------------------------11/06/2024
+'--Incrementors reviewed (if necessary)-----------------------------------------11/06/2024
+'--Denomination reviewed -------------------------------------------------------11/06/2024
+'--Script name reviewed---------------------------------------------------------11/06/2024
+'--BULK - remove 1 incrementor at end of script reviewed------------------------11/06/2024
+
+'-----Finishing up------------------------------------------------------------------------------------------------------------------
+'--Confirm all GitHub tasks are complete----------------------------------------11/06/2024
+'--comment Code-----------------------------------------------------------------11/06/2024
+'--Update Changelog for release/update------------------------------------------11/06/2024
+'--Remove testing message boxes-------------------------------------------------11/06/2024
+'--Remove testing code/unnecessary code-----------------------------------------11/06/2024
+'--Review/update SharePoint instructions----------------------------------------11/06/2024
+'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------11/06/2024
+'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------11/06/2024
+'--COMPLETE LIST OF SCRIPTS update policy references----------------------------11/06/2024
+'--Complete misc. documentation (if applicable)---------------------------------11/06/2024
+'--Update project team/issue contact (if applicable)----------------------------11/06/2024

--- a/dail/sdx-match.vbs
+++ b/dail/sdx-match.vbs
@@ -1,5 +1,5 @@
 'STATS GATHERING=============================================================================================================
-name_of_script = "DAIL - SDX Match.vbs"
+name_of_script = "DAIL - SDX MATCH.vbs"
 start_time = timer
 STATS_counter = 1               'sets the stats counter at one
 STATS_manualtime = 1            'manual run time in seconds  -----REPLACE STATS_MANUALTIME = 1 with the anctual manualtime based on time study

--- a/dail/sdx-match.vbs
+++ b/dail/sdx-match.vbs
@@ -1,0 +1,151 @@
+'STATS GATHERING=============================================================================================================
+name_of_script = "TYPE - NEW SCRIPT TEMPLATE.vbs"       'REPLACE TYPE with either ACTIONS, BULK, DAIL, NAV, NOTES, NOTICES, or UTILITIES. The name of the script should be all caps. The ".vbs" should be all lower case.
+start_time = timer
+STATS_counter = 1               'sets the stats counter at one
+STATS_manualtime = 1            'manual run time in seconds  -----REPLACE STATS_MANUALTIME = 1 with the anctual manualtime based on time study
+STATS_denomination = "C"        'C is for each case; I is for Instance, M is for member; REPLACE with the denomonation appliable to your script.
+'END OF stats block==========================================================================================================
+
+'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
+IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
+	IF run_locally = FALSE or run_locally = "" THEN	   'If the scripts are set to run locally, it skips this and uses an FSO below.
+		IF use_master_branch = TRUE THEN			   'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		Else											'Everyone else should use the release branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		End if
+		SET req = CreateObject("Msxml2.XMLHttp.6.0")				'Creates an object to get a FuncLib_URL
+		req.open "GET", FuncLib_URL, FALSE							'Attempts to open the FuncLib_URL
+		req.send													'Sends request
+		IF req.Status = 200 THEN									'200 means great success
+			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
+			Execute req.responseText								'Executes the script code
+		ELSE														'Error message
+			critical_error_msgbox = MsgBox ("Something has gone wrong. The Functions Library code stored on GitHub was not able to be reached." & vbNewLine & vbNewLine &_
+                                            "FuncLib URL: " & FuncLib_URL & vbNewLine & vbNewLine &_
+                                            "The script has stopped. Please check your Internet connection. Consult a scripts administrator with any questions.", _
+                                            vbOKonly + vbCritical, "BlueZone Scripts Critical Error")
+            StopScript
+		END IF
+	ELSE
+		FuncLib_URL = "C:\MAXIS-scripts\MASTER FUNCTIONS LIBRARY.vbs"
+		Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")
+		Set fso_command = run_another_script_fso.OpenTextFile(FuncLib_URL)
+		text_from_the_other_script = fso_command.ReadAll
+		fso_command.Close
+		Execute text_from_the_other_script
+	END IF
+END IF
+'END FUNCTIONS LIBRARY BLOCK================================================================================================
+
+'CHANGELOG BLOCK===========================================================================================================
+'Starts by defining a changelog array
+changelog = array()
+
+'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
+'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County
+CALL changelog_update("01/01/01", "Initial version.", "Ilse Ferris, Hennepin County") 'REPLACE with release date and your name.
+
+'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
+changelog_display
+'END CHANGELOG BLOCK =======================================================================================================
+
+'THE SCRIPT==================================================================================================================
+EMConnect "" 'Connects to BlueZone
+CALL MAXIS_case_number_finder(MAXIS_case_number)    				'Grabs the MAXIS case number automatically
+Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)		'Grabs the footer month and year from MAXIS
+'  -- OR --
+MAXIS_footer_month = CM_plus_1_mo									'Directly assigns a footer month based on the current month
+MAXIS_footer_year = CM_plus_1_yr
+
+Dialog1 = "" 'blanking out dialog name
+'Add dialog here: Add the dialog just before calling the dialog below unless you need it in the dialog due to using COMBO Boxes or other looping reasons. Blank out the dialog name with Dialog1 = "" before adding dialog.
+'    Some Dialog Elements:  Initial Dialog Header: 			BeginDialog Dialog1, 0, 0, 191, 105, "CATEGORY - NAME Case Number Dialog"  				-- Use CATEGORY - NAME somewhere in the header
+'							Script Instructions Button:		PushButton 135, 5, 50, 15, "Instructions", script_instructions_btn						-- Have a button to open the instructions
+'							Script Purpose/Overview: 		Text 10, 70, 120, 30, "Here is a quick summary of the purpose of the script."			-- Give the worker a little guidance
+'							Include edit boxes for necessary details like Case Number, Footer Month, Footer Year, and Worker Signature
+'Shows dialog (replace "sample_dialog" with the actual dialog you entered above)----------------------------------
+DO
+    Do
+        err_msg = ""    'This is the error message handling
+        Dialog Dialog1
+        cancel_confirmation or cancel_without_confirmation
+        'Add in all of your mandatory field handling from your dialog here.
+        Call validate_MAXIS_case_number(err_msg, "*") ' IF NEEDED
+        Call validate_footer_month_entry(MAXIS_footer_month, MAXIS_footer_year, err_msg, "*")   'IF NEEDED
+        'The rest of the mandatory handling here
+        IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note." 'IF NEEDED
+		If ButtonPressed = script_instructions_btn Then
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/CATEGORY/CATEGORY%20-%20NAME.docx"	'copy the instructions URL here
+			err_msg = "LOOP"
+		End If
+        IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
+    Loop until err_msg = ""
+    'Add to all dialogs where you need to work within BLUEZONE
+    CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+'End dialog section-----------------------------------------------------------------------------------------------
+
+'Checks to see if in MAXIS
+CALL check_for_MAXIS(True) or Call check_for_MAXIS(False)
+
+'Reset to SELF to check the MAXIS region
+'This is also helpful to ensure we are not starting in a CASE/NOTE or something
+Call back_to_SELF
+Call clear_line_of_text(18, 43) 					'clear and rewrite the CASE Number. This is optional but can help the worker not to lose the case number.
+EMWriteScreen MAXIS_case_number, 18, 43             'writing in the case number so that if cancelled, the worker doesn't lose the case number.
+
+'MAXIS Region Check
+'OPTIONAL - there may be a good reason to be able to run in inquiry or production
+EMReadScreen MX_region, 10, 22, 48
+MX_region = trim(MX_region)
+If MX_region = "INQUIRY DB" Then
+	continue_in_inquiry = MsgBox("You have started this script run in INQUIRY." & vbNewLine & vbNewLine & "The script cannot complete a CASE:NOTE when run in inquiry. The functionality is limited when run in inquiry. " & vbNewLine & vbNewLine & "Would you like to continue in INQUIRY?", vbQuestion + vbYesNo, "Continue in INQUIRY")
+	If continue_in_inquiry = vbNo Then
+		Call script_end_procedure("~PT NAME Script cancelled as it was run in inquiry.")
+	End If
+End If
+
+'PRIV Handling
+Call navigate_to_MAXIS_screen_review_PRIV("CASE", "CURR", is_this_priv)
+If is_this_PRIV = True then script_end_procedure("This case is privileged and you do not have access to it. The script will now end.")
+
+'Out of County Handling
+'There are a few reasons to allow a script to run on an out of county case - so review if this is needed.
+EMReadScreen pw_county_code, 2, 21, 19
+If pw_county_code <> "27" Then script_end_procedure("This case is not in Hennepin County and cannot be updated. The script will now end.")
+
+'Do you need to check for PRIV status
+Call navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB")
+
+'Do you need to check to see if case is out of county? Add Out-of-County handling here:
+'All your other navigation, data catpure and logic here. any other logic or pre case noting actions here.
+
+Call MAXIS_background_check 'IF NEEDED: meaning if you send it through background. Move this to where it makes sense.
+
+'Do you need to set a TIKL?
+Call create_TIKL(TIKL_text, num_of_days, date_to_start, ten_day_adjust, TIKL_note_text)
+
+'Now it navigates to a blank case note
+Call start_a_blank_case_note
+
+'...and enters a title (replace variables with your own content)...
+CALL write_variable_in_case_note("*** CASE NOTE HEADER ***")
+
+'...some editboxes or droplistboxes (replace variables with your own content)...
+CALL write_bullet_and_variable_in_case_note( "Here's the first bullet",  a_variable_from_your_dialog        )
+CALL write_bullet_and_variable_in_case_note( "Here's another bullet",    another_variable_from_your_dialog  )
+
+'...checkbox responses (replace variables with your own content)...
+If some_checkbox_from_your_dialog = checked     then CALL write_variable_in_case_note( "* The checkbox was checked."     )
+If some_checkbox_from_your_dialog = unchecked   then CALL write_variable_in_case_note( "* The checkbox was not checked." )
+
+'...and a worker signature.
+CALL write_variable_in_case_note("---")
+CALL write_variable_in_case_note(worker_signature)
+'leave the case note open and in edit mode unless you have a business reason not to (BULK scripts, multiple case notes, etc.)
+
+'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
+script_end_procedure("")
+
+'Add your closing issue documentation here. Make sure it's the most up-to-date version (date on file).

--- a/dail/sdx-match.vbs
+++ b/dail/sdx-match.vbs
@@ -53,21 +53,10 @@ changelog_display
 'THE SCRIPT==================================================================================================================
 EMConnect "" 'Connects to BlueZone
 'Read the dail message
-MsgBox "Are we at dail_row 6?"
-EMReadScreen DAIL_type, 4, 6, 6
-DAIL_type = trim(DAIL_type)
-EMReadScreen MAXIS_case_number, 8, 5, 73
-MAXIS_case_number = trim(MAXIS_case_number)
 EMReadScreen full_message, 60, 6, 20
 full_message = trim(full_message)
 
 Dialog1 = "" 'blanking out dialog name
-'Add dialog here: Add the dialog just before calling the dialog below unless you need it in the dialog due to using COMBO Boxes or other looping reasons. Blank out the dialog name with Dialog1 = "" before adding dialog.
-'    Some Dialog Elements:  Initial Dialog Header: 			BeginDialog Dialog1, 0, 0, 191, 105, "CATEGORY - NAME Case Number Dialog"  				-- Use CATEGORY - NAME somewhere in the header
-'							Script Instructions Button:		PushButton 135, 5, 50, 15, "Instructions", script_instructions_btn						-- Have a button to open the instructions
-'							Script Purpose/Overview: 		Text 10, 70, 120, 30, "Here is a quick summary of the purpose of the script."			-- Give the worker a little guidance
-'							Include edit boxes for necessary details like Case Number, Footer Month, Footer Year, and Worker Signature
-'Shows dialog (replace "sample_dialog" with the actual dialog you entered above)----------------------------------
 
 BeginDialog Dialog1, 0, 0, 281, 135, "DAIL - SDX Match"
   ButtonGroup ButtonPressed
@@ -77,7 +66,7 @@ BeginDialog Dialog1, 0, 0, 281, 135, "DAIL - SDX Match"
     OkButton 170, 115, 50, 15
     CancelButton 225, 115, 50, 15
   Text 5, 5, 55, 10, "DAIL Message - "
-  Text 60, 5, 210, 10, "dail_message"
+  Text 60, 5, 210, 10, full_message
   Text 5, 20, 270, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/procedures for information on how to process:"
   Text 65, 50, 95, 10, "Link to Combined Manual"
   Text 65, 70, 75, 10, "Link to POLI/TEMP"
@@ -89,92 +78,22 @@ DO
         err_msg = ""    'This is the error message handling
         Dialog Dialog1
         cancel_without_confirmation
-        'Add in all of your mandatory field handling from your dialog here.
-        'The rest of the mandatory handling here
 		If ButtonPressed = combined_manual_btn Then
 			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=CM_00121203"
 			err_msg = "LOOP"
 		End If
 		If ButtonPressed = poli_temp_btn Then
-			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/sites/hs-es-poli-temp/Documents%203/Forms/AllItems.aspx"
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:b:/r/sites/hs-es-poli-temp/Documents%203/TE%2002.12.14%20INTERIM%20ASSISTANCE%20REIMBURSEMENT%20INTERFACE.pdf"
 			err_msg = "LOOP"
 		End If
 		If ButtonPressed = hsr_manual_btn Then 
 			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/INFO.aspx#sdx-match-ssi-pending-maxis-created-pben-iaa-needed-*"
 			err_msg = "LOOP"
 		End If
-
-        ' IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
-        IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
     Loop until err_msg = ""
-    'Add to all dialogs where you need to work within BLUEZONE
     CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 'End dialog section-----------------------------------------------------------------------------------------------
 
-'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
-script_end_procedure("The script will now end.")
-
-' 'Checks to see if in MAXIS
-' CALL check_for_MAXIS(True) or Call check_for_MAXIS(False)
-
-' 'Reset to SELF to check the MAXIS region
-' 'This is also helpful to ensure we are not starting in a CASE/NOTE or something
-' Call back_to_SELF
-' Call clear_line_of_text(18, 43) 					'clear and rewrite the CASE Number. This is optional but can help the worker not to lose the case number.
-' EMWriteScreen MAXIS_case_number, 18, 43             'writing in the case number so that if cancelled, the worker doesn't lose the case number.
-
-' 'MAXIS Region Check
-' 'OPTIONAL - there may be a good reason to be able to run in inquiry or production
-' EMReadScreen MX_region, 10, 22, 48
-' MX_region = trim(MX_region)
-' If MX_region = "INQUIRY DB" Then
-' 	continue_in_inquiry = MsgBox("You have started this script run in INQUIRY." & vbNewLine & vbNewLine & "The script cannot complete a CASE:NOTE when run in inquiry. The functionality is limited when run in inquiry. " & vbNewLine & vbNewLine & "Would you like to continue in INQUIRY?", vbQuestion + vbYesNo, "Continue in INQUIRY")
-' 	If continue_in_inquiry = vbNo Then
-' 		Call script_end_procedure("~PT NAME Script cancelled as it was run in inquiry.")
-' 	End If
-' End If
-
-' 'PRIV Handling
-' Call navigate_to_MAXIS_screen_review_PRIV("CASE", "CURR", is_this_priv)
-' If is_this_PRIV = True then script_end_procedure("This case is privileged and you do not have access to it. The script will now end.")
-
-' 'Out of County Handling
-' 'There are a few reasons to allow a script to run on an out of county case - so review if this is needed.
-' EMReadScreen pw_county_code, 2, 21, 19
-' If pw_county_code <> "27" Then script_end_procedure("This case is not in Hennepin County and cannot be updated. The script will now end.")
-
-' 'Do you need to check for PRIV status
-' Call navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB")
-
-' 'Do you need to check to see if case is out of county? Add Out-of-County handling here:
-' 'All your other navigation, data catpure and logic here. any other logic or pre case noting actions here.
-
-' Call MAXIS_background_check 'IF NEEDED: meaning if you send it through background. Move this to where it makes sense.
-
-' 'Do you need to set a TIKL?
-' Call create_TIKL(TIKL_text, num_of_days, date_to_start, ten_day_adjust, TIKL_note_text)
-
-' 'Now it navigates to a blank case note
-' Call start_a_blank_case_note
-
-' '...and enters a title (replace variables with your own content)...
-' CALL write_variable_in_case_note("*** CASE NOTE HEADER ***")
-
-' '...some editboxes or droplistboxes (replace variables with your own content)...
-' CALL write_bullet_and_variable_in_case_note( "Here's the first bullet",  a_variable_from_your_dialog        )
-' CALL write_bullet_and_variable_in_case_note( "Here's another bullet",    another_variable_from_your_dialog  )
-
-' '...checkbox responses (replace variables with your own content)...
-' If some_checkbox_from_your_dialog = checked     then CALL write_variable_in_case_note( "* The checkbox was checked."     )
-' If some_checkbox_from_your_dialog = unchecked   then CALL write_variable_in_case_note( "* The checkbox was not checked." )
-
-' '...and a worker signature.
-' CALL write_variable_in_case_note("---")
-' CALL write_variable_in_case_note(worker_signature)
-' 'leave the case note open and in edit mode unless you have a business reason not to (BULK scripts, multiple case notes, etc.)
-
-'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
-script_end_procedure("")
-
-'Add your closing issue documentation here. Make sure it's the most up-to-date version (date on file).
+'End the script.
+script_end_procedure("Please follow the instructions provided in the Combined Manual, POLI/TEMP, and/or HSR Manual. The script will now end.")

--- a/dail/sdx-match.vbs
+++ b/dail/sdx-match.vbs
@@ -44,7 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County
-CALL changelog_update("01/01/01", "Initial version.", "Ilse Ferris, Hennepin County") 'REPLACE with release date and your name.
+CALL changelog_update("11/01/24", "Initial version.", "Mark Riegel, Hennepin County") 'REPLACE with release date and your name.
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
 changelog_display
@@ -52,11 +52,14 @@ changelog_display
 
 'THE SCRIPT==================================================================================================================
 EMConnect "" 'Connects to BlueZone
-CALL MAXIS_case_number_finder(MAXIS_case_number)    				'Grabs the MAXIS case number automatically
-Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)		'Grabs the footer month and year from MAXIS
-'  -- OR --
-MAXIS_footer_month = CM_plus_1_mo									'Directly assigns a footer month based on the current month
-MAXIS_footer_year = CM_plus_1_yr
+'Read the dail message
+MsgBox "Are we at dail_row 6?"
+EMReadScreen DAIL_type, 4, 6, 6
+DAIL_type = trim(DAIL_type)
+EMReadScreen MAXIS_case_number, 8, 5, 73
+MAXIS_case_number = trim(MAXIS_case_number)
+EMReadScreen full_message, 60, 6, 20
+full_message = trim(full_message)
 
 Dialog1 = "" 'blanking out dialog name
 'Add dialog here: Add the dialog just before calling the dialog below unless you need it in the dialog due to using COMBO Boxes or other looping reasons. Blank out the dialog name with Dialog1 = "" before adding dialog.
@@ -65,20 +68,43 @@ Dialog1 = "" 'blanking out dialog name
 '							Script Purpose/Overview: 		Text 10, 70, 120, 30, "Here is a quick summary of the purpose of the script."			-- Give the worker a little guidance
 '							Include edit boxes for necessary details like Case Number, Footer Month, Footer Year, and Worker Signature
 'Shows dialog (replace "sample_dialog" with the actual dialog you entered above)----------------------------------
+
+BeginDialog Dialog1, 0, 0, 281, 135, "DAIL - SDX Match"
+  ButtonGroup ButtonPressed
+    PushButton 5, 45, 55, 15, "CM 0012.12.03", combined_manual_btn
+    PushButton 5, 65, 55, 15, "TE 02.12.14", poli_temp_btn
+    PushButton 5, 85, 55, 15, "HSR Manual", hsr_manual_btn
+    OkButton 170, 115, 50, 15
+    CancelButton 225, 115, 50, 15
+  Text 5, 5, 55, 10, "DAIL Message - "
+  Text 60, 5, 210, 10, "dail_message"
+  Text 5, 20, 270, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/procedures for information on how to process:"
+  Text 65, 50, 95, 10, "Link to Combined Manual"
+  Text 65, 70, 75, 10, "Link to POLI/TEMP"
+  Text 65, 90, 85, 10, "Link to HSR Manual"
+EndDialog
+
 DO
     Do
         err_msg = ""    'This is the error message handling
         Dialog Dialog1
-        cancel_confirmation or cancel_without_confirmation
+        cancel_without_confirmation
         'Add in all of your mandatory field handling from your dialog here.
-        Call validate_MAXIS_case_number(err_msg, "*") ' IF NEEDED
-        Call validate_footer_month_entry(MAXIS_footer_month, MAXIS_footer_year, err_msg, "*")   'IF NEEDED
         'The rest of the mandatory handling here
-        IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note." 'IF NEEDED
-		If ButtonPressed = script_instructions_btn Then
-			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/CATEGORY/CATEGORY%20-%20NAME.docx"	'copy the instructions URL here
+		If ButtonPressed = combined_manual_btn Then
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=CM_00121203"
 			err_msg = "LOOP"
 		End If
+		If ButtonPressed = poli_temp_btn Then
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/sites/hs-es-poli-temp/Documents%203/Forms/AllItems.aspx"
+			err_msg = "LOOP"
+		End If
+		If ButtonPressed = hsr_manual_btn Then 
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/INFO.aspx#sdx-match-ssi-pending-maxis-created-pben-iaa-needed-*"
+			err_msg = "LOOP"
+		End If
+
+        ' IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
         IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
     Loop until err_msg = ""
     'Add to all dialogs where you need to work within BLUEZONE
@@ -86,64 +112,67 @@ DO
 LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 'End dialog section-----------------------------------------------------------------------------------------------
 
-'Checks to see if in MAXIS
-CALL check_for_MAXIS(True) or Call check_for_MAXIS(False)
+'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
+script_end_procedure("The script will now end.")
 
-'Reset to SELF to check the MAXIS region
-'This is also helpful to ensure we are not starting in a CASE/NOTE or something
-Call back_to_SELF
-Call clear_line_of_text(18, 43) 					'clear and rewrite the CASE Number. This is optional but can help the worker not to lose the case number.
-EMWriteScreen MAXIS_case_number, 18, 43             'writing in the case number so that if cancelled, the worker doesn't lose the case number.
+' 'Checks to see if in MAXIS
+' CALL check_for_MAXIS(True) or Call check_for_MAXIS(False)
 
-'MAXIS Region Check
-'OPTIONAL - there may be a good reason to be able to run in inquiry or production
-EMReadScreen MX_region, 10, 22, 48
-MX_region = trim(MX_region)
-If MX_region = "INQUIRY DB" Then
-	continue_in_inquiry = MsgBox("You have started this script run in INQUIRY." & vbNewLine & vbNewLine & "The script cannot complete a CASE:NOTE when run in inquiry. The functionality is limited when run in inquiry. " & vbNewLine & vbNewLine & "Would you like to continue in INQUIRY?", vbQuestion + vbYesNo, "Continue in INQUIRY")
-	If continue_in_inquiry = vbNo Then
-		Call script_end_procedure("~PT NAME Script cancelled as it was run in inquiry.")
-	End If
-End If
+' 'Reset to SELF to check the MAXIS region
+' 'This is also helpful to ensure we are not starting in a CASE/NOTE or something
+' Call back_to_SELF
+' Call clear_line_of_text(18, 43) 					'clear and rewrite the CASE Number. This is optional but can help the worker not to lose the case number.
+' EMWriteScreen MAXIS_case_number, 18, 43             'writing in the case number so that if cancelled, the worker doesn't lose the case number.
 
-'PRIV Handling
-Call navigate_to_MAXIS_screen_review_PRIV("CASE", "CURR", is_this_priv)
-If is_this_PRIV = True then script_end_procedure("This case is privileged and you do not have access to it. The script will now end.")
+' 'MAXIS Region Check
+' 'OPTIONAL - there may be a good reason to be able to run in inquiry or production
+' EMReadScreen MX_region, 10, 22, 48
+' MX_region = trim(MX_region)
+' If MX_region = "INQUIRY DB" Then
+' 	continue_in_inquiry = MsgBox("You have started this script run in INQUIRY." & vbNewLine & vbNewLine & "The script cannot complete a CASE:NOTE when run in inquiry. The functionality is limited when run in inquiry. " & vbNewLine & vbNewLine & "Would you like to continue in INQUIRY?", vbQuestion + vbYesNo, "Continue in INQUIRY")
+' 	If continue_in_inquiry = vbNo Then
+' 		Call script_end_procedure("~PT NAME Script cancelled as it was run in inquiry.")
+' 	End If
+' End If
 
-'Out of County Handling
-'There are a few reasons to allow a script to run on an out of county case - so review if this is needed.
-EMReadScreen pw_county_code, 2, 21, 19
-If pw_county_code <> "27" Then script_end_procedure("This case is not in Hennepin County and cannot be updated. The script will now end.")
+' 'PRIV Handling
+' Call navigate_to_MAXIS_screen_review_PRIV("CASE", "CURR", is_this_priv)
+' If is_this_PRIV = True then script_end_procedure("This case is privileged and you do not have access to it. The script will now end.")
 
-'Do you need to check for PRIV status
-Call navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB")
+' 'Out of County Handling
+' 'There are a few reasons to allow a script to run on an out of county case - so review if this is needed.
+' EMReadScreen pw_county_code, 2, 21, 19
+' If pw_county_code <> "27" Then script_end_procedure("This case is not in Hennepin County and cannot be updated. The script will now end.")
 
-'Do you need to check to see if case is out of county? Add Out-of-County handling here:
-'All your other navigation, data catpure and logic here. any other logic or pre case noting actions here.
+' 'Do you need to check for PRIV status
+' Call navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB")
 
-Call MAXIS_background_check 'IF NEEDED: meaning if you send it through background. Move this to where it makes sense.
+' 'Do you need to check to see if case is out of county? Add Out-of-County handling here:
+' 'All your other navigation, data catpure and logic here. any other logic or pre case noting actions here.
 
-'Do you need to set a TIKL?
-Call create_TIKL(TIKL_text, num_of_days, date_to_start, ten_day_adjust, TIKL_note_text)
+' Call MAXIS_background_check 'IF NEEDED: meaning if you send it through background. Move this to where it makes sense.
 
-'Now it navigates to a blank case note
-Call start_a_blank_case_note
+' 'Do you need to set a TIKL?
+' Call create_TIKL(TIKL_text, num_of_days, date_to_start, ten_day_adjust, TIKL_note_text)
 
-'...and enters a title (replace variables with your own content)...
-CALL write_variable_in_case_note("*** CASE NOTE HEADER ***")
+' 'Now it navigates to a blank case note
+' Call start_a_blank_case_note
 
-'...some editboxes or droplistboxes (replace variables with your own content)...
-CALL write_bullet_and_variable_in_case_note( "Here's the first bullet",  a_variable_from_your_dialog        )
-CALL write_bullet_and_variable_in_case_note( "Here's another bullet",    another_variable_from_your_dialog  )
+' '...and enters a title (replace variables with your own content)...
+' CALL write_variable_in_case_note("*** CASE NOTE HEADER ***")
 
-'...checkbox responses (replace variables with your own content)...
-If some_checkbox_from_your_dialog = checked     then CALL write_variable_in_case_note( "* The checkbox was checked."     )
-If some_checkbox_from_your_dialog = unchecked   then CALL write_variable_in_case_note( "* The checkbox was not checked." )
+' '...some editboxes or droplistboxes (replace variables with your own content)...
+' CALL write_bullet_and_variable_in_case_note( "Here's the first bullet",  a_variable_from_your_dialog        )
+' CALL write_bullet_and_variable_in_case_note( "Here's another bullet",    another_variable_from_your_dialog  )
 
-'...and a worker signature.
-CALL write_variable_in_case_note("---")
-CALL write_variable_in_case_note(worker_signature)
-'leave the case note open and in edit mode unless you have a business reason not to (BULK scripts, multiple case notes, etc.)
+' '...checkbox responses (replace variables with your own content)...
+' If some_checkbox_from_your_dialog = checked     then CALL write_variable_in_case_note( "* The checkbox was checked."     )
+' If some_checkbox_from_your_dialog = unchecked   then CALL write_variable_in_case_note( "* The checkbox was not checked." )
+
+' '...and a worker signature.
+' CALL write_variable_in_case_note("---")
+' CALL write_variable_in_case_note(worker_signature)
+' 'leave the case note open and in edit mode unless you have a business reason not to (BULK scripts, multiple case notes, etc.)
 
 'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
 script_end_procedure("")


### PR DESCRIPTION
Added functionality to pull up Combined Manual, POLI/TEMP, and HSR Manual links within a dialog when a SDX Match DAIL message is encountered. The script instructions are quite basic, but I [updated them here](https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/_layouts/15/Doc.aspx?sourcedoc=%7B7D2E3349-1333-4628-B572-754EED31AFB4%7D&file=DAIL%20-%20SDX%20MATCH.docx). 