### PR TITLE
#2064 NOTES - Elig Summ - Back out of all Case Notes after completed

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -31502,6 +31502,7 @@ For each_month = 0 to UBound(REPORTING_COMPLETE_ARRAY, 2)
 			PF10
 			MsgBox "ER Note Gone?"
 		End If
+		PF3
 	End If
 
 
@@ -31536,6 +31537,7 @@ For each_month = 0 to UBound(REPORTING_COMPLETE_ARRAY, 2)
 			PF10
 			MsgBox "SR NOTE Gone?"
 		End If
+		PF3
 	End If
 Next
 

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -31148,6 +31148,12 @@ If denials_found_on_pnd2 = True Then
 				Call write_variable_in_CASE_NOTE("---")
 				Call write_variable_in_CASE_NOTE(worker_signature)
 
+				If developer_mode = True Then
+					MsgBox "STOP HERE AND DELETE THE NOTE"		'TESTING OPTION'
+					PF10
+					Msgbox "You forgot - but the NOTE is gone"
+				End If
+				PF3
 			End If
 
 			If progs_denied_for_wthdrw <> "" Then
@@ -31163,6 +31169,13 @@ If denials_found_on_pnd2 = True Then
 				Call write_variable_in_CASE_NOTE("* Resident requested to withdraw application.")
 				Call write_variable_in_CASE_NOTE("---")
 				Call write_variable_in_CASE_NOTE(worker_signature)
+
+				If developer_mode = True Then
+					MsgBox "STOP HERE AND DELETE THE NOTE"		'TESTING OPTION'
+					PF10
+					Msgbox "You forgot - but the NOTE is gone"
+				End If
+				PF3
 			End If
 
 		End If
@@ -31243,6 +31256,12 @@ If denials_found_on_pnd2 = True Then
 				Call write_variable_in_CASE_NOTE("---")
 				Call write_variable_in_CASE_NOTE(worker_signature)
 
+				If developer_mode = True Then
+					MsgBox "STOP HERE AND DELETE THE NOTE"		'TESTING OPTION'
+					PF10
+					Msgbox "You forgot - but the NOTE is gone"
+				End If
+				PF3
 			End If
 
 			If progs_denied_for_wthdrw <> "" Then
@@ -31258,6 +31277,13 @@ If denials_found_on_pnd2 = True Then
 				Call write_variable_in_CASE_NOTE("* Resident requested to withdraw application.")
 				Call write_variable_in_CASE_NOTE("---")
 				Call write_variable_in_CASE_NOTE(worker_signature)
+
+				If developer_mode = True Then
+					MsgBox "STOP HERE AND DELETE THE NOTE"		'TESTING OPTION'
+					PF10
+					Msgbox "You forgot - but the NOTE is gone"
+				End If
+				PF3
 			End If
 		End If
 	End If


### PR DESCRIPTION
Update to Eligibility Summary to ensure it will work well with the updates to start_a_blank_case_note. 

When a CASE/NOTE is created and all information is entered, we need to back out by pressing PF3 before continuing the script.