### PR TITLE
#2093 Add new CEC message to actionable_dail function

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -11582,6 +11582,7 @@ Function non_actionable_dails(actionable_dail)
         instr(dail_msg, "- TRANS #") OR _
         instr(dail_msg, "RSDI UPDATED - (REF") OR _
         instr(dail_msg, "SSI UPDATED - (REF") OR _
+        instr(dail_msg, "MEMBER IS CHILD UNDER AGE 6. ANNUAL HC NOTICE SENT") OR _
         instr(dail_msg, "SNAP ABAWD ELIGIBILITY HAS EXPIRED, APPROVE NEW ELIG RESULTS") then
             actionable_dail = False
         '----------------------------------------------------------------------------------------------------Removing older specific INFO messages


### PR DESCRIPTION
Updated actionable_dail function to include new PEPR message related to CEC Annual Info Message: "MEMBER IS CHILD UNDER AGE 6. ANNUAL HC NOTICE SENT." Message will be deleted as part of DAIL decimator runs since this message will be indicated as not actionable (actionable_dail = false).