### PR TITLE
#2084 Shelter Main Menu - declare dialog variable

### DIFF
--- a/shelter/shelter-main-menu.vbs
+++ b/shelter/shelter-main-menu.vbs
@@ -177,6 +177,7 @@ subcategory_selected = "# - L"
 ButtonPressed = menu_0_to_L_button
 Do
 	'Creates the dialog
+	Dialog1 = ""
 	call declare_main_menu_dialog("SHELTER")
 
 	'At the beginning of the loop, we are not ready to exit it. Conditions later on will impact this.


### PR DESCRIPTION
No error reported on this menu yet but the other menus with this declaration missing all failed at some point. 

No other menus appear to be missing a declaration of some kind.