### PR TITLE
#1952 NOTES - ELIG SUMM - GRH Inelig NOT Income based supp hsg logic

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -14747,6 +14747,7 @@ class grh_eligibility_detail
 			EMReadScreen grh_elig_case_test_income, 				6, 11, 45
 			EMReadScreen grh_elig_case_test_setting, 				6, 12, 45
 			EMReadScreen grh_elig_case_test_verif, 					6, 13, 45
+			If grh_elig_memb_elig_status = "INELIGIBLE" and grh_elig_case_test_income = "PASSED" Then appears_supportive_housing_disregard_case = False
 
 			grh_elig_case_test_application_withdrawn = trim(grh_elig_case_test_application_withdrawn)
 			grh_elig_case_test_pben_coop = trim(grh_elig_case_test_pben_coop)


### PR DESCRIPTION
We can ignore the supportive housing disregard logic for GRH cases that are ineligible for reasons OTHER than income because the budget shouldn't matter in these instances. 