### PR TITLE
1226 DAIL - CATCH ALL, evaluation and updates

### DIFF
--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -379,6 +379,10 @@ End If
 
 If instr(full_message, "DISA HAS ENDED - REVIEW DISA STATUS OR REDETERMINE ELIG") Then
 
+    'Navigate to STAT/DISA
+    Call write_value_and_transmit("S", 6, 3)
+    Call write_value_and_transmit("DISA", 20, 71)
+
     'Dialog with links to policy references
     Dialog1 = "" 'blanking out dialog name
     BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - DISA HAS ENDED - REVIEW DISA STATUS OR REDETERMINE ELIG"

--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -350,6 +350,8 @@ If instr(full_message, "GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIA
         Text 75, 50, 95, 10, "Link to Combined Manual"
         Text 75, 70, 85, 10, "Link to HSR Manual"
         Text 75, 90, 85, 10, "Link to Script Instructions"
+        ButtonGroup ButtonPressed
+        PushButton 5, 105, 210, 15, "Redirect to NOTES - OTHER MAINTENANCE BENEFITS script", redirect_notes_other_maint_benefits_btn
     EndDialog
 
     DO
@@ -368,6 +370,12 @@ If instr(full_message, "GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIA
             If ButtonPressed = script_instructions_btn Then 
                 run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/DAIL%20-%20CATCH%20ALL.docx"
                 err_msg = "LOOP"
+            End If
+            If ButtonPressed = redirect_notes_other_maint_benefits_btn Then 
+                'Navigate back to SELF and add the case number
+                back_to_SELF
+                EMWriteScreen MAXIS_case_number, 18, 43 
+                CALL run_from_GitHub(script_repository & "notes/other-benefits-referral.vbs")
             End If
         Loop until err_msg = ""
         CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS

--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -333,6 +333,50 @@ If instr(full_message, "SSN HAS NOT BEEN VERIFIED IN OVER 60 DAYS") Then
     script_end_procedure("Please follow the instructions provided in the Combined Manual, POLI/TEMP, and/or HSR Manual. The script will now end.")
 End If
 
+If instr(full_message, "GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIATE") Then
+
+    'Dialog with links to policy references
+    Dialog1 = "" 'blanking out dialog name
+    BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIATE"
+        ButtonGroup ButtonPressed
+        PushButton 5, 45, 65, 15, "CM 12.0012.12", combined_manual_btn
+        PushButton 5, 65, 65, 15, "HSR Manual", hsr_manual_btn
+        PushButton 5, 85, 65, 15, "Script Instructions", script_instructions_btn
+        OkButton 205, 135, 50, 15
+        CancelButton 255, 135, 50, 15
+        Text 5, 5, 55, 10, "DAIL Message - "
+        Text 60, 5, 245, 10, full_message
+        Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
+        Text 75, 50, 95, 10, "Link to Combined Manual"
+        Text 75, 70, 85, 10, "Link to HSR Manual"
+        Text 75, 90, 85, 10, "Link to Script Instructions"
+    EndDialog
+
+    DO
+        Do
+            err_msg = ""    'This is the error message handling
+            Dialog Dialog1
+            cancel_without_confirmation
+            If ButtonPressed = combined_manual_btn Then
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_001212"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = hsr_manual_btn Then 
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/PEPR.aspx#ga-has-been-actv-for-2-years-%E2%80%93-refer-to-ssa-if-appropriate"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = script_instructions_btn Then 
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/DAIL%20-%20CATCH%20ALL.docx"
+                err_msg = "LOOP"
+            End If
+        Loop until err_msg = ""
+        CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+    LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+
+    'End the script.
+    script_end_procedure("Please follow the instructions provided in the Combined Manual and/or HSR Manual. The script will now end.")
+End If
+
 EMWriteScreen "S", 6, 3         'Goes to Case Note - maintains tie with DAIL
 TRANSMIT
 

--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -338,21 +338,24 @@ If instr(full_message, "GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIA
     'Dialog with links to policy references
     Dialog1 = "" 'blanking out dialog name
     BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIATE"
+        Text 5, 5, 55, 10, "DAIL Message - "
+        Text 60, 5, 245, 10, "full_message"
+        Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
         ButtonGroup ButtonPressed
         PushButton 5, 45, 65, 15, "CM 12.0012.12", combined_manual_btn
-        PushButton 5, 65, 65, 15, "HSR Manual", hsr_manual_btn
-        PushButton 5, 85, 65, 15, "Script Instructions", script_instructions_btn
-        OkButton 205, 135, 50, 15
-        CancelButton 255, 135, 50, 15
-        Text 5, 5, 55, 10, "DAIL Message - "
-        Text 60, 5, 245, 10, full_message
-        Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
         Text 75, 50, 95, 10, "Link to Combined Manual"
+        ButtonGroup ButtonPressed
+        PushButton 5, 65, 65, 15, "HSR Manual", hsr_manual_btn
         Text 75, 70, 85, 10, "Link to HSR Manual"
+        ButtonGroup ButtonPressed
+        PushButton 5, 85, 65, 15, "Script Instructions", script_instructions_btn
         Text 75, 90, 85, 10, "Link to Script Instructions"
         ButtonGroup ButtonPressed
         PushButton 5, 105, 210, 15, "Redirect to NOTES - OTHER MAINTENANCE BENEFITS script", redirect_notes_other_maint_benefits_btn
+        OkButton 205, 135, 50, 15
+        CancelButton 255, 135, 50, 15
     EndDialog
+  
 
     DO
         Do
@@ -511,46 +514,46 @@ script_end_procedure_with_error_report(DAIL_type & vbcr & full_message & vbcr & 
 '------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------
 '
 '------Dialogs--------------------------------------------------------------------------------------------------------------------
-'--Dialog1 = "" on all dialogs -------------------------------------------------
-'--Tab orders reviewed & confirmed----------------------------------------------
-'--Mandatory fields all present & Reviewed--------------------------------------
-'--All variables in dialog match mandatory fields-------------------------------
-'Review dialog names for content and content fit in dialog----------------------
-'--FIRST DIALOG--NEW EFF 5/23/2024----------------------------------------------
-'--Include script category and name somewhere on first dialog-------------------
-'--Create a button to reference instructions------------------------------------
+'--Dialog1 = "" on all dialogs -------------------------------------------------12/23/2024
+'--Tab orders reviewed & confirmed----------------------------------------------12/23/2024
+'--Mandatory fields all present & Reviewed--------------------------------------12/23/2024
+'--All variables in dialog match mandatory fields-------------------------------12/23/2024
+'Review dialog names for content and content fit in dialog----------------------12/23/2024
+'--FIRST DIALOG--NEW EFF 5/23/2024----------------------------------------------N/A 
+'--Include script category and name somewhere on first dialog-------------------N/A
+'--Create a button to reference instructions------------------------------------12/23/2024
 '
 '-----CASE:NOTE-------------------------------------------------------------------------------------------------------------------
-'--All variables are CASE:NOTEing (if required)---------------------------------
-'--CASE:NOTE Header doesn't look funky------------------------------------------
-'--Leave CASE:NOTE in edit mode if applicable-----------------------------------
+'--All variables are CASE:NOTEing (if required)---------------------------------12/23/2024
+'--CASE:NOTE Header doesn't look funky------------------------------------------12/23/2024
+'--Leave CASE:NOTE in edit mode if applicable-----------------------------------12/23/2024
 '--write_variable_in_CASE_NOTE function: confirm that proper punctuation is used -----------------------------------
 '
 '-----General Supports-------------------------------------------------------------------------------------------------------------
-'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------
-'--MAXIS_background_check reviewed (if applicable)------------------------------
-'--PRIV Case handling reviewed -------------------------------------------------
-'--Out-of-County handling reviewed----------------------------------------------
-'--script_end_procedures (w/ or w/o error messaging)----------------------------
-'--BULK - review output of statistics and run time/count (if applicable)--------
-'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------
+'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------12/23/2024
+'--MAXIS_background_check reviewed (if applicable)------------------------------12/23/2024
+'--PRIV Case handling reviewed -------------------------------------------------12/23/2024
+'--Out-of-County handling reviewed----------------------------------------------12/23/2024
+'--script_end_procedures (w/ or w/o error messaging)----------------------------12/23/2024
+'--BULK - review output of statistics and run time/count (if applicable)--------12/23/2024
+'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------12/23/2024
 '
 '-----Statistics--------------------------------------------------------------------------------------------------------------------
-'--Manual time study reviewed --------------------------------------------------
-'--Incrementors reviewed (if necessary)-----------------------------------------
-'--Denomination reviewed -------------------------------------------------------
-'--Script name reviewed---------------------------------------------------------
-'--BULK - remove 1 incrementor at end of script reviewed------------------------
+'--Manual time study reviewed --------------------------------------------------12/23/2024
+'--Incrementors reviewed (if necessary)-----------------------------------------12/23/2024
+'--Denomination reviewed -------------------------------------------------------12/23/2024
+'--Script name reviewed---------------------------------------------------------12/23/2024
+'--BULK - remove 1 incrementor at end of script reviewed------------------------N/A
 
 '-----Finishing up------------------------------------------------------------------------------------------------------------------
-'--Confirm all GitHub tasks are complete----------------------------------------
-'--comment Code-----------------------------------------------------------------
-'--Update Changelog for release/update------------------------------------------
-'--Remove testing message boxes-------------------------------------------------
-'--Remove testing code/unnecessary code-----------------------------------------
-'--Review/update SharePoint instructions----------------------------------------
-'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------
-'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------
-'--COMPLETE LIST OF SCRIPTS update policy references----------------------------
-'--Complete misc. documentation (if applicable)---------------------------------
-'--Update project team/issue contact (if applicable)----------------------------
+'--Confirm all GitHub tasks are complete----------------------------------------12/23/2024
+'--comment Code-----------------------------------------------------------------12/23/2024
+'--Update Changelog for release/update------------------------------------------12/23/2024
+'--Remove testing message boxes-------------------------------------------------12/23/2024
+'--Remove testing code/unnecessary code-----------------------------------------12/23/2024
+'--Review/update SharePoint instructions----------------------------------------12/23/2024
+'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------12/23/2024
+'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------12/23/2024
+'--COMPLETE LIST OF SCRIPTS update policy references----------------------------12/23/2024
+'--Complete misc. documentation (if applicable)---------------------------------12/23/2024
+'--Update project team/issue contact (if applicable)----------------------------12/23/2024

--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -103,7 +103,7 @@ If instr(full_message, "VERIFICATIONS REQUESTED FOR THIS CASE. PLEASE REVIEW CAS
     'Search CASE/NOTEs to determine if there is a VERIFICATIONS REQUESTED CASE/NOTE
 
     'Using TIKL date to set too old date, no need to read for dates prior to 30 days before TIKL date
-    too_old_date = DateAdd("D", -30, date)
+    too_old_date = DateAdd("D", -120, date)
 
     note_row = 5
     Do
@@ -289,7 +289,7 @@ If instr(full_message, "SSN HAS NOT BEEN VERIFIED IN OVER 60 DAYS") Then
     Dialog1 = "" 'blanking out dialog name
     BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - SSN HAS NOT BEEN VERIFIED"
     ButtonGroup ButtonPressed
-        PushButton 5, 45, 65, 15, "CM 0012.03", combined_manual_btn
+        PushButton 5, 45, 65, 15, "CM 12.0012.03", combined_manual_btn
         PushButton 5, 65, 65, 15, "TE 02.12.14", poli_temp_btn
         PushButton 5, 85, 65, 15, "HSR Manual", hsr_manual_btn
         PushButton 5, 105, 65, 15, "Script Instructions", script_instructions_btn
@@ -375,6 +375,44 @@ If instr(full_message, "GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIA
 
     'End the script.
     script_end_procedure("Please follow the instructions provided in the Combined Manual and/or HSR Manual. The script will now end.")
+End If
+
+If instr(full_message, "DISA HAS ENDED - REVIEW DISA STATUS OR REDETERMINE ELIG") Then
+
+    'Dialog with links to policy references
+    Dialog1 = "" 'blanking out dialog name
+    BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - DISA HAS ENDED - REVIEW DISA STATUS OR REDETERMINE ELIG"
+        ButtonGroup ButtonPressed
+        PushButton 5, 45, 65, 15, "CM 12.0012.15", combined_manual_btn
+        PushButton 5, 65, 65, 15, "Script Instructions", script_instructions_btn
+        OkButton 205, 135, 50, 15
+        CancelButton 255, 135, 50, 15
+        Text 5, 5, 55, 10, "DAIL Message - "
+        Text 60, 5, 245, 10, "full_message"
+        Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
+        Text 75, 50, 95, 10, "Link to Combined Manual"
+        Text 75, 70, 85, 10, "Link to Script Instructions"
+    EndDialog
+
+    DO
+        Do
+            err_msg = ""    'This is the error message handling
+            Dialog Dialog1
+            cancel_without_confirmation
+            If ButtonPressed = combined_manual_btn Then
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=cm_001215"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = script_instructions_btn Then 
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/DAIL%20-%20CATCH%20ALL.docx"
+                err_msg = "LOOP"
+            End If
+        Loop until err_msg = ""
+        CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+    LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+
+    'End the script.
+    script_end_procedure("Please follow the instructions provided in the Combined Manual, POLI/TEMP, and/or HSR Manual. The script will now end.")
 End If
 
 EMWriteScreen "S", 6, 3         'Goes to Case Note - maintains tie with DAIL

--- a/dail/catch-all.vbs
+++ b/dail/catch-all.vbs
@@ -283,6 +283,56 @@ If instr(full_message, "VERIFICATIONS REQUESTED FOR THIS CASE. PLEASE REVIEW CAS
 
 End If
 
+If instr(full_message, "SSN HAS NOT BEEN VERIFIED IN OVER 60 DAYS") Then
+
+    'Dialog with links to policy references
+    Dialog1 = "" 'blanking out dialog name
+    BeginDialog Dialog1, 0, 0, 311, 155, "DAIL - SSN HAS NOT BEEN VERIFIED"
+    ButtonGroup ButtonPressed
+        PushButton 5, 45, 65, 15, "CM 0012.03", combined_manual_btn
+        PushButton 5, 65, 65, 15, "TE 02.12.14", poli_temp_btn
+        PushButton 5, 85, 65, 15, "HSR Manual", hsr_manual_btn
+        PushButton 5, 105, 65, 15, "Script Instructions", script_instructions_btn
+        OkButton 205, 135, 50, 15
+        CancelButton 255, 135, 50, 15
+    Text 5, 5, 55, 10, "DAIL Message - "
+    Text 60, 5, 245, 10, full_message
+    Text 5, 20, 300, 20, "This DAIL message is not currently supported by scripts. Please see the following policies/ procedures for information on how to process:"
+    Text 75, 50, 95, 10, "Link to Combined Manual"
+    Text 75, 70, 75, 10, "Link to POLI/TEMP"
+    Text 75, 90, 85, 10, "Link to HSR Manual"
+    Text 75, 110, 85, 10, "Link to Script Instructions"
+    EndDialog
+
+    DO
+        Do
+            err_msg = ""    'This is the error message handling
+            Dialog Dialog1
+            cancel_without_confirmation
+            If ButtonPressed = combined_manual_btn Then
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://www.dhs.state.mn.us/main/idcplg?IdcService=GET_DYNAMIC_CONVERSION&RevisionSelectionMethod=LatestReleased&dDocName=CM_001203"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = poli_temp_btn Then
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:b:/r/sites/hs-es-poli-temp/Documents%203/TE%2002.08.081%20DAIL%20MESSAGE%20%20%20SSN%20NOT%20VERIFIED.pdf"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = hsr_manual_btn Then 
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/teams/hs-es-manual/SitePages/PEPR.aspx#ssn-has-not-been-verified-in-over-60-days"
+                err_msg = "LOOP"
+            End If
+            If ButtonPressed = script_instructions_btn Then 
+                run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/DAIL%20-%20CATCH%20ALL.docx"
+                err_msg = "LOOP"
+            End If
+        Loop until err_msg = ""
+        CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+    LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+
+    'End the script.
+    script_end_procedure("Please follow the instructions provided in the Combined Manual, POLI/TEMP, and/or HSR Manual. The script will now end.")
+End If
+
 EMWriteScreen "S", 6, 3         'Goes to Case Note - maintains tie with DAIL
 TRANSMIT
 


### PR DESCRIPTION
Made updates to general script functionality:
- Updated the header of the CASE/NOTE to include more specifics.
- Removed ‘Action Taken On: date & time’ from CASE/NOTE.
- Write the entire DAIL message to the CASE/NOTE.
- Updated script instructions

Added handling for the following messages:

VERIFICATIONS REQUESTED FOR THIS CASE. PLEASE REVIEW CASE (TIKL)
- Script navigates to CASE/NOTEs to find matching CASE/NOTE (>>>VERIFICATIONS REQUESTED<<<) with Verifs due date that matches the TIKL date. Opens dialog where worker can either: indicates that verifications have been received and the script will then delete the TIKL and then redirect to NOTES - DOCS RECEIVED, OR indicate that verifications have not been received and the script will then run the case through background and then end.

DISA HAS ENDED - REVIEW DISA STATUS OR REDETERMINE ELIG (PEPR)
- Build on work done through https://github.com/Hennepin-County/MAXIS-scripts/issues/627 . Opens dialog with policy references. Navigates to DISA panel.

GA HAS BEEN ACTV FOR 2 YEARS - REFER TO SSA IF APPROPRIATE (PEPR)
- Build on work done through https://github.com/Hennepin-County/MAXIS-scripts/issues/627 . Opens dialog with policy references, includes button to navigate to NOTES - OTHER BENEFITS REFERRAL

SSN HAS NOT BEEN VERIFIED IN OVER 60 DAYS (PEPR)
- Build on work done through https://github.com/Hennepin-County/MAXIS-scripts/issues/627 . Open dialog with policy references.

I wasn't able to find specific HSR, POLI/TEMP, and/or CM references for all of the new messages that now have handling. In these instances, I removed the buttons linking to the policy references. If there are specific policy references that I missed, let me know and I can add them in.