### PR TITLE
#2170 Update language to match actual PEPR DAIL message

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -11604,7 +11604,7 @@ Function non_actionable_dails(actionable_dail)
         instr(dail_msg, "- TRANS #") OR _
         instr(dail_msg, "RSDI UPDATED - (REF") OR _
         instr(dail_msg, "SSI UPDATED - (REF") OR _
-        instr(dail_msg, "MEMBER IS CHILD UNDER AGE 6. ANNUAL HC NOTICE SENT") OR _
+        instr(dail_msg, "MEMBER IS CHILD UNDER AGE 6 - ANNUAL HC NOTICE SENT") OR _
         instr(dail_msg, "SNAP ABAWD ELIGIBILITY HAS EXPIRED, APPROVE NEW ELIG RESULTS") then
             actionable_dail = False
         '----------------------------------------------------------------------------------------------------Removing older specific INFO messages


### PR DESCRIPTION
Updated language in actionable_dail function to reflect correct DAIL language for CEC PEPR message - "MEMBER IS CHILD UNDER AGE 6 - ANNUAL HC NOTICE SENT". Fixes https://github.com/Hennepin-County/MAXIS-scripts/issues/2093.