### PR TITLE
#99 Create DAIL scrubber for MEC2 messages

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -3060,6 +3060,22 @@ script_array(script_num).usage_eval				= ""
 script_num = script_num + 1							   'Increment by one
 ReDim Preserve script_array(script_num)	   'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie	  'Set this array element to be a new script. Script details below...
+script_array(script_num).script_name		    = "MEC2 Message"
+' script_array(script_num).description		    = "Deletes non-actionable MEC2 messages and opens a dialog with policy links for actionable MEC2 messages."
+script_array(script_num).category               = "DAIL"
+script_array(script_num).workflows              = ""
+script_array(script_num).tags                   = array("")
+script_array(script_num).dlg_keys               = array("")
+script_array(script_num).subcategory            = array("")
+script_array(script_num).release_date           = #01/21/2025#
+script_array(script_num).hot_topic_link			= ""
+script_array(script_num).used_for_elig			= False
+script_array(script_num).policy_references		= array("")						'SEE Line 58 for format'
+script_array(script_num).usage_eval				= "STANDARD"
+
+script_num = script_num + 1							   'Increment by one
+ReDim Preserve script_array(script_num)	   'Resets the array to add one more element to it
+Set script_array(script_num) = new script_bowie	  'Set this array element to be a new script. Script details below...
 script_array(script_num).script_name		    = "MEMO from List"
 ' script_array(script_num).description		    = "Creates the same MEMO on cases listed in REPT/ACTV, manually entered, or from an Excel spreadsheet of your choice."
 script_array(script_num).category               = "ADMIN"

--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -3060,22 +3060,6 @@ script_array(script_num).usage_eval				= ""
 script_num = script_num + 1							   'Increment by one
 ReDim Preserve script_array(script_num)	   'Resets the array to add one more element to it
 Set script_array(script_num) = new script_bowie	  'Set this array element to be a new script. Script details below...
-script_array(script_num).script_name		    = "MEC2 Message"
-' script_array(script_num).description		    = "Deletes non-actionable MEC2 messages and opens a dialog with policy links for actionable MEC2 messages."
-script_array(script_num).category               = "DAIL"
-script_array(script_num).workflows              = ""
-script_array(script_num).tags                   = array("")
-script_array(script_num).dlg_keys               = array("")
-script_array(script_num).subcategory            = array("")
-script_array(script_num).release_date           = #01/21/2025#
-script_array(script_num).hot_topic_link			= ""
-script_array(script_num).used_for_elig			= False
-script_array(script_num).policy_references		= array("")						'SEE Line 58 for format'
-script_array(script_num).usage_eval				= "STANDARD"
-
-script_num = script_num + 1							   'Increment by one
-ReDim Preserve script_array(script_num)	   'Resets the array to add one more element to it
-Set script_array(script_num) = new script_bowie	  'Set this array element to be a new script. Script details below...
 script_array(script_num).script_name		    = "MEMO from List"
 ' script_array(script_num).description		    = "Creates the same MEMO on cases listed in REPT/ACTV, manually entered, or from an Excel spreadsheet of your choice."
 script_array(script_num).category               = "ADMIN"
@@ -5150,6 +5134,22 @@ script_array(script_num).tags                   = array("Communication", "Deduct
 script_array(script_num).dlg_keys               = array("Up")
 script_array(script_num).subcategory            = array("LTC")
 script_array(script_num).release_date           = #10/01/2000#
+script_array(script_num).hot_topic_link			= ""
+script_array(script_num).used_for_elig			= False
+script_array(script_num).policy_references		= array("")						'SEE Line 58 for format'
+script_array(script_num).usage_eval				= "STANDARD"
+
+script_num = script_num + 1							   'Increment by one
+ReDim Preserve script_array(script_num)	   'Resets the array to add one more element to it
+Set script_array(script_num) = new script_bowie	  'Set this array element to be a new script. Script details below...
+script_array(script_num).script_name		    = "MEC2 Message"
+' script_array(script_num).description		    = "Deletes non-actionable MEC2 messages and opens a dialog with policy links for actionable MEC2 messages."
+script_array(script_num).category               = "DAIL"
+script_array(script_num).workflows              = ""
+script_array(script_num).tags                   = array("")
+script_array(script_num).dlg_keys               = array("")
+script_array(script_num).subcategory            = array("")
+script_array(script_num).release_date           = #01/21/2025#
 script_array(script_num).hot_topic_link			= ""
 script_array(script_num).used_for_elig			= False
 script_array(script_num).policy_references		= array("")						'SEE Line 58 for format'

--- a/dail/MEC2-message.vbs
+++ b/dail/MEC2-message.vbs
@@ -106,7 +106,7 @@ If instr(full_message, "RSDI END DATE") OR instr(full_message, "SSI REPORTED TO 
 				err_msg = "LOOP"
 			End If
 			If ButtonPressed = script_instructions_btn Then 
-				run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/DAIL%20-%20MEC2%20Message.docx"
+				run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/ALL%20DAIL%20SCRIPTS.docx"
 				err_msg = "LOOP"
 			End If
 		Loop until err_msg = ""
@@ -121,18 +121,27 @@ Else
 
 	'Dialog informing worker that message will be deleted
 	Dialog1 = "" 'blanking out dialog name
-	BeginDialog Dialog1, 0, 0, 311, 115, "DAIL - MEC2 Message"
+	BeginDialog Dialog1, 0, 0, 306, 115, "DAIL - MEC2 Message"
 		ButtonGroup ButtonPressed
 		OkButton 205, 95, 50, 15
 		CancelButton 255, 95, 50, 15
 		Text 5, 5, 55, 10, "DAIL Message"
 		Text 5, 20, 300, 35, full_message
 		Text 5, 65, 300, 20, "This MEC2 message is non-actionable and will be deleted. Press 'OK' to delete the message. Press 'Cancel' to stop the script."
+		ButtonGroup ButtonPressed
+		PushButton 5, 95, 65, 15, "Script Instructions", script_instructions_btn
 	EndDialog
 
 	DO
-		Dialog Dialog1
-		cancel_without_confirmation
+		Do
+			err_msg = ""    'This is the error message handling
+			Dialog Dialog1
+			cancel_without_confirmation
+			If ButtonPressed = script_instructions_btn Then 
+				run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/DAIL/ALL%20DAIL%20SCRIPTS.docx"
+				err_msg = "LOOP"
+			End If
+		Loop until err_msg = ""
 		CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
 	LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
 
@@ -433,46 +442,46 @@ End if
 '------Task/Step--------------------------------------------------------------Date completed---------------Notes-----------------------
 '
 '------Dialogs--------------------------------------------------------------------------------------------------------------------
-'--Dialog1 = "" on all dialogs -------------------------------------------------
-'--Tab orders reviewed & confirmed----------------------------------------------
-'--Mandatory fields all present & Reviewed--------------------------------------
-'--All variables in dialog match mandatory fields-------------------------------
-'Review dialog names for content and content fit in dialog----------------------
-'--FIRST DIALOG--NEW EFF 5/23/2024----------------------------------------------
-'--Include script category and name somewhere on first dialog-------------------
-'--Create a button to reference instructions------------------------------------
+'--Dialog1 = "" on all dialogs -------------------------------------------------01/21/2025
+'--Tab orders reviewed & confirmed----------------------------------------------01/21/2025
+'--Mandatory fields all present & Reviewed--------------------------------------01/21/2025
+'--All variables in dialog match mandatory fields-------------------------------01/21/2025
+'Review dialog names for content and content fit in dialog----------------------01/21/2025
+'--FIRST DIALOG--NEW EFF 5/23/2024----------------------------------------------01/21/2025
+'--Include script category and name somewhere on first dialog-------------------01/21/2025
+'--Create a button to reference instructions------------------------------------01/21/2025
 '
 '-----CASE:NOTE-------------------------------------------------------------------------------------------------------------------
-'--All variables are CASE:NOTEing (if required)---------------------------------
-'--CASE:NOTE Header doesn't look funky------------------------------------------
-'--Leave CASE:NOTE in edit mode if applicable-----------------------------------
-'--write_variable_in_CASE_NOTE function: confirm that proper punctuation is used -----------------------------------
+'--All variables are CASE:NOTEing (if required)---------------------------------N/A
+'--CASE:NOTE Header doesn't look funky------------------------------------------N/A
+'--Leave CASE:NOTE in edit mode if applicable-----------------------------------N/A
+'--write_variable_in_CASE_NOTE function: confirm proper punctuation is used-----N/A
 '
 '-----General Supports-------------------------------------------------------------------------------------------------------------
-'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------
-'--MAXIS_background_check reviewed (if applicable)------------------------------
-'--PRIV Case handling reviewed -------------------------------------------------
-'--Out-of-County handling reviewed----------------------------------------------
-'--script_end_procedures (w/ or w/o error messaging)----------------------------
-'--BULK - review output of statistics and run time/count (if applicable)--------
-'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------
+'--Check_for_MAXIS/Check_for_MMIS reviewed--------------------------------------01/21/2025
+'--MAXIS_background_check reviewed (if applicable)------------------------------01/21/2025
+'--PRIV Case handling reviewed -------------------------------------------------01/21/2025
+'--Out-of-County handling reviewed----------------------------------------------01/21/2025
+'--script_end_procedures (w/ or w/o error messaging)----------------------------01/21/2025
+'--BULK - review output of statistics and run time/count (if applicable)--------01/21/2025
+'--All strings for MAXIS entry are uppercase vs. lower case (Ex: "X")-----------01/21/2025
 '
 '-----Statistics--------------------------------------------------------------------------------------------------------------------
-'--Manual time study reviewed --------------------------------------------------
-'--Incrementors reviewed (if necessary)-----------------------------------------
-'--Denomination reviewed -------------------------------------------------------
-'--Script name reviewed---------------------------------------------------------
-'--BULK - remove 1 incrementor at end of script reviewed------------------------
+'--Manual time study reviewed --------------------------------------------------01/21/2025
+'--Incrementors reviewed (if necessary)-----------------------------------------01/21/2025
+'--Denomination reviewed -------------------------------------------------------01/21/2025
+'--Script name reviewed---------------------------------------------------------01/21/2025
+'--BULK - remove 1 incrementor at end of script reviewed------------------------N/A
 
 '-----Finishing up------------------------------------------------------------------------------------------------------------------
-'--Confirm all GitHub tasks are complete----------------------------------------
-'--comment Code-----------------------------------------------------------------
-'--Update Changelog for release/update------------------------------------------
-'--Remove testing message boxes-------------------------------------------------
-'--Remove testing code/unnecessary code-----------------------------------------
-'--Review/update SharePoint instructions----------------------------------------
-'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------
-'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------
-'--COMPLETE LIST OF SCRIPTS update policy references----------------------------
-'--Complete misc. documentation (if applicable)---------------------------------
-'--Update project team/issue contact (if applicable)----------------------------
+'--Confirm all GitHub tasks are complete----------------------------------------01/21/2025
+'--comment Code-----------------------------------------------------------------01/21/2025
+'--Update Changelog for release/update------------------------------------------01/21/2025
+'--Remove testing message boxes-------------------------------------------------01/21/2025
+'--Remove testing code/unnecessary code-----------------------------------------01/21/2025
+'--Review/update SharePoint instructions----------------------------------------01/21/2025
+'--Other SharePoint sites review (HSR Manual, etc.)-----------------------------01/21/2025
+'--COMPLETE LIST OF SCRIPTS reviewed--------------------------------------------01/21/2025
+'--COMPLETE LIST OF SCRIPTS update policy references----------------------------01/21/2025
+'--Complete misc. documentation (if applicable)---------------------------------01/21/2025
+'--Update project team/issue contact (if applicable)----------------------------01/21/2025

--- a/dail/MEC2-message.vbs
+++ b/dail/MEC2-message.vbs
@@ -1,0 +1,151 @@
+'STATS GATHERING=============================================================================================================
+name_of_script = "DAIL - MEC2 Message.vbs"       'REPLACE TYPE with either ACTIONS, BULK, DAIL, NAV, NOTES, NOTICES, or UTILITIES. The name of the script should be all caps. The ".vbs" should be all lower case.
+start_time = timer
+STATS_counter = 1               'sets the stats counter at one
+STATS_manualtime = 1            'manual run time in seconds  -----REPLACE STATS_MANUALTIME = 1 with the anctual manualtime based on time study
+STATS_denomination = "C"        'C is for each case; I is for Instance, M is for member; REPLACE with the denomonation appliable to your script.
+'END OF stats block==========================================================================================================
+
+'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
+IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
+	IF run_locally = FALSE or run_locally = "" THEN	   'If the scripts are set to run locally, it skips this and uses an FSO below.
+		IF use_master_branch = TRUE THEN			   'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		Else											'Everyone else should use the release branch.
+			FuncLib_URL = "https://raw.githubusercontent.com/Hennepin-County/MAXIS-scripts/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
+		End if
+		SET req = CreateObject("Msxml2.XMLHttp.6.0")				'Creates an object to get a FuncLib_URL
+		req.open "GET", FuncLib_URL, FALSE							'Attempts to open the FuncLib_URL
+		req.send													'Sends request
+		IF req.Status = 200 THEN									'200 means great success
+			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
+			Execute req.responseText								'Executes the script code
+		ELSE														'Error message
+			critical_error_msgbox = MsgBox ("Something has gone wrong. The Functions Library code stored on GitHub was not able to be reached." & vbNewLine & vbNewLine &_
+                                            "FuncLib URL: " & FuncLib_URL & vbNewLine & vbNewLine &_
+                                            "The script has stopped. Please check your Internet connection. Consult a scripts administrator with any questions.", _
+                                            vbOKonly + vbCritical, "BlueZone Scripts Critical Error")
+            StopScript
+		END IF
+	ELSE
+		FuncLib_URL = "C:\MAXIS-scripts\MASTER FUNCTIONS LIBRARY.vbs"
+		Set run_another_script_fso = CreateObject("Scripting.FileSystemObject")
+		Set fso_command = run_another_script_fso.OpenTextFile(FuncLib_URL)
+		text_from_the_other_script = fso_command.ReadAll
+		fso_command.Close
+		Execute text_from_the_other_script
+	END IF
+END IF
+'END FUNCTIONS LIBRARY BLOCK================================================================================================
+
+'CHANGELOG BLOCK===========================================================================================================
+'Starts by defining a changelog array
+changelog = array()
+
+'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
+'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County
+CALL changelog_update("01/01/01", "Initial version.", "Ilse Ferris, Hennepin County") 'REPLACE with release date and your name.
+
+'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
+changelog_display
+'END CHANGELOG BLOCK =======================================================================================================
+
+'THE SCRIPT==================================================================================================================
+EMConnect "" 'Connects to BlueZone
+CALL MAXIS_case_number_finder(MAXIS_case_number)    				'Grabs the MAXIS case number automatically
+Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)		'Grabs the footer month and year from MAXIS
+'  -- OR --
+MAXIS_footer_month = CM_plus_1_mo									'Directly assigns a footer month based on the current month
+MAXIS_footer_year = CM_plus_1_yr
+
+Dialog1 = "" 'blanking out dialog name
+'Add dialog here: Add the dialog just before calling the dialog below unless you need it in the dialog due to using COMBO Boxes or other looping reasons. Blank out the dialog name with Dialog1 = "" before adding dialog.
+'    Some Dialog Elements:  Initial Dialog Header: 			BeginDialog Dialog1, 0, 0, 191, 105, "CATEGORY - NAME Case Number Dialog"  				-- Use CATEGORY - NAME somewhere in the header
+'							Script Instructions Button:		PushButton 135, 5, 50, 15, "Instructions", script_instructions_btn						-- Have a button to open the instructions
+'							Script Purpose/Overview: 		Text 10, 70, 120, 30, "Here is a quick summary of the purpose of the script."			-- Give the worker a little guidance
+'							Include edit boxes for necessary details like Case Number, Footer Month, Footer Year, and Worker Signature
+'Shows dialog (replace "sample_dialog" with the actual dialog you entered above)----------------------------------
+DO
+    Do
+        err_msg = ""    'This is the error message handling
+        Dialog Dialog1
+        cancel_confirmation or cancel_without_confirmation
+        'Add in all of your mandatory field handling from your dialog here.
+        Call validate_MAXIS_case_number(err_msg, "*") ' IF NEEDED
+        Call validate_footer_month_entry(MAXIS_footer_month, MAXIS_footer_year, err_msg, "*")   'IF NEEDED
+        'The rest of the mandatory handling here
+        IF trim(worker_signature) = "" THEN err_msg = err_msg & vbCr & "* Please sign your case note." 'IF NEEDED
+		If ButtonPressed = script_instructions_btn Then
+			run "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe https://hennepin.sharepoint.com/:w:/r/teams/hs-economic-supports-hub/BlueZone_Script_Instructions/CATEGORY/CATEGORY%20-%20NAME.docx"	'copy the instructions URL here
+			err_msg = "LOOP"
+		End If
+        IF err_msg <> "" AND err_msg <> "LOOP" THEN MsgBox "*** NOTICE!***" & vbNewLine & err_msg & vbNewLine
+    Loop until err_msg = ""
+    'Add to all dialogs where you need to work within BLUEZONE
+    CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+LOOP UNTIL are_we_passworded_out = false					'loops until user passwords back in
+'End dialog section-----------------------------------------------------------------------------------------------
+
+'Checks to see if in MAXIS
+CALL check_for_MAXIS(True) or Call check_for_MAXIS(False)
+
+'Reset to SELF to check the MAXIS region
+'This is also helpful to ensure we are not starting in a CASE/NOTE or something
+Call back_to_SELF
+Call clear_line_of_text(18, 43) 					'clear and rewrite the CASE Number. This is optional but can help the worker not to lose the case number.
+EMWriteScreen MAXIS_case_number, 18, 43             'writing in the case number so that if cancelled, the worker doesn't lose the case number.
+
+'MAXIS Region Check
+'OPTIONAL - there may be a good reason to be able to run in inquiry or production
+EMReadScreen MX_region, 10, 22, 48
+MX_region = trim(MX_region)
+If MX_region = "INQUIRY DB" Then
+	continue_in_inquiry = MsgBox("You have started this script run in INQUIRY." & vbNewLine & vbNewLine & "The script cannot complete a CASE:NOTE when run in inquiry. The functionality is limited when run in inquiry. " & vbNewLine & vbNewLine & "Would you like to continue in INQUIRY?", vbQuestion + vbYesNo, "Continue in INQUIRY")
+	If continue_in_inquiry = vbNo Then
+		Call script_end_procedure("~PT NAME Script cancelled as it was run in inquiry.")
+	End If
+End If
+
+'PRIV Handling
+Call navigate_to_MAXIS_screen_review_PRIV("CASE", "CURR", is_this_priv)
+If is_this_PRIV = True then script_end_procedure("This case is privileged and you do not have access to it. The script will now end.")
+
+'Out of County Handling
+'There are a few reasons to allow a script to run on an out of county case - so review if this is needed.
+EMReadScreen pw_county_code, 2, 21, 19
+If pw_county_code <> "27" Then script_end_procedure("This case is not in Hennepin County and cannot be updated. The script will now end.")
+
+'Do you need to check for PRIV status
+Call navigate_to_MAXIS_screen_review_PRIV("STAT", "MEMB")
+
+'Do you need to check to see if case is out of county? Add Out-of-County handling here:
+'All your other navigation, data catpure and logic here. any other logic or pre case noting actions here.
+
+Call MAXIS_background_check 'IF NEEDED: meaning if you send it through background. Move this to where it makes sense.
+
+'Do you need to set a TIKL?
+Call create_TIKL(TIKL_text, num_of_days, date_to_start, ten_day_adjust, TIKL_note_text)
+
+'Now it navigates to a blank case note
+Call start_a_blank_case_note
+
+'...and enters a title (replace variables with your own content)...
+CALL write_variable_in_case_note("*** CASE NOTE HEADER ***")
+
+'...some editboxes or droplistboxes (replace variables with your own content)...
+CALL write_bullet_and_variable_in_case_note( "Here's the first bullet",  a_variable_from_your_dialog        )
+CALL write_bullet_and_variable_in_case_note( "Here's another bullet",    another_variable_from_your_dialog  )
+
+'...checkbox responses (replace variables with your own content)...
+If some_checkbox_from_your_dialog = checked     then CALL write_variable_in_case_note( "* The checkbox was checked."     )
+If some_checkbox_from_your_dialog = unchecked   then CALL write_variable_in_case_note( "* The checkbox was not checked." )
+
+'...and a worker signature.
+CALL write_variable_in_case_note("---")
+CALL write_variable_in_case_note(worker_signature)
+'leave the case note open and in edit mode unless you have a business reason not to (BULK scripts, multiple case notes, etc.)
+
+'End the script. Put any success messages in between the quotes, *always* starting with the word "Success!"
+script_end_procedure("")
+
+'Add your closing issue documentation here. Make sure it's the most up-to-date version (date on file).

--- a/dail/MEC2-message.vbs
+++ b/dail/MEC2-message.vbs
@@ -53,9 +53,6 @@ changelog_display
 'THE SCRIPT==================================================================================================================
 EMConnect "" 'Connects to BlueZone
 
-'Read the dail message
-' EmWriteScreen "X", 6, 3
-' transmit
 'Reads the entire line above the DAIL message (the full case name and case number)
 EmReadScreen full_case_name_number, 76, 5, 5
 dail_message_member_name = left(full_case_name_number, 4)
@@ -172,9 +169,9 @@ Else
 					EMWriteScreen "DAIL", 16, 43
 					EMWriteScreen "DAIL", 21, 70
 					transmit
-
+					
 					EMReadScreen back_to_dail_check, 8, 1, 72
-
+					
 					If back_to_dail_check <> "FMKDLAM6" Then
 						'Script will end if unable to navigate to DAIL from SELF
 						script_end_procedure("The script is unable to navigate back to the DAIL. The script will now end.")
@@ -184,10 +181,10 @@ Else
 						Call write_value_and_transmit("X", 4, 12)
 						EmWriteScreen "_", 7, 39
 						Call write_value_and_transmit("X", 16, 39)
-						
+
 						'Find previous case number and then case name
-						Call write_value_and_transmit(MAXIS_case_number, 16, 39)
-						Call write_value_and_transmit(dail_message_member_name, 16, 39)
+						Call write_value_and_transmit(MAXIS_case_number, 20, 38)
+						Call write_value_and_transmit(dail_message_member_name, 21, 25)
 
 						'Script will enter do loop to find match
 						'Set dail_row to 6 at start
@@ -207,16 +204,17 @@ Else
 
 							If check_full_case_name_number_message = full_case_name_number_message Then
 								'Matching message found, it will delete and then the script will end
-		
+
 								'Check if script is about to delete the last dail message to avoid DAIL bouncing backwards or issue with deleting only message in the DAIL
 								EMReadScreen last_dail_check, 12, 3, 67
 								last_dail_check = trim(last_dail_check)
 		
 								'If the current dail message is equal to the final dail message then it will delete the message and then exit the do loop so the script does not restart
 								last_dail_check = split(last_dail_check, " ")
-		
+								
+
 								Call write_value_and_transmit("D", dail_row, 3)
-		
+
 								'Handling for deleting message under someone else's x number
 								EMReadScreen other_worker_error, 25, 24, 2
 								other_worker_error = trim(other_worker_error)
@@ -295,6 +293,9 @@ Else
 									'If the script does find that there is a new case number (indicated by "CASE NBR"), it will write a "T" in the next row and transmit, bringing that case number to the top of your DAIL
 									Call write_value_and_transmit("T", dail_row + 1, 3)
 								End if
+
+								'Reset dail_row to 6
+								dail_row = 6
 							End If
 						Loop
 					End If
@@ -307,9 +308,9 @@ Else
 				EmWriteScreen "_", 7, 39
 				Call write_value_and_transmit("X", 16, 39)
 
-				'Script should now navigate to specific member name, or at least get close
-				EMWriteScreen dail_message_member_name, 21, 25
-				transmit
+				'Find previous case number and then case name
+				Call write_value_and_transmit(MAXIS_case_number, 20, 38)
+				Call write_value_and_transmit(dail_message_member_name, 21, 25)
 
 				'Script will enter do loop to find match
 				'Set dail_row to 6 at start
@@ -325,7 +326,7 @@ Else
 					EMReadScreen check_full_message_4, 70, 12, 5
 					check_full_case_name_number_message = check_full_case_name_number & trim(trim(check_full_message_1) & " " & trim(check_full_message_2) & " " & trim(check_full_message_3) & " " & trim(check_full_message_4))
 					'Exit message and transmit back to DAIL
-					transmit	
+					transmit
 
 					If check_full_case_name_number_message = full_case_name_number_message Then
 						'Matching message found, it will delete and then the script will end
@@ -336,6 +337,7 @@ Else
 
 						'If the current dail message is equal to the final dail message then it will delete the message and then exit the do loop so the script does not restart
 						last_dail_check = split(last_dail_check, " ")
+						
 
 						Call write_value_and_transmit("D", dail_row, 3)
 
@@ -417,6 +419,9 @@ Else
 							'If the script does find that there is a new case number (indicated by "CASE NBR"), it will write a "T" in the next row and transmit, bringing that case number to the top of your DAIL
 							Call write_value_and_transmit("T", dail_row + 1, 3)
 						End if
+
+						'Reset dail_row to 6
+						dail_row = 6
 					End If
 				Loop
 			End If

--- a/dail/dail-scrubber.vbs
+++ b/dail/dail-scrubber.vbs
@@ -320,6 +320,12 @@ If ISPI_check = "ISPI" then
     call run_from_GitHub(script_repository & "dail/incarceration.vbs")
 END IF
 
+'MEC2 Message (will delete or provide information for proper processing)
+If stat_check = "MEC2" Then 
+	If running_in_INQUIRY = True Then call script_end_procedure("It appears you are currently running in INQUIRY. The support for this DAIL requires the ability to delete messages in the DAIL and cannot operate in INQUIRY. The script will now end.")
+    call run_from_GitHub(script_repository & "dail/mec2-message.vbs")
+END IF
+
 'MEMBER HAS BEEN DISABLED 2 YEARS - REFER TO MEDICARE
 EMReadScreen MEDI_check, 52, 6, 20
 If MEDI_check = "MEMBER HAS BEEN DISABLED 2 YEARS - REFER TO MEDICARE" then


### PR DESCRIPTION
Added functionality to DAIL scrubber to determine if MEC2 message is actionable or non-actionable. For non-actionable messages, the script will notify the worker before deleting the message. The script has handling to navigate back to the DAIL message if needed to delete the message. If the MEC2 message is actionable, then the script will navigate to the corresponding STAT panel and provide a link to the HSR manual for further guidance on how to process the message. 