### PR TITLE
#2050, #2158 & #2178 NOTES - Interview Updates to enhance user experience

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1662,7 +1662,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
         addr_eff_date = replace(addr_eff_date, " ", "/")						'formatting the information from the second half
         addr_future_date = trim(addr_future_date)
         addr_future_date = replace(addr_future_date, " ", "/")
-		addr_future_date = DateAdd("d", 0, addr_future_date)					'Ensuring date is in date format
+		If addr_future_date <> "" and IsDate(addr_future_date) Then addr_future_date = DateAdd("d", 0, addr_future_date)					'Ensuring date is in date format
         mail_line_one = replace(mail_line_one, "_", "")
         mail_line_two = replace(mail_line_two, "_", "")
 		mail_street_full = trim(mail_line_one & " " & mail_line_two)

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1662,6 +1662,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
         addr_eff_date = replace(addr_eff_date, " ", "/")						'formatting the information from the second half
         addr_future_date = trim(addr_future_date)
         addr_future_date = replace(addr_future_date, " ", "/")
+		addr_future_date = DateAdd("d", 0, addr_future_date)					'Ensuring date is in date format
         mail_line_one = replace(mail_line_one, "_", "")
         mail_line_two = replace(mail_line_two, "_", "")
 		mail_street_full = trim(mail_line_one & " " & mail_line_two)
@@ -1755,6 +1756,7 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 		var_year = Right(addr_eff_date, 2)
 		addr_eff_date = var_month & "/" & var_day & "/" & var_year
 		addr_eff_date = trim(addr_eff_date)
+		addr_eff_date = DateAdd("d", 0, addr_eff_date)					'Ensuring date is in date format
 		addr_future_date = trim(addr_future_date)
 		phone_one = trim(phone_one)
 		phone_two = trim(phone_two)
@@ -1778,6 +1780,8 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 
 			'Determining correct month to update ADDR panel
 			footer_month_as_date = MAXIS_footer_month & "/01/" & MAXIS_footer_year
+			footer_month_as_date = DateAdd("d", 0, footer_month_as_date)					'Ensuring date is in date format
+			
 			If addr_eff_date > footer_month_as_date Then	'If addr_eff provided in the dialog is greater than the footer month date, we need to change the footer month to align with addr_eff month
 				addr_greater = TRUE
 				orig_footer_month = MAXIS_footer_month
@@ -1789,17 +1793,19 @@ function access_ADDR_panel(access_type, notes_on_address, resi_line_one, resi_li
 				addr_less = TRUE
 				orig_addr_eff_date = addr_eff_date
 				addr_eff_date = MAXIS_footer_month & "/01/" & MAXIS_footer_year
+				addr_eff_date = DateAdd("d", 0, addr_eff_date)					'Ensuring date is in date format
 			End If
 
 			Call navigate_to_MAXIS_screen("STAT", "ADDR")							'going to ADDR
 			EMReadScreen panel_addr_eff_date, 2, 4, 43								'reading addr effective date because we will need to compare it to the one provided in the dialog
 			EMReadScreen curr_addr_footer_month, 2, 20, 55							'reading the footer month and year on the panel because there is footer months pecific differences
 			EMReadScreen curr_addr_footer_year, 2, 20, 58
-			the_footer_month_date = curr_addr_footer_month &  "/1/" & curr_addr_footer_year		'making a date out of the footer month
+			the_footer_month_date = curr_addr_footer_month &  "/01/" & curr_addr_footer_year		'making a date out of the footer month
 			the_footer_month_date = DateAdd("d", 0, the_footer_month_date)
 			new_version = True														'defaulting to using the new verion of the panel with text authorization and email
 			If DateDiff("d", the_footer_month_date, #10/1/2021#) > 0 Then new_version = False	'if the footer months is BEFORE 10/1/2021, then we need to read the old version
 			panel_addr_eff_date = replace(panel_addr_eff_date, " ", "/")
+			panel_addr_eff_date = DateAdd("d", 0, panel_addr_eff_date)					'Ensuring date is in date format
 			If addr_eff_date < panel_addr_eff_date Then 				'handling to update the addr_eff_date if it is before the date already in the panel
 				day_different = TRUE
 				og_addr_eff = addr_eff_date

--- a/misc/interview-forms-classes.vbs
+++ b/misc/interview-forms-classes.vbs
@@ -642,8 +642,9 @@ class form_questions
 			dialog Dialog1
 			If ButtonPressed = -1 Then ButtonPressed = return_btn
 			If ButtonPressed = clear_btn Then
-				verif_status = "Not Needed"
-				verif_notes = ""
+				detail_verif_status(item_index) = ""
+				detail_verif_notes(item_index) = ""
+				ButtonPressed = return_btn
 			End If
 		Loop until ButtonPressed = return_btn
 	end sub
@@ -666,8 +667,9 @@ class form_questions
 			dialog Dialog1
 			If ButtonPressed = -1 Then ButtonPressed = return_btn
 			If ButtonPressed = clear_btn Then
-				verif_status = "Not Needed"
+				verif_status = ""
 				verif_notes = ""
+				ButtonPressed = return_btn
 			End If
 		Loop until ButtonPressed = return_btn
 	end sub

--- a/misc/interview-forms-classes.vbs
+++ b/misc/interview-forms-classes.vbs
@@ -178,7 +178,7 @@ class form_questions
 
 			GroupBox 5, y_pos, 475, grp_len, number & "." & dialog_phrasing
 			y_pos = y_pos + 20
-			Text 15, y_pos, 40, 10, "CAF Answer"
+			Text 13, y_pos, 42, 10, "Form Answer"
 			DropListBox 55, y_pos - 5, 35, 45, question_answers, question_yn
 			Text 95, y_pos, 25, 10, "write-in:"
 			EditBox 120, y_pos - 5, 350, 15, question_notes
@@ -277,7 +277,7 @@ class form_questions
 			'funcitonality here
 			GroupBox 5, y_pos, 475, dialog_height-5, number & "." & dialog_phrasing
 			y_pos = y_pos + 20
-			Text 15, y_pos, 40, 10, "CAF Answer"
+			Text 13, y_pos, 42, 10, "Form Answer"
 			DropListBox 55, y_pos - 5, 35, 45, question_answers, question_yn
 			Text 95, y_pos, 25, 10, "write-in:"
 			If verif_status = "" Then
@@ -308,12 +308,12 @@ class form_questions
 			col_3_2 = 360
 			col_3_3 = 430
 
-			Text 	col_1_1, 		y_pos, 40, 10, "CAF Answer"
-			Text 	col_1_3 - 3, 	y_pos, 40, 10, "CAF Amount"
-			Text 	col_2_1, 		y_pos, 40, 10, "CAF Answer"
-			Text 	col_2_3 - 3, 	y_pos, 40, 10, "CAF Amount"
-			Text 	col_3_1, 		y_pos, 40, 10, "CAF Answer"
-			Text 	col_3_3 - 3, 	y_pos, 40, 10, "CAF Amount"
+			Text 	col_1_1, 		y_pos, 42, 10, "Form Answer"
+			Text 	col_1_3 - 3, 	y_pos, 42, 10, "Form Amount"
+			Text 	col_2_1, 		y_pos, 42, 10, "Form Answer"
+			Text 	col_2_3 - 3, 	y_pos, 42, 10, "Form Amount"
+			Text 	col_3_1, 		y_pos, 42, 10, "Form Answer"
+			Text 	col_3_3 - 3, 	y_pos, 42, 10, "Form Amount"
 			y_pos = y_pos + 15
 
 			DropListBox 	col_1_1, 	y_pos, 		35, 45, question_answers, unea_1_yn
@@ -417,8 +417,8 @@ class form_questions
 
 
 			If make_array_checkboxes = true Then
-				If info_type = "msa" Then Text 	col_1_1, y_pos, 200, 10, "CAF Answer (check the expenses indicated on the CAF)"
-				If info_type = "stwk" Then Text col_1_1, y_pos, 200, 10, "CAF Answer (check the answers indicated on the CAF)"
+				If info_type = "msa" Then Text 	col_1_1, y_pos, 200, 10, "Form Answer (check the expenses indicated on the form)"
+				If info_type = "stwk" Then Text col_1_1, y_pos, 200, 10, "Form Answer (check the answers indicated on the form)"
 				y_pos = y_pos + 15
 
 				CheckBox  	col_1_1, y_pos, drplst_len+txt_len, 10, item_info_list(0), TEMP_ARRAY(0)
@@ -435,9 +435,9 @@ class form_questions
 				y_pos = y_pos + 5
 			Else
 
-				Text 	col_1_1, 		y_pos, 40, 10, "CAF Answer"
-				Text 	col_2_1, 		y_pos, 40, 10, "CAF Answer"
-				If col_3_1 <> "" Then Text 	col_3_1, y_pos, 40, 10, "CAF Answer"
+				Text 	col_1_1, 		y_pos, 42, 10, "Form Answer"
+				Text 	col_2_1, 		y_pos, 42, 10, "Form Answer"
+				If col_3_1 <> "" Then Text 	col_3_1, y_pos, 42, 10, "Form Answer"
 				y_pos = y_pos + 15
 
 				DropListBox 	col_1_1, y_pos - 5, drplst_len, 45, question_answers, TEMP_ARRAY(0)
@@ -494,7 +494,7 @@ class form_questions
 				phrase_width = len(sub_number & "." & sub_phrase)*3.5
 				phrase_width = round(phrase_width)
 				Text 15, y_pos, phrase_width, 10, sub_number & "." & sub_phrase
-				Text 15+phrase_width, y_pos, 55, 10, "CAF Answer"
+				Text 15+phrase_width, y_pos, 55, 10, "Form Answer"
 				DropListBox 65+phrase_width, y_pos - 5, 35, 45, question_answers, addtl_question
 				y_pos = y_pos + 20
 			End If
@@ -519,7 +519,7 @@ class form_questions
 		ElseIf info_type = "two-part" Then
 			GroupBox 5, y_pos, 475, dialog_height-5, number & "." & dialog_phrasing
 			y_pos = y_pos + 20
-			Text 15, y_pos, 40, 10, "CAF Answer"
+			Text 13, y_pos, 42, 10, "Form Answer"
 			DropListBox 55, y_pos - 5, 35, 45, question_answers, question_yn
 			Text 95, y_pos, 25, 10, "write-in:"
 			If verif_status = "" Then
@@ -533,7 +533,7 @@ class form_questions
 			phrase_width = len(sub_number & "." & sub_phrase)*3.5
 			phrase_width = round(phrase_width)
 			Text 15, y_pos, phrase_width, 10, sub_number & "." & sub_phrase
-			Text 15+phrase_width, y_pos, 55, 10, "CAF Answer"
+			Text 15+phrase_width, y_pos, 55, 10, "Form Answer"
 			DropListBox 65+phrase_width, y_pos - 5, 35, 45, question_answers, addtl_question
 			y_pos = y_pos + 15
 			Text 15, y_pos, 60, 10, "Interview Notes:"
@@ -544,7 +544,7 @@ class form_questions
 		ElseIf info_type = "single-detail" Then
 			GroupBox 5, y_pos, 475, dialog_height-5, number & "." & dialog_phrasing
 			y_pos = y_pos + 20
-			Text 15, y_pos, 40, 10, "CAF Answer"
+			Text 13, y_pos, 42, 10, "Form Answer"
 			DropListBox 55, y_pos - 5, 35, 45, question_answers, question_yn
 
 			phrase_width = len(sub_phrase & ":")*3.75
@@ -676,17 +676,17 @@ class form_questions
 		If info_type = "standard" or info_type = "two-part" or info_type = "single-detail" or detail_array_exists = true Then
 			'funcitonality here
 			If caf_answer <> "" OR trim(write_in_info) <> "" OR verif_status <> "" OR trim(interview_notes) <> "" Then CALL write_variable_in_CASE_NOTE(note_phrasing)
-			q_input = "    CAF Answer - " & caf_answer
+			q_input = "    Form Answer - " & caf_answer
 			If info_type = "single-detail" Then
 				If trim(sub_answer) <> "" Then q_input = q_input & " " & sub_note_phrase & ": " & sub_answer
 			End If
 			If caf_answer <> "" OR trim(write_in_info) <> "" Then q_input = q_input & " (Confirmed)"
-			If q_input <> "    CAF Answer - " Then CALL write_variable_in_CASE_NOTE(q_input)
+			If q_input <> "    Form Answer - " Then CALL write_variable_in_CASE_NOTE(q_input)
 			If info_type = "two-part" Then
 				q_sub_verbiage = "    Q" & number & sub_number & "." & sub_note_phrase
 				If sub_answer <> "" Then
 					Call write_variable_in_CASE_NOTE(q_sub_verbiage)
-					Call write_variable_in_CASE_NOTE("        CAF Answer - " & sub_answer)
+					Call write_variable_in_CASE_NOTE("        Form Answer - " & sub_answer)
 				End If
 			End If
 			If trim(write_in_info) <> "" Then CALL write_variable_in_CASE_NOTE("    WriteIn Answer - " & write_in_info)
@@ -779,7 +779,7 @@ class form_questions
 		ElseIf info_type = "unea" Then
 			If entirely_blank = false Then
 				Call write_variable_in_CASE_NOTE(note_phrasing)
-				CALL write_variable_in_CASE_NOTE("    CAF Answer:")
+				CALL write_variable_in_CASE_NOTE("    Form Answer:")
 
 				for i = 0 to 8
 					item_ans_list(i) = left(item_ans_list(i) & "   ", 5)
@@ -798,7 +798,7 @@ class form_questions
 		ElseIf info_type = "housing" or info_type = "utilities" or info_type = "assets" or info_type = "msa" or info_type = "stwk" Then
 			If entirely_blank = false Then
 				Call write_variable_in_CASE_NOTE(note_phrasing)
-				CALL write_variable_in_CASE_NOTE("    CAF Answer:")
+				CALL write_variable_in_CASE_NOTE("    Form Answer:")
 
 				for i = 0 to UBound(item_ans_list)
 					If IsNumeric(item_ans_list(i)) = True Then
@@ -847,7 +847,7 @@ class form_questions
 				q_sub_verbiage = "    Q" & number & sub_number & "." & sub_note_phrase
 				If sub_answer <> "" Then
 					Call write_variable_in_CASE_NOTE(q_sub_verbiage)
-					Call write_variable_in_CASE_NOTE("        CAF Answer - " & sub_answer)
+					Call write_variable_in_CASE_NOTE("        Form Answer - " & sub_answer)
 				End If
 			End If
 			If trim(write_in_info) <> "" Then CALL write_variable_in_CASE_NOTE("    WriteIn Answer - " & write_in_info)
@@ -864,10 +864,10 @@ class form_questions
 		objSelection.TypeText doc_phrasing & vbCr
 
 		If info_type = "standard" or info_type = "two-part" or info_type = "single-detail" or detail_array_exists = true Then
-			objSelection.TypeText chr(9) & "CAF Answer: " & caf_answer & vbCr
+			objSelection.TypeText chr(9) & "Form Answer: " & caf_answer & vbCr
 			If info_type = "two-part" Then
 				objSelection.TypeText "Q "& number&"."&sub_number&". "&sub_phrase & vbCr
-				objSelection.TypeText chr(9) & "CAF Answer: " & sub_answer & vbCr
+				objSelection.TypeText chr(9) & "Form Answer: " & sub_answer & vbCr
 			End If
 			If info_type = "single-detail" Then
 				If sub_answer <> "" Then objSelection.TypeText chr(9) & sub_note_phrase & ": " & sub_answer & vbCr
@@ -927,7 +927,7 @@ class form_questions
 							TABLE_ARRAY(array_counters).Cell(3, 1).Range.Text = "EMPLOYER/BUSINESS NAME"
 							TABLE_ARRAY(array_counters).Cell(4, 1).Range.Text = detail_business(each_item)
 
-							TABLE_ARRAY(array_counters).Cell(5, 1).Range.Text = "CAF NOTES"
+							TABLE_ARRAY(array_counters).Cell(5, 1).Range.Text = "FORM NOTES"
 							TABLE_ARRAY(array_counters).Cell(6, 1).Range.Text = detail_write_in_info(each_item)
 
 							TABLE_ARRAY(array_counters).Cell(7, 1).Range.Text = "INTERVIEW NOTES"
@@ -1208,10 +1208,10 @@ class form_questions
 				If subsidy_yn = "" and subsidy_amount = "" Then objSelection.TypeText chr(9) & "Subsidy: BLANK    Subsidy Amount: $ BLANK /month" & vbCr
 			End If
 
-			If write_in_info <> "" Then objSelection.TypeText chr(9) & "CAF Info Write-In: " & write_in_info & vbCr
+			If write_in_info <> "" Then objSelection.TypeText chr(9) & "Form Info Write-In: " & write_in_info & vbCr
 			If verif_status <> "Mot Needed" AND verif_status <> "" Then objSelection.TypeText chr(9) & "Verification: " & verif_status & vbCr
 			If verif_notes <> "" Then objSelection.TypeText chr(9) & chr(9) & "Details: " & verif_notes & vbCr
-			If caf_answer <> "" OR trim(write_in_info) <> "" Then objSelection.TypeText chr(9) & "CAF Confirmed during the Interview" & vbCR
+			If caf_answer <> "" OR trim(write_in_info) <> "" Then objSelection.TypeText chr(9) & "Form Confirmed during the Interview" & vbCR
 			If interview_notes <> "" Then objSelection.TypeText chr(9) & "Notes from Interview: " & interview_notes & vbCR
 		ElseIf info_type = "unea" or info_type = "housing" or info_type = "utilities" or info_type = "assets" or info_type = "msa" or info_type = "stwk" Then
 
@@ -1354,14 +1354,14 @@ class form_questions
 			array_counters = array_counters + 1
 			If sub_phrase <> "" Then
 				objSelection.TypeText "Q "& number&"."&sub_number&". "&sub_phrase & vbCr
-				objSelection.TypeText chr(9) & "CAF Answer: " & sub_answer & vbCr
+				objSelection.TypeText chr(9) & "Form Answer: " & sub_answer & vbCr
 			End If
 
-			If write_in_info <> "" Then objSelection.TypeText chr(9) & "CAF Info Write-In: " & write_in_info & vbCr
+			If write_in_info <> "" Then objSelection.TypeText chr(9) & "Form Info Write-In: " & write_in_info & vbCr
 			If verif_status <> "Mot Needed" AND verif_status <> "" Then objSelection.TypeText chr(9) & "Verification: " & verif_status & vbCr
 			If verif_notes <> "" Then objSelection.TypeText chr(9) & chr(9) & "Details: " & verif_notes & vbCr
 
-			If entirely_blank = false Then objSelection.TypeText chr(9) & "CAF Confirmed during the Interview" & vbCR
+			If entirely_blank = false Then objSelection.TypeText chr(9) & "Form Confirmed during the Interview" & vbCR
 			If interview_notes <> "" Then objSelection.TypeText chr(9) & "Notes from Interview: " & interview_notes & vbCR
 		End If
 	end sub
@@ -2396,7 +2396,7 @@ function array_details_dlg(form_question_numb, selected)
 			End If
 
 
-			Text 10, det_dlg_len-80, 110, 10, "CAF WRITE-IN INFORMATION:"
+			Text 10, det_dlg_len-80, 110, 10, "FORM WRITE-IN INFORMATION:"
 			EditBox 10, det_dlg_len-70, 305, 15, temp_write_in_info
 			Text 10, det_dlg_len-50, 85, 10, "INTERVIEW NOTES:"
 			EditBox 10, det_dlg_len-40, 305, 15, temp_interview_notes

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -1067,6 +1067,9 @@ function define_main_dialog()
 			EditBox 190, 100, 45, 15, emergency_deadline
 		' ElseIf page_display =  Then
 		ElseIf page_display = show_pg_last Then
+			If second_signature_detail = "Select or Type" or second_signature_detail = "" Then
+				If UBound(HH_MEMB_ARRAY, 2) = 0 Then second_signature_detail = "Not Required"
+			End If
 			Text 498, last_pos, 60, 10, "CAF Last Page"
 
 			GroupBox 5, 5, 475, 60, "Confirm Authorized Representative"

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -8377,7 +8377,10 @@ End if
 
 Call check_for_MAXIS(False)
 
-If need_to_update_addr = "True" then need_to_update_addr = True
+If need_to_update_addr = "True" then 
+	need_to_update_addr = True
+	If addr_verif = "__" OR addr_verif = "Blank" Then addr_verif = "OT"
+End If
 If need_to_update_addr = "False" then need_to_update_addr = False
 
 

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -2624,6 +2624,7 @@ function verbal_requests()
 	If cash1_closed_in_past_30_days = True or cash1_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 	If cash2_closed_in_past_30_days = True or cash2_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 	If issued_date <> "" Then dlg_len = dlg_len + 10
+	If dlg_len = 230 Then dlg_len = dlg_len + 10
 
 	Dialog1 = ""
 	BeginDialog Dialog1, 0, 0, 316, dlg_len, "Programs to Interview For"
@@ -7556,12 +7557,14 @@ End If
 Do
 	DO
 		dlg_len = 210
-		If run_by_interview_team = True Then dlg_len = 295
+		If run_by_interview_team = True Then dlg_len = 285
+		orig_dlg_len = dlg_len
 		If snap_closed_in_past_30_days = True or snap_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 		If grh_closed_in_past_30_days = True or grh_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 		If cash1_closed_in_past_30_days = True or cash1_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 		If cash2_closed_in_past_30_days = True or cash2_closed_in_past_4_months = True Then dlg_len = dlg_len + 10
 		If issued_date <> "" Then dlg_len = dlg_len + 10
+		If dlg_len = orig_dlg_len Then dlg_len = dlg_len + 10
 
 		Dialog1 = ""
 		BeginDialog Dialog1, 0, 0, 326, dlg_len, "Programs to Interview For"

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -9951,32 +9951,42 @@ End If
 objSelection.EndKey end_of_doc						'this sets the cursor to the end of the document for more writing
 objSelection.TypeParagraph()						'adds a line between the table and the next information
 
-objSelection.Font.Bold = TRUE
-objSelection.TypeText "EXPEDITED Interview Answers:" & vbCr
-objSelection.Font.Bold = FALSE
-If case_is_expedited = True Then
-	objSelection.TypeText "Based on income information this case APPEARS ELIGIBLE FOR EXPEDITED SNAP." & vbCr
-Else
-	objSelection.TypeText "This case does not appear eligible for expedited SNAP based on the income information." & vbCr
-End If
-
-objSelection.TypeText chr(9) & "Income in the month of application: " & intv_app_month_income & vbCr
-objSelection.TypeText chr(9) & "Assets in the month of application: " & intv_app_month_asset & vbCr
-objSelection.TypeText chr(9) & "Expenses in the month of application: " & app_month_expenses & vbCr
-objSelection.TypeText chr(9) & chr(9) & "Housing expense in the month of application: " & intv_app_month_housing_expense & vbCr
-objSelection.TypeText chr(9) & chr(9) & "Utilities in the month of application: " & utilities_cost & vbCr
-If case_is_expedited = True Then
-	If id_verif_on_file = "No" OR snap_active_in_other_state = "Yes" OR last_snap_was_exp = "Yes" Then
-		objSelection.TypeText chr(9) & "Expedited Approval must be delayed:" & vbCr
-		objSelection.TypeText chr(9) & chr(9) & "Detail: " & expedited_delay_info & vbCr
-		If id_verif_on_file = "No" Then 			objSelection.TypeText chr(9) & chr(9) & "" & vbCr
-		If snap_active_in_other_state = "Yes" Then 	objSelection.TypeText chr(9) & chr(9) & "" & vbCr
-		If last_snap_was_exp = "Yes" Then 			objSelection.TypeText chr(9) & chr(9) & "" & vbCr
+If expedited_determination_needed = True Then
+	objSelection.Font.Bold = TRUE
+	objSelection.TypeText "EXPEDITED Interview Answers:" & vbCr
+	objSelection.Font.Bold = FALSE
+	If case_is_expedited = True Then
+		objSelection.TypeText "Based on income information this case APPEARS ELIGIBLE FOR EXPEDITED SNAP." & vbCr
+	Else
+		objSelection.TypeText "This case does not appear eligible for expedited SNAP based on the income information." & vbCr
 	End If
-End If
+	If run_by_interview_team = True Then
+		objSelection.TypeText chr(9) & "Income in the month of application: " & exp_det_income & vbCr
+		objSelection.TypeText chr(9) & "Assets in the month of application: " & exp_det_assets & vbCr
+		objSelection.TypeText chr(9) & "Expenses in the month of application: " & calculated_expenses & vbCr
+		objSelection.TypeText chr(9) & chr(9) & "Housing expense in the month of application: " & exp_det_housing & vbCr
+		objSelection.TypeText chr(9) & chr(9) & "Utilities in the month of application: " & exp_det_utilities & vbCr
+		If trim(exp_det_notes) <> "" Then objSelection.TypeText chr(9) & "Additional Notes: " & exp_det_notes & vbCr
+	Else
+		objSelection.TypeText chr(9) & "Income in the month of application: " & intv_app_month_income & vbCr
+		objSelection.TypeText chr(9) & "Assets in the month of application: " & intv_app_month_asset & vbCr
+		objSelection.TypeText chr(9) & "Expenses in the month of application: " & app_month_expenses & vbCr
+		objSelection.TypeText chr(9) & chr(9) & "Housing expense in the month of application: " & intv_app_month_housing_expense & vbCr
+		objSelection.TypeText chr(9) & chr(9) & "Utilities in the month of application: " & utilities_cost & vbCr
+		If case_is_expedited = True Then
+			If id_verif_on_file = "No" OR snap_active_in_other_state = "Yes" OR last_snap_was_exp = "Yes" Then
+				objSelection.TypeText chr(9) & "Expedited Approval must be delayed:" & vbCr
+				objSelection.TypeText chr(9) & chr(9) & "Detail: " & expedited_delay_info & vbCr
+				If id_verif_on_file = "No" Then 			objSelection.TypeText chr(9) & chr(9) & "" & vbCr
+				If snap_active_in_other_state = "Yes" Then 	objSelection.TypeText chr(9) & chr(9) & "" & vbCr
+				If last_snap_was_exp = "Yes" Then 			objSelection.TypeText chr(9) & chr(9) & "" & vbCr
+			End If
+		End If
+	End If
 
-objSelection.EndKey end_of_doc						'this sets the cursor to the end of the document for more writing
-objSelection.TypeParagraph()						'adds a line between the table and the next information
+	objSelection.EndKey end_of_doc						'this sets the cursor to the end of the document for more writing
+	objSelection.TypeParagraph()						'adds a line between the table and the next information
+End If
 
 objSelection.Font.Bold = TRUE
 objSelection.TypeText "Interview Answers:" & vbCr

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -56,6 +56,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("01/27/2025", "Interview Updates:##~## - Added a 'Clear ALL' button to verifications.##~##   (New Interview - Verifications instruction document!)##~## - Remove entry of signature date as it is not necessary to document.##~## - Added information on the WIF and CASE/NOTE about verbal signature to align with policy.##~## - Updated some formatting and verbiage to align with different form types.##~## - Fixed bug in the Expedited information in the WIF.##~## ##~##These updates are far reaching and with a large script like the Interview script, there may be places where additional functionality or updates are needed. Please report anything you notice about these changes.##~##", "Casey Love, Hennepin County")
 call changelog_update("11/27/2024", "Update to the process for documenting verbal program requests and documenting verbal program request withdrawals.##~##", "Casey Love, Hennepin County")
 call changelog_update("11/20/2024", "BIG NEWS ! ##~## ##~## The Interview Script now supports different questions for different form selections!!!!##~## ##~##As this is brand new AND a very large change there may be some unexpected results or bugs. Please alert the script team to any bugs, questions, or thoughts you have on the updates.##~## ##~##We are very excited to be able to get this functionality out.", "Casey Love, Hennepin County")
 call changelog_update("10/23/2024", "Added emergency questions.", "Mark Riegel, Hennepin County")
@@ -10368,7 +10369,7 @@ ElseIf signature_detail = "Blank" Then
 	objSelection.TypeText "Signature of Primary Adult is blank." & vbCr
 End If
 If second_signature_detail <> "Not Required" AND second_signature_detail <> "Blank" Then
-	objSelection.TypeText "Signature of Secondary Adult: " & second_signature_person ", " & second_signature_detail & vbCr
+	objSelection.TypeText "Signature of Secondary Adult: " & second_signature_person & ", " & second_signature_detail & vbCr
 ElseIf second_signature_detail = "Blank" Then
 	objSelection.TypeText "Signature of Secondary Adult is blank." & vbCr
 End If

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -4619,6 +4619,7 @@ function verification_dialog()
 
               ButtonGroup ButtonPressed
                 PushButton 540, 10, 60, 15, "Return to Dialog", return_to_dialog_button
+				PushButton 465, 365, 125, 15, "Clear ALL Requested Verifications", clear_verifs_btn
               ' Text 10, 340, 580, 50, verifs_needed
             EndDialog
 
@@ -4818,6 +4819,32 @@ function verification_dialog()
 
 			If ButtonPressed = add_verif_button Then verif_err_msg = "LOOP" & verif_err_msg
             If ButtonPressed = fill_button Then verif_err_msg = "LOOP" & verif_err_msg
+			If ButtonPressed = clear_verifs_btn Then
+				verif_err_msg = "LOOP" & verif_err_msg
+				verifs_selected = ""
+
+				For the_members = 0 to UBound(HH_MEMB_ARRAY, 2)
+					If HH_MEMB_ARRAY(client_verification, the_members) = "Requested" Then
+						HH_MEMB_ARRAY(client_verification, the_members) = ""
+						HH_MEMB_ARRAY(client_verification_details, the_members) = ""
+					End If
+				Next
+
+				For quest = 0 to UBound(FORM_QUESTION_ARRAY)
+					If FORM_QUESTION_ARRAY(quest).verif_status = "Requested" Then
+						FORM_QUESTION_ARRAY(quest).verif_status = ""
+						FORM_QUESTION_ARRAY(quest).verif_notes = ""
+					End If
+					If FORM_QUESTION_ARRAY(quest).detail_array_exists = True Then
+						For each_item = 0 to UBound(FORM_QUESTION_ARRAY(quest).detail_interview_notes)
+							If FORM_QUESTION_ARRAY(quest).detail_verif_status(each_item) = "Requested" Then
+								FORM_QUESTION_ARRAY(quest).detail_verif_status(each_item) = ""
+								FORM_QUESTION_ARRAY(quest).detail_verif_notes(each_item) = ""
+							End If
+						Next
+					End If
+				Next
+			End If
         Loop until verif_err_msg = ""
         ButtonPressed = verif_button
     End If
@@ -7129,7 +7156,7 @@ If vars_filled = True Then
 				FORM_QUESTION_ARRAY(question_num).guide_btn 			= 500+question_num
 				FORM_QUESTION_ARRAY(question_num).verif_btn 			= 1000+question_num
 				If FORM_QUESTION_ARRAY(question_num).prefil_btn <> "" Then FORM_QUESTION_ARRAY(question_num).prefil_btn			= 2000+question_num
-				If FORM_QUESTION_ARRAY(question_num).add_to_array_btn <> "" Then FORM_QUESTION_ARRAY(question_num).add_to_array_btn	= 3000+question_num
+				If FORM_QUESTION_ARRAY(question_num).detail_array_exists = True Then FORM_QUESTION_ARRAY(question_num).add_to_array_btn	= 3000+question_num
 				question_num = question_num + 1
 			next
 			set xmlDoc = nothing
@@ -7879,6 +7906,7 @@ amounts_btn						= 827
 determination_btn				= 828
 return_to_dialog_button			= 829
 fn_review_btn					= 830
+clear_verifs_btn				= 831
 
 open_r_and_r_btn				= 700
 accounting_service_desk_btn		= 701
@@ -8001,6 +8029,7 @@ discrepancy_questions = start_at + 2
 expedited_determination = start_at + 3
 show_pg_last = start_at + 4
 
+Call navigate_to_MAXIS_screen("STAT", "MEMB")
 
 interview_questions_clear = False
 Do
@@ -10267,7 +10296,7 @@ If resident_emergency_yn <> " " or (trim(emergency_type) <> "" and trim(emergenc
 		objSelection.TypeText "What emergency is the resident is experiencing?" & vbCr
 		objSelection.TypeText chr(9) & emergency_type & vbCr
 	End If
-	If trim(emergency_discussion) <> "" Then C
+	If trim(emergency_discussion) <> "" Then
 		objSelection.TypeText "Discussion of emergency with resident:" & vbCr
 		objSelection.TypeText chr(9) & emergency_discussion & vbCr
 	End If

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -246,6 +246,7 @@ function assess_caf_1_expedited_questions(expedited_screening)
 	exp_q_2_assets_this_month = exp_q_2_assets_this_month & ""
 	exp_q_3_rent_this_month = exp_q_3_rent_this_month & ""
 
+	If expedited_screening_on_form = False Then expedited_screening = ""
 end function
 
 full_err_msg = full_err_msg & "~!~" & "1^* CAF DATESTAMP ##~##   - Enter a valid date for the CAF datestamp.##~##"
@@ -390,13 +391,13 @@ function check_for_errors(interview_questions_clear)
 	End If
 
 	If EMER_on_CAF_checkbox = checked Then
-		If resident_emergency_yn = " " or trim(emergency_type) = "" or emergency_type = "Select or type" or trim(emergency_discussion) = "" or trim(emergency_amount) = "" or trim(emergency_deadline) = "" Then
+		If resident_emergency_yn = " " or trim(emergency_type) = "" or emergency_type = "Select or Type" or trim(emergency_discussion) = "" or trim(emergency_amount) = "" or trim(emergency_deadline) = "" Then
 			err_msg = err_msg & "~!~" & emer_numb & "^* The resident indicated they are applying for EMER. The EMER Q fields must all be filled out."
 		End If
 	End If
 
 	If resident_emergency_yn = "Yes" Then
-		If trim(emergency_type) = "" or emergency_type = "Select one" or trim(emergency_discussion) = "" or trim(emergency_amount) = "" or trim(emergency_deadline) = "" Then
+		If trim(emergency_type) = "" or emergency_type = "Select or Type" or trim(emergency_discussion) = "" or trim(emergency_amount) = "" or trim(emergency_deadline) = "" Then
 			err_msg = err_msg & "~!~" & emer_numb & "^* You indicated the resident is experiencing an emergency. You must fill out all of the fields describing the emergency."
 		End If
 	End If
@@ -487,21 +488,23 @@ function define_main_dialog()
             EditBox 120, 110, 340, 15, arep_interview_id_information
 			EditBox 10, 160, 450, 15, non_applicant_interview_info
 
-		    EditBox 325, 205, 50, 15, exp_q_1_income_this_month
-		    EditBox 325, 225, 50, 15, exp_q_2_assets_this_month
-		    EditBox 325, 245, 50, 15, exp_q_3_rent_this_month
-		    CheckBox 140, 265, 30, 10, "Heat", caf_exp_pay_heat_checkbox
-		    CheckBox 175, 265, 65, 10, "Air Conditioning", caf_exp_pay_ac_checkbox
-		    CheckBox 245, 265, 45, 10, "Electricity", caf_exp_pay_electricity_checkbox
-		    CheckBox 295, 265, 35, 10, "Phone", caf_exp_pay_phone_checkbox
-		    CheckBox 340, 265, 35, 10, "None", caf_exp_pay_none_checkbox
-		    DropListBox 260, 280, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_migrant_seasonal_formworker_yn
-		    DropListBox 380, 295, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_received_previous_assistance_yn
-		    EditBox 95, 315, 80, 15, exp_previous_assistance_when
-		    EditBox 215, 315, 85, 15, exp_previous_assistance_where
-		    EditBox 335, 315, 85, 15, exp_previous_assistance_what
-		    DropListBox 175, 335, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_pregnant_yn
-		    ComboBox 270, 335, 150, 45, all_the_clients, exp_pregnant_who
+			If expedited_screening_on_form = True Then
+				EditBox 325, 205, 50, 15, exp_q_1_income_this_month
+				EditBox 325, 225, 50, 15, exp_q_2_assets_this_month
+				EditBox 325, 245, 50, 15, exp_q_3_rent_this_month
+				CheckBox 140, 265, 30, 10, "Heat", caf_exp_pay_heat_checkbox
+				CheckBox 175, 265, 65, 10, "Air Conditioning", caf_exp_pay_ac_checkbox
+				CheckBox 245, 265, 45, 10, "Electricity", caf_exp_pay_electricity_checkbox
+				CheckBox 295, 265, 35, 10, "Phone", caf_exp_pay_phone_checkbox
+				CheckBox 340, 265, 35, 10, "None", caf_exp_pay_none_checkbox
+				DropListBox 260, 280, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_migrant_seasonal_formworker_yn
+				DropListBox 380, 295, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_received_previous_assistance_yn
+				EditBox 95, 315, 80, 15, exp_previous_assistance_when
+				EditBox 215, 315, 85, 15, exp_previous_assistance_where
+				EditBox 335, 315, 85, 15, exp_previous_assistance_what
+				DropListBox 175, 335, 40, 45, ""+chr(9)+"No"+chr(9)+"Yes", exp_pregnant_yn
+				ComboBox 270, 335, 150, 45, all_the_clients, exp_pregnant_who
+			End If
 
 		    Text 10, 15, 110, 10, "Who are you interviewing with?"
 			Text 65, 35, 55, 10, "Interview via"
@@ -513,19 +516,21 @@ function define_main_dialog()
 			Text 120, 135, 300, 10, "- If no ID is required, this can be detailed here."
 			Text 10, 150, 300, 10, "If interview is NOT with a Household Adult, explain relationship and add any details:"
 
-		    GroupBox 25, 185, 400, 170, "CAF 1 Answers - Expedited Section"
-			Text 30, 195, 375, 10, "ENTER THE INFORMATION FROM THE CAF HERE."
-		    Text 35, 210, 270, 10, "1. How much income (cash or checks) did or will your household get this month?"
-		    Text 35, 230, 290, 10, "2. How much does your household (including children) have cash, checking or savings?"
-		    Text 35, 250, 225, 10, "3. How much does your household pay for rent/mortgage per month?"
-		    Text 45, 265, 90, 10, "What utilities do you pay?"
-		    Text 35, 285, 225, 10, "4. Is anyone in your household a migrant or seasonal farm worker?"
-		    Text 35, 300, 345, 10, "5. Has anyone in your household ever received cash assistance, commodities or SNAP benefits before?"
-		    Text 45, 320, 50, 10, "If yes, When?"
-		    Text 185, 320, 30, 10, "Where?"
-		    Text 310, 320, 25, 10, "What?"
-		    Text 35, 340, 135, 10, "6. Is anyone in your household pregnant?"
-		    Text 225, 340, 45, 10, "If yes, who?"
+			If expedited_screening_on_form = True Then
+				GroupBox 25, 185, 400, 170, "CAF 1 Answers - Expedited Section"
+				Text 30, 195, 375, 10, "ENTER THE INFORMATION FROM THE CAF HERE."
+				Text 35, 210, 270, 10, "1. How much income (cash or checks) did or will your household get this month?"
+				Text 35, 230, 290, 10, "2. How much does your household (including children) have cash, checking or savings?"
+				Text 35, 250, 225, 10, "3. How much does your household pay for rent/mortgage per month?"
+				Text 45, 265, 90, 10, "What utilities do you pay?"
+				Text 35, 285, 225, 10, "4. Is anyone in your household a migrant or seasonal farm worker?"
+				Text 35, 300, 345, 10, "5. Has anyone in your household ever received cash assistance, commodities or SNAP benefits before?"
+				Text 45, 320, 50, 10, "If yes, When?"
+				Text 185, 320, 30, 10, "Where?"
+				Text 310, 320, 25, 10, "What?"
+				Text 35, 340, 135, 10, "6. Is anyone in your household pregnant?"
+				Text 225, 340, 45, 10, "If yes, who?"
+			End If
 
 		ElseIf page_display = show_pg_one_address Then
 			Text 504, 32, 60, 10, "CAF ADDR"
@@ -1992,18 +1997,22 @@ function display_expedited_dialog()
 			If exp_page_display = show_exp_pg_amounts then
 				Text 504, 12, 65, 10, "Amounts"
 
-				GroupBox 5, 5, 390, 75, "Expedited Screening"
-				' If exp_screening_note_found = True Then
-				Text 10, 20, 145, 10, "Information pulled from previous case note."
-				Text 20, 35, 70, 10, "Income from CAF1: $ "
-				Text 100, 35, 80, 10, exp_q_1_income_this_month
-				Text 195, 35, 65, 10, "Assets from CAF1: $ "
-				Text 270, 35, 75, 10, exp_q_2_assets_this_month
-				Text 20, 50, 90, 10, "Housing from CAF1: $ "
-				Text 100, 50, 65, 10, exp_q_3_rent_this_month
-				Text 195, 50, 65, 10, "Utilities from CAF1: $ "
-				Text 270, 50, 75, 10, exp_q_4_utilities_this_month
-				Text 15, 65, 160, 10, expedited_screening
+				If expedited_screening_on_form = True Then
+					GroupBox 5, 5, 390, 75, "Expedited Screening"
+					' If exp_screening_note_found = True Then
+					Text 10, 20, 145, 10, "Information pulled from previous case note."
+					Text 20, 35, 70, 10, "Income from CAF1: $ "
+					Text 100, 35, 80, 10, exp_q_1_income_this_month
+					Text 195, 35, 65, 10, "Assets from CAF1: $ "
+					Text 270, 35, 75, 10, exp_q_2_assets_this_month
+					Text 20, 50, 90, 10, "Housing from CAF1: $ "
+					Text 100, 50, 65, 10, exp_q_3_rent_this_month
+					Text 195, 50, 65, 10, "Utilities from CAF1: $ "
+					Text 270, 50, 75, 10, exp_q_4_utilities_this_month
+					Text 15, 65, 160, 10, expedited_screening
+				Else
+					Text 10, 20, 350, 10, "Expedited Screening Questions not present on this form. No information to Display."
+				End If
 				' End If
 				' If exp_screening_note_found = False Then
 				' 	Text 10, 20, 350, 10, "CASE:NOTE for Expedited Screening could not be found. No information to Display."
@@ -4957,13 +4966,13 @@ function write_interview_CASE_NOTE()
 
 
 	'If at least one field is filled in, then it will write the emergency info to case note
-	If resident_emergency_yn <> " " or trim(emergency_type) <> "" or trim(emergency_discussion) <> "" or trim(emergency_amount) <> "" or trim(emergency_deadline) <> "" Then
+	If resident_emergency_yn <> " " or (trim(emergency_type) <> "" and trim(emergency_type) <> "Select or Type") or trim(emergency_discussion) <> "" or trim(emergency_amount) <> "" or trim(emergency_deadline) <> "" Then
 		CALL write_variable_in_CASE_NOTE("-----  Emergency Questions -----")
-		CALL write_variable_in_CASE_NOTE("      Resident experiencing an emergency - " & resident_emergency_yn)
-		CALL write_variable_in_CASE_NOTE("      Type of emergency - " & emergency_type)
-		CALL write_variable_in_CASE_NOTE("      Discussion of emergency with resident - " & emergency_discussion)
-		CALL write_variable_in_CASE_NOTE("      Amount needed to resolve emergency - " & emergency_amount)
-		CALL write_variable_in_CASE_NOTE("      Deadline to resolve emergency - " & emergency_deadline)
+		If resident_emergency_yn <> " " Then CALL write_variable_in_CASE_NOTE("      Resident experiencing an emergency - " & resident_emergency_yn)
+		If trim(emergency_type) <> "" and trim(emergency_type) <> "Select or Type" Then CALL write_variable_in_CASE_NOTE("      Type of emergency - " & emergency_type)
+		If trim(emergency_discussion) <> "" Then CALL write_variable_in_CASE_NOTE("      Discussion of emergency with resident - " & emergency_discussion)
+		If trim(emergency_amount) <> ""  Then CALL write_variable_in_CASE_NOTE("      Amount needed to resolve emergency - " & emergency_amount)
+		If trim(emergency_deadline) <> "" Then CALL write_variable_in_CASE_NOTE("      Deadline to resolve emergency - " & emergency_deadline)
 	End If
 
 	If edrs_match_found = False Then Call write_variable_in_CASE_NOTE("eDRS run for all Household Members: No DISQ Matches Found")
@@ -7069,32 +7078,13 @@ Do
 Loop until summ_check = "SUMM"
 EMReadScreen case_pw, 7, 21, 17
 
-If CAF_form = "CAF (DHS-5223)" Then
-	CAF_form_name = "Combined Application Form"
-	form_number = "5223"
-End If
-If CAF_form = "HUF (DHS-8107)" Then
-	CAF_form_name = "Household Update Form"
-	form_number = "8107"
-End If
-If CAF_form = "SNAP App for Srs (DHS-5223F)" Then
-	CAF_form_name = "SNAP Application for Seniors"
-	form_number = "5223F"
-End If
-If CAF_form = "MNbenefits" Then
-	CAF_form_name = "MNbenefits Web Form"
-	form_number = ""
-End If
-If CAF_form = "Combined AR for Certain Pops (DHS-3727)" Then
-	CAF_form_name = "Combined Annual Renewal"
-	form_number = "3727"
-End If
-
 If select_err_msg_handling = "Alert at the time you attempt to save each page of the dialog." Then show_err_msg_during_movement = TRUE
 If select_err_msg_handling = "Alert only once completing and leaving the final dialog." Then show_err_msg_during_movement = FALSE
 
 show_known_addr = FALSE
 vars_filled = FALSE
+
+Orig_CAF_form = CAF_form
 
 Call back_to_SELF
 Call restore_your_work(vars_filled)			'looking for a 'restart' run
@@ -7205,6 +7195,31 @@ If vars_filled = True Then
 	End With
 End If
 
+If Orig_CAF_form <> CAF_form Then MsgBox "You have selected " & Orig_CAF_form & " as the form submitted." & vbCr & vbCr & "You requested to restore details of a previous run and a different form was loaded." & vbCr & vbCr & "FORM CANNOT BE CHANGED. The script will operate using the form " & CAF_form & ". To change this, you must restart the script and lose any previous data."
+
+expedited_screening_on_form = True
+If CAF_form = "CAF (DHS-5223)" Then
+	CAF_form_name = "Combined Application Form"
+	form_number = "5223"
+End If
+If CAF_form = "HUF (DHS-8107)" Then
+	CAF_form_name = "Household Update Form"
+	form_number = "8107"
+	expedited_screening_on_form = False
+End If
+If CAF_form = "SNAP App for Srs (DHS-5223F)" Then
+	CAF_form_name = "SNAP Application for Seniors"
+	form_number = "5223F"
+End If
+If CAF_form = "MNbenefits" Then
+	CAF_form_name = "MNbenefits Web Form"
+	form_number = ""
+End If
+If CAF_form = "Combined AR for Certain Pops (DHS-3727)" Then
+	CAF_form_name = "Combined Annual Renewal"
+	form_number = "3727"
+	expedited_screening_on_form = False
+End If
 
 Call determine_program_and_case_status_from_CASE_CURR(case_active, case_pending, case_rein, family_cash_case, mfip_case, dwp_case, adult_cash_case, ga_case, msa_case, grh_case, snap_case, ma_case, msp_case, emer_case, unknown_cash_pending, unknown_hc_pending, ga_status, msa_status, mfip_status, dwp_status, grh_status, snap_status, ma_status, msp_status, msp_type, emer_status, emer_type, case_status, list_active_programs, list_pending_programs)
 EMReadScreen worker_id_for_data_table, 7, 21, 14
@@ -9457,8 +9472,8 @@ Set o2Exec = WshShell.Exec("notepad " & intvw_done_msg_file)
 Set objWord = CreateObject("Word.Application")
 
 'Adding all of the information in the dialogs into a Word Document
-If no_case_number_checkbox = checked Then objWord.Caption = "CAF Form Details - NEW CASE"
-If no_case_number_checkbox = unchecked Then objWord.Caption = "CAF Form Details - CASE #" & MAXIS_case_number			'Title of the document
+If no_case_number_checkbox = checked Then objWord.Caption = "Form Details - NEW CASE"
+If no_case_number_checkbox = unchecked Then objWord.Caption = "Form Details - CASE #" & MAXIS_case_number			'Title of the document
 ' objWord.Visible = True														'Let the worker see the document
 objWord.Visible = False 														'The worker should NOT see the docuement
 'allow certain workers to see the document
@@ -9479,6 +9494,7 @@ If MAXIS_case_number <> "" Then objSelection.TypeText "Case Number: " & MAXIS_ca
 ' If no_case_number_checkbox = checked Then objSelection.TypeText "New Case - no case number" & vbCr
 objSelection.TypeText "Interview Date: " & interview_date & vbCR
 objSelection.TypeText "DATE OF APPLICATION: " & CAF_datestamp & vbCR
+objSelection.TypeText "APPLICATION FORM: " & CAF_form_name & vbCR
 objSelection.TypeText "Completed by: " & worker_name & vbCR
 objSelection.TypeText "Interview completed with: " & who_are_we_completing_the_interview_with & vbCR
 objSelection.TypeText "Interview completed via: " & how_are_we_completing_the_interview & vbCR
@@ -9597,7 +9613,7 @@ If GRH_on_CAF_checkbox = checked Then caf_progs = caf_progs & ", HS/GRH"
 If SNAP_on_CAF_checkbox = checked Then caf_progs = caf_progs & ", SNAP"
 If EMER_on_CAF_checkbox = checked Then caf_progs = caf_progs & ", EMER"
 If left(caf_progs, 2) = ", " Then caf_progs = right(caf_progs, len(caf_progs)-2)
-objSelection.TypeText "PROGRAMS REQUESTED ON CAF: " & caf_progs & vbCr
+objSelection.TypeText "PROGRAMS REQUESTED ON FORM: " & caf_progs & vbCr
 
 progs_verbal_request = ""
 If cash_verbal_request = "Yes" Then progs_verbal_request = progs_verbal_request & ", Cash"
@@ -9894,61 +9910,71 @@ objSelection.TypeText "INTERVIEW NOTES: " & HH_MEMB_ARRAY(client_notes, 0) & vbC
 If disc_homeless_no_mail_addr = "RESOLVED" Then objSelection.TypeText "- Household Experiencing Housing Insecurity - MAIL is Primary Communication of Agency Requests and Actions - additional interview conversation: " & disc_homeless_confirmation & vbCr
 If disc_no_phone_number = "RESOLVED" Then objSelection.TypeText "- No Phone Number was Provided - additional interview conversation: " & disc_phone_confirmation & vbCr
 
-' objSelection.Font.Bold = TRUE
-objSelection.TypeText "CAF 1 - EXPEDITED QUESTIONS from the CAF"
-Set objRange = objSelection.Range					'range is needed to create tables
-objDoc.Tables.Add objRange, 8, 2					'This sets the rows and columns needed row then column'
-set objEXPTable = objDoc.Tables(3)		'Creates the table with the specific index'
+'Now we have a dynamic number of tables
+'each table has to be defined with its index so we need to have a variable to increment
+table_count = 3			'table index variable
 
-objEXPTable.AutoFormat(16)							'This adds the borders to the table and formats it
-objEXPTable.Columns(1).Width = 375					'Setting the widths of the columns
-objEXPTable.Columns(2).Width = 120
-for col = 1 to 2
-	for row = 1 to 8
-		objEXPTable.Cell(row, col).Range.Font.Bold = TRUE	'Making the cell text bold.
+If expedited_screening_on_form = True Then
+
+	' objSelection.Font.Bold = TRUE
+	objSelection.TypeText "EXPEDITED QUESTIONS from the Form"
+	Set objRange = objSelection.Range					'range is needed to create tables
+	objDoc.Tables.Add objRange, 8, 2					'This sets the rows and columns needed row then column'
+	set objEXPTable = objDoc.Tables(table_count)		'Creates the table with the specific index'
+	table_count = table_count + 1
+
+	objEXPTable.AutoFormat(16)							'This adds the borders to the table and formats it
+	objEXPTable.Columns(1).Width = 375					'Setting the widths of the columns
+	objEXPTable.Columns(2).Width = 120
+	for col = 1 to 2
+		for row = 1 to 8
+			objEXPTable.Cell(row, col).Range.Font.Bold = TRUE	'Making the cell text bold.
+		next
 	next
-next
 
-'Adding the Expedited text to the table for Expedited
-objEXPTable.Cell(1, 1).Range.Text = "1. How much income (cash or checks) did or will your household get this month?"
-objEXPTable.Cell(1, 2).Range.Text = exp_q_1_income_this_month
+	'Adding the Expedited text to the table for Expedited
+	objEXPTable.Cell(1, 1).Range.Text = "1. How much income (cash or checks) did or will your household get this month?"
+	objEXPTable.Cell(1, 2).Range.Text = exp_q_1_income_this_month
 
-objEXPTable.Cell(2, 1).Range.Text = "2. How much does your household (including children) have cash, checking or savings?"
-objEXPTable.Cell(2, 2).Range.Text = exp_q_2_assets_this_month
+	objEXPTable.Cell(2, 1).Range.Text = "2. How much does your household (including children) have cash, checking or savings?"
+	objEXPTable.Cell(2, 2).Range.Text = exp_q_2_assets_this_month
 
-objEXPTable.Cell(3, 1).Range.Text = "3. How much does your household pay for rent/mortgage per month?"
-objEXPTable.Cell(3, 2).Range.Text = exp_q_3_rent_this_month
+	objEXPTable.Cell(3, 1).Range.Text = "3. How much does your household pay for rent/mortgage per month?"
+	objEXPTable.Cell(3, 2).Range.Text = exp_q_3_rent_this_month
 
-objEXPTable.Cell(4, 1).Range.Text = "   What utilities do you pay?"
-If caf_exp_pay_heat_checkbox = checked Then util_pay = util_pay & "Heat, "
-If caf_exp_pay_ac_checkbox = checked Then util_pay = util_pay & "Air Conditioning, "
-If caf_exp_pay_electricity_checkbox = checked Then util_pay = util_pay & "Electricity, "
-If caf_exp_pay_phone_checkbox = checked Then util_pay = util_pay & "Phone, "
-If caf_exp_pay_none_checkbox = checked Then util_pay = util_pay & "NONE"
-If right(util_pay, 2) = ", " Then util_pay = left(util_pay, len(util_pay) - 2)
-objEXPTable.Cell(4, 2).Range.Text = util_pay
+	objEXPTable.Cell(4, 1).Range.Text = "   What utilities do you pay?"
+	If caf_exp_pay_heat_checkbox = checked Then util_pay = util_pay & "Heat, "
+	If caf_exp_pay_ac_checkbox = checked Then util_pay = util_pay & "Air Conditioning, "
+	If caf_exp_pay_electricity_checkbox = checked Then util_pay = util_pay & "Electricity, "
+	If caf_exp_pay_phone_checkbox = checked Then util_pay = util_pay & "Phone, "
+	If caf_exp_pay_none_checkbox = checked Then util_pay = util_pay & "NONE"
+	If right(util_pay, 2) = ", " Then util_pay = left(util_pay, len(util_pay) - 2)
+	objEXPTable.Cell(4, 2).Range.Text = util_pay
 
-objEXPTable.Cell(5, 1).Range.Text = "4. Is anyone in your household a migrant or seasonal farm worker?"
-objEXPTable.Cell(5, 2).Range.Text = exp_migrant_seasonal_formworker_yn
+	objEXPTable.Cell(5, 1).Range.Text = "4. Is anyone in your household a migrant or seasonal farm worker?"
+	objEXPTable.Cell(5, 2).Range.Text = exp_migrant_seasonal_formworker_yn
 
-objEXPTable.Cell(6, 1).Range.Text = "5. Has anyone in your household ever received cash assistance, commodities or SNAP benefits before?"
-objEXPTable.Cell(6, 2).Range.Text = exp_received_previous_assistance_yn
+	objEXPTable.Cell(6, 1).Range.Text = "5. Has anyone in your household ever received cash assistance, commodities or SNAP benefits before?"
+	objEXPTable.Cell(6, 2).Range.Text = exp_received_previous_assistance_yn
 
-objEXPTable.Rows(7).Cells.Split 1, 6, TRUE										'Splitting the cells to add more detail for the three questions here
-objEXPTable.Cell(7, 1).Range.Text = "When?"
-objEXPTable.Cell(7, 2).Range.Text = exp_previous_assistance_when
-objEXPTable.Cell(7, 3).Range.Text = "Where?"
-objEXPTable.Cell(7, 4).Range.Text = exp_previous_assistance_where
-objEXPTable.Cell(7, 5).Range.Text = "What?"
-objEXPTable.Cell(7, 6).Range.Text = exp_previous_assistance_what
+	objEXPTable.Rows(7).Cells.Split 1, 6, TRUE										'Splitting the cells to add more detail for the three questions here
+	objEXPTable.Cell(7, 1).Range.Text = "When?"
+	objEXPTable.Cell(7, 2).Range.Text = exp_previous_assistance_when
+	objEXPTable.Cell(7, 3).Range.Text = "Where?"
+	objEXPTable.Cell(7, 4).Range.Text = exp_previous_assistance_where
+	objEXPTable.Cell(7, 5).Range.Text = "What?"
+	objEXPTable.Cell(7, 6).Range.Text = exp_previous_assistance_what
 
-objEXPTable.Cell(8, 1).Range.Text = "6. Is anyone in your household pregnant?"
-If exp_pregnant_who <> "" Then
-	objEXPTable.Cell(8, 2).Range.Text = exp_pregnant_yn & ", " &  exp_pregnant_who
-Else
-	objEXPTable.Cell(8, 2).Range.Text = exp_pregnant_yn
+	objEXPTable.Cell(8, 1).Range.Text = "6. Is anyone in your household pregnant?"
+	If exp_pregnant_who <> "" Then
+		objEXPTable.Cell(8, 2).Range.Text = exp_pregnant_yn & ", " &  exp_pregnant_who
+	Else
+		objEXPTable.Cell(8, 2).Range.Text = exp_pregnant_yn
+	End If
+	objSelection.EndKey end_of_doc						'this sets the cursor to the end of the document for more writing
+
 End If
-objSelection.EndKey end_of_doc						'this sets the cursor to the end of the document for more writing
+
 objSelection.TypeParagraph()						'adds a line between the table and the next information
 
 If expedited_determination_needed = True Then
@@ -9998,9 +10024,6 @@ objSelection.TypeText chr(9) & "Immigration Status: " & HH_MEMB_ARRAY(imig_statu
 objSelection.TypeText chr(9) & "Verification: " & HH_MEMB_ARRAY(client_verification, 0) & vbCr
 If HH_MEMB_ARRAY(client_verification_details, 0) <> "" Then objSelection.TypeText chr(9) & chr(9) & "Details: " & HH_MEMB_ARRAY(client_verification_details, 0) & vbCr
 
-'Now we have a dynamic number of tables
-'each table has to be defined with its index so we need to have a variable to increment
-table_count = 4			'table index variable
 additional_person = False
 If UBound(HH_MEMB_ARRAY, 2) <> 0 Then
     For each_member = 1 to UBound(HH_MEMB_ARRAY, 2)
@@ -10216,9 +10239,9 @@ For each_question = 0 to UBound(FORM_QUESTION_ARRAY)
 	FORM_QUESTION_ARRAY(each_question).add_to_wif()
 Next
 
-objSelection.TypeText "CAF QUALIFYING QUESTIONS" & vbCr
+objSelection.TypeText "QUALIFYING QUESTIONS" & vbCr
 
-objSelection.TypeText "Has a court or any other civil or administrative process in Minnesota or any other state found anyone in the household guilty or has anyone been disqualified from receiving public assistance for breaking any of the rules listed in the CAF?" & vbCr
+objSelection.TypeText "Has a court or any other civil or administrative process in Minnesota or any other state found anyone in the household guilty or has anyone been disqualified from receiving public assistance for breaking any of the rules listed in the Form?" & vbCr
 objSelection.TypeText chr(9) & qual_question_one & vbCr
 If trim(qual_memb_one) <> "" AND qual_memb_one <> "Select or Type" Then objSelection.TypeText chr(9) & qual_memb_one & vbCr
 objSelection.TypeText "Has anyone in the household been convicted of making fraudulent statements about their place of residence to get cash or SNAP benefits from more than one state?" & vbCr
@@ -10234,17 +10257,31 @@ objSelection.TypeText "Is anyone in your household currently violating a conditi
 objSelection.TypeText chr(9) & qual_question_five & vbCr
 If trim(qual_memb_five) <> "" AND qual_memb_five <> "Select or Type" Then objSelection.TypeText chr(9) & qual_memb_five & vbCr
 
-objSelection.TypeText "EMERGENCY QUESTIONS" & vbCr
-objSelection.TypeText "Is the resident experiencing an emergency?" & vbCr
-objSelection.TypeText chr(9) & resident_emergency_yn & vbCr
-objSelection.TypeText "What emergency is the resident is experiencing?" & vbCr
-objSelection.TypeText chr(9) & emergency_type & vbCr
-objSelection.TypeText "Discussion of emergency with resident:" & vbCr
-objSelection.TypeText chr(9) & emergency_discussion & vbCr
-objSelection.TypeText "What amount is needed to resolve the emergency?" & vbCr
-objSelection.TypeText chr(9) & emergency_amount & vbCr
-objSelection.TypeText "What is the deadline to resolve the emergency?" & vbCr
-objSelection.TypeText chr(9) & emergency_deadline & vbCr
+If resident_emergency_yn <> " " or (trim(emergency_type) <> "" and trim(emergency_type) <> "Select or Type") or trim(emergency_discussion) <> "" or trim(emergency_amount) <> "" or trim(emergency_deadline) <> "" Then
+	objSelection.TypeText "EMERGENCY QUESTIONS" & vbCr
+	If resident_emergency_yn <> " " Then
+		objSelection.TypeText "Is the resident experiencing an emergency?" & vbCr
+		objSelection.TypeText chr(9) & resident_emergency_yn & vbCr
+	End If
+	If trim(emergency_type) <> "" and trim(emergency_type) <> "Select or Type" Then
+		objSelection.TypeText "What emergency is the resident is experiencing?" & vbCr
+		objSelection.TypeText chr(9) & emergency_type & vbCr
+	End If
+	If trim(emergency_discussion) <> "" Then C
+		objSelection.TypeText "Discussion of emergency with resident:" & vbCr
+		objSelection.TypeText chr(9) & emergency_discussion & vbCr
+	End If
+	If trim(emergency_amount) <> ""  Then
+		objSelection.TypeText "What amount is needed to resolve the emergency?" & vbCr
+		objSelection.TypeText chr(9) & emergency_amount & vbCr
+	End If
+	If trim(emergency_deadline) <> "" Then
+		objSelection.TypeText "What is the deadline to resolve the emergency?" & vbCr
+		objSelection.TypeText chr(9) & emergency_deadline & vbCr
+	End If
+Else
+	objSelection.TypeText "No Emergency Details Recorded" & vbCr
+End If
 
 objSelection.Font.Size = "14"
 objSelection.Font.Bold = FALSE
@@ -10302,7 +10339,7 @@ If arep_action = "Yes - keep this AREP" Then
 
 	End If
 
-	If arep_on_CAF_checkbox = checked Then objSelection.TypeText "This AREP information was entered on the CAF." & vbCR
+	If arep_on_CAF_checkbox = checked Then objSelection.TypeText "This AREP information was entered on the Form." & vbCR
 ElseIf arep_action = "No - remove this AREP from my case" OR arep_authorization = "DO NOT AUTHORIZE AN AREP" Then
 	objSelection.TypeText "AREP information known/provided but resident does NOT want this AREP to be Authorized:" & vbCR
 	objSelection.TypeText "Name: " & arep_name & vbCr
@@ -10364,14 +10401,14 @@ If discrepancies_exist = True Then
 		objSelection.TypeText "  - Resolution: " & disc_out_of_county_confirmation & vbCr
 	End If
 	If disc_rent_amounts = "RESOLVED" Then
-		objSelection.TypeText "The Housing Expense information on CAF Page 1 and CAF Question 14 do not appear to Match" & vbCr
-		objSelection.TypeText "  - CAF Page 1 Housing Expense: " & exp_q_3_rent_this_month & vbCr
+		objSelection.TypeText "The Housing Expense information within the Form do not appear to Match" & vbCr
+		objSelection.TypeText "  - Page 1 Housing Expense: " & exp_q_3_rent_this_month & vbCr
 		objSelection.TypeText "  - Question on Housing Expense: " & rent_summary & vbCr
 		objSelection.TypeText "  - Resolution: " & disc_rent_amounts_confirmation & vbCr
 	End If
 	If disc_utility_amounts = "RESOLVED" Then
-		objSelection.TypeText "The Utility Expense information on CAF Page 1 and CAF Question 15 do not appear to Match" & vbCr
-		objSelection.TypeText "  - CAF Page 1 Utility Expense: " & disc_utility_caf_1_summary & vbCr
+		objSelection.TypeText "The Utility Expense information within the Form do not appear to Match" & vbCr
+		objSelection.TypeText "  - Page 1 Utility Expense: " & disc_utility_caf_1_summary & vbCr
 		objSelection.TypeText "  - Question on Utility Expense: " & utility_summary & vbCr
 		objSelection.TypeText "  - Resolution: " & disc_utility_amounts_confirmation & vbCr
 	End If
@@ -10968,7 +11005,7 @@ If objFSO.FileExists(pdf_doc_path) = TRUE Then
 	o2Exec.Terminate()
 	'Now we ask if the worker would like the PDF to be opened by the script before the script closes
 	'This is helpful because they may not be familiar with where these are saved and they could work from the PDF to process the reVw
-	reopen_pdf_doc_msg = MsgBox("The information gathered in the interview has been saved as a PDF and will be added to ECF as a separate 'Interview Notes' document." & vbCr & vbCr & "This document will take the place of your CAF INTERVIEW ANNOTATIONS, as long as you have entered all interview notes to the script." & vbCr & "Agency Signature is not required on the application form." & vbCr & vbCr & "Would you like the PDF Document opened to process/review?", vbQuestion + vbSystemModal + vbYesNo, "Open PDF Doc?")
+	reopen_pdf_doc_msg = MsgBox("The information gathered in the interview has been saved as a PDF and will be added to ECF as a separate 'Interview Notes' document." & vbCr & vbCr & "This document will take the place of the INTERVIEW ANNOTATIONS on the form in ECF, as long as you have entered all interview notes to the script." & vbCr & "Agency Signature is not required on the application form." & vbCr & vbCr & "Would you like the PDF Document opened to process/review?", vbQuestion + vbSystemModal + vbYesNo, "Open PDF Doc?")
 	If reopen_pdf_doc_msg = vbYes Then
 		With (CreateObject("Scripting.FileSystemObject"))
 

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -348,19 +348,9 @@ function check_for_errors(interview_questions_clear)
 		'If signatires are signed or verbal - then person and date must be completed
 		If signature_detail = "Signature Completed" OR signature_detail  = "Accepted Verbally" Then
 			If signature_person = "" AND signature_person = "Select or Type" Then err_msg = err_msg & "~!~" & last_num & "^* Signature of Primary Adult - person##~##   - Since the signature was completed, indicate whose sigature it is."
-			If IsDate(signature_date) = False Then
-				err_msg = err_msg & "~!~" & last_num & "^* Signature of Primary Adult - date##~##   - Enter the date of the signature as a valid date."
-			Else
-				If DateDiff("d", date, signature_date) > 0 Then err_msg = err_msg & "~!~" & last_num & "^* Signature of Primary Adult - date##~##   - The date of the primary signature cannot be in the future."
-			End If
 		End If
 		If second_signature_detail = "Signature Completed" OR second_signature_detail  = "Accepted Verbally" Then
 			If second_signature_person = "" AND second_signature_person = "Select or Type" Then err_msg = err_msg & "~!~" & last_num & "^* Signature of Other Adult - person##~##   - Since the secondary adult signature was completed, indicate whose sigature it is."
-			If IsDate(second_signature_date) = False Then
-				err_msg = err_msg & "~!~" & last_num & "^* Signature of Other Adult - date##~##   - Enter the date of the signature as a valid date."
-			Else
-				If DateDiff("d", date, second_signature_date) > 0 Then err_msg = err_msg & "~!~" & last_num & "^* Signature of Other Adult - date##~##   - The date of the primary signature cannot be in the future."
-			End If
 		End If
 		'Interview date must be a date and not in the future
 		' If  Then err_msg = err_msg & "~!~" & "11^* FIELD##~##   - "
@@ -1100,15 +1090,11 @@ function define_main_dialog()
 		    Text 10, 85, 90, 10, "Signature of Primary Adult"
 		    ComboBox 105, 80, 110, 45, "Select or Type"+chr(9)+"Signature Completed"+chr(9)+"Blank"+chr(9)+"Accepted Verbally"+chr(9)+"Not Required"+chr(9)+signature_detail, signature_detail
 		    Text 220, 85, 25, 10, "person"
-		    ComboBox 250, 80, 115, 45, all_the_clients+chr(9)+signature_person, signature_person
-		    Text 375, 85, 20, 10, "date"
-		    EditBox 400, 80, 50, 15, signature_date
+		    ComboBox 250, 80, 200, 45, all_the_clients+chr(9)+signature_person, signature_person
 		    Text 10, 105, 90, 10, "Signature of Other Adult"
 		    ComboBox 105, 100, 110, 45, "Select or Type"+chr(9)+"Signature Completed"+chr(9)+"Not Required"+chr(9)+"Blank"+chr(9)+"Accepted Verbally"+chr(9)+second_signature_detail, second_signature_detail
 		    Text 220, 105, 25, 10, "person"
-		    ComboBox 250, 100, 115, 45, all_the_clients+chr(9)+second_signature_person, second_signature_person
-		    Text 375, 105, 20, 10, "date"
-		    EditBox 400, 100, 50, 15, second_signature_date
+		    ComboBox 250, 100, 200, 45, all_the_clients+chr(9)+second_signature_person, second_signature_person
 
 			Text 10, 125, 130, 10, "Resident signature accepted verbally?"
 			DropListBox 135, 120, 60, 45, "Select..."+chr(9)+"Yes"+chr(9)+"No", client_signed_verbally_yn
@@ -2940,10 +2926,8 @@ function save_your_work()
 
 			objTextStream.WriteLine "SIG - 01 - " & signature_detail
 			objTextStream.WriteLine "SIG - 02 - " & signature_person
-			objTextStream.WriteLine "SIG - 03 - " & signature_date
 			objTextStream.WriteLine "SIG - 04 - " & second_signature_detail
 			objTextStream.WriteLine "SIG - 05 - " & second_signature_person
-			objTextStream.WriteLine "SIG - 06 - " & second_signature_date
 			objTextStream.WriteLine "SIG - 07 - " & client_signed_verbally_yn
 			objTextStream.WriteLine "SIG - 08 - " & interview_date
 			objTextStream.WriteLine "ASSESS - 01 - " & exp_snap_approval_date
@@ -3311,10 +3295,8 @@ function save_your_work()
 
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 01 - " & signature_detail
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 02 - " & signature_person
-			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 03 - " & signature_date
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 04 - " & second_signature_detail
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 05 - " & second_signature_person
-			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 06 - " & second_signature_date
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 07 - " & client_signed_verbally_yn
 			script_run_lowdown = script_run_lowdown & vbCr & "SIG - 08 - " & interview_date & vbCr & vbCr
 			script_run_lowdown = script_run_lowdown & vbCr & "ASSESS - 01 - " & exp_snap_approval_date
@@ -3750,10 +3732,8 @@ function restore_your_work(vars_filled)
 
 					If left(text_line, 8) = "SIG - 01" Then signature_detail = Mid(text_line, 12)
 					If left(text_line, 8) = "SIG - 02" Then signature_person = Mid(text_line, 12)
-					If left(text_line, 8) = "SIG - 03" Then signature_date = Mid(text_line, 12)
 					If left(text_line, 8) = "SIG - 04" Then second_signature_detail = Mid(text_line, 12)
 					If left(text_line, 8) = "SIG - 05" Then second_signature_person = Mid(text_line, 12)
-					If left(text_line, 8) = "SIG - 06" Then second_signature_date = Mid(text_line, 12)
 					If left(text_line, 8) = "SIG - 07" Then client_signed_verbally_yn = Mid(text_line, 12)
 					If left(text_line, 8) = "SIG - 08" Then interview_date = Mid(text_line, 12)
 
@@ -6792,7 +6772,7 @@ Dim CAF_arep_name, CAF_arep_relationship, CAF_arep_phone_number, CAF_arep_addr_s
 Dim arep_complete_forms_checkbox, arep_get_notices_checkbox, arep_use_SNAP_checkbox
 Dim CAF_arep_complete_forms_checkbox, CAF_arep_get_notices_checkbox, CAF_arep_use_SNAP_checkbox
 Dim arep_on_CAF_checkbox, arep_action, CAF_arep_action, arep_and_CAF_arep_match, arep_authorization, arep_exists, arep_authorized
-Dim signature_detail, signature_person, signature_date, second_signature_detail, second_signature_person, second_signature_date
+Dim signature_detail, signature_person, second_signature_detail, second_signature_person
 Dim client_signed_verbally_yn, interview_date, add_to_time, update_arep, verifs_needed, verifs_selected, verif_req_form_sent_date, number_verifs_checkbox, verifs_postponed_checkbox
 Dim verif_snap_checkbox, verif_cash_checkbox, verif_mfip_checkbox, verif_dwp_checkbox, verif_msa_checkbox, verif_ga_checkbox, verif_grh_checkbox, verif_emer_checkbox, verif_hc_checkbox
 Dim exp_snap_approval_date, exp_snap_delays, snap_denial_date, snap_denial_explain, pend_snap_on_case, do_we_have_applicant_id
@@ -10320,13 +10300,13 @@ objSelection.Font.Size = "12"
 
 objSelection.TypeText "Signature of Primary Adult: " & signature_detail
 If signature_detail <> "Not Required" AND signature_detail <> "Blank" Then
-	objSelection.TypeText " by " & signature_person & " on " & signature_date
+	objSelection.TypeText " by " & signature_person
 End If
 objSelection.TypeText vbCr
 
 objSelection.TypeText "Signature of Secondary Adult: " & second_signature_detail
 If second_signature_detail <> "Not Required" AND second_signature_detail <> "Blank" Then
-	objSelection.TypeText " by " & second_signature_person & " on " & second_signature_date
+	objSelection.TypeText " by " & second_signature_person
 End If
 objSelection.TypeText vbCr
 objSelection.TypeText vbCr


### PR DESCRIPTION
Updates to the interview script to better support forms, interview policy and handling. 

- Verifications can be entirely cleared. 
- Improve the 'Clear' button for all question based verifications.
- Updated the verbiage in the dialogs and outputs to align with the the allowance for different form selections.
- Expedited Determination output in the WIF needed better logic to handle for cases that do not require an expedited determination and for the output when used by the interview team.
- Removed signature date. 
- Updated handling for verbal signature documentation.
- Default second signature to Not Required for a single person household.

This update does not handle for two additional planned updates:
1. Add Program History information to Follow Up (maybe XML output). 
2. Update the Person Display information dialog.
I will work on these depending on other incoming work in the next week.