### PR TITLE
#1952 NOTES - Eligibility Summary - GRH Initial App Month Handling

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -20216,7 +20216,8 @@ If (user_ID_for_validation = "CALO001" or user_ID_for_validation = "ILFE001" or 
 ' developer_mode = False
 
 Call MAXIS_background_check				'we are adding a background check to make sure the case is through background before attempting to read ELIG.
-' If MAXIS_case_number = "493723" Then allow_late_note = True
+If MAXIS_case_number = "2669373" Then allow_late_note = True
+If MAXIS_case_number = "772738" Then allow_late_note = True
 Call date_array_generator(first_footer_month, first_footer_year, MONTHS_ARRAY)
 
 ex_parte_approval = False

--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -24292,6 +24292,10 @@ If enter_CNOTE_for_GRH = True Then
 
 				If GRH_ELIG_APPROVALS(elig_ind).grh_elig_source_of_info = "FIAT" Then GRH_UNIQUE_APPROVALS(fiat_reason, approval_selected) = "Required to add GRH Supportive Housing Disregard to the budget as this process is not yet automated in the system."
 			End If
+			If GRH_ELIG_APPROVALS(elig_ind).all_income_disregarded = True Then
+				If GRH_ELIG_APPROVALS(elig_ind).grh_elig_budg_inc_unavail_1st_month <> "" Then GRH_UNIQUE_APPROVALS(income_disregard_note, approval_selected) = "$ " & GRH_ELIG_APPROVALS(elig_ind).grh_elig_budg_inc_unavail_1st_month & " of Income in the month of application is unavailable to the resident and not counted."
+			End If
+
 			GRH_UNIQUE_APPROVALS(grh_supp_hsg_disrgd_wcom_sent, approval_selected) = False
 
 			ei_count = 0


### PR DESCRIPTION
Ignore supportive housing disregard in any month with no counted income. This will handle for any initial month in which the income is unavailable and not counted. Additionally added handling to note information when all of the income is disregarded. 