### PR TITLE
#2233 & #2235 - Interview Team supports

### DIFF
--- a/admin/interview-team-case-tracking.vbs
+++ b/admin/interview-team-case-tracking.vbs
@@ -50,6 +50,8 @@ call changelog_update("01/13/2025", "Initial version.", "Casey Love, Hennepin Co
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
 
+'TODO  - NEED DIALOG AND REGION TESTING
+
 If NOT IsArray(interviewer_array) Then
 	Dim tester_array()
 	ReDim tester_array(0)
@@ -73,42 +75,45 @@ Const Case_Number_COL 				= 01
 Const Application_Date_COL 			= 02
 Const Interview_Date_COL 			= 03
 Const Interview_Worker_COL 			= 04
-Const Interview_Length_COL			= 05
-Const CASH_COL 						= 06
-Const FA_COL 						= 07
-Const SNAP_COL 						= 08
-Const Expedited_COL 				= 09
-Const GRH_COL 						= 10
-Const EMER_COL 						= 11
-Const EMER_REQ_TYPE_COL 			= 12
-Const Addtnl_Intrvwr_Note_COL		= 13
-Const CAF_NOTE_Date_COL 			= 14
-Const CAF_NOTE_Worker_COL 			= 15
-Const Next_Contact_Date_COL			= 16
-Const Next_Contact_Worker_COL		= 17
-Const Next_Contact_Header_COL		= 18
-Const Contacts_Count_COL			= 19
-Const NON_CAF_Followup_NOTE_Date_COL = 20
-Const NON_CAF_Followup_NOTE_Worker_COL = 21
-Const NON_CAF_Followup_NOTE_Header_COL = 22
-Const SNAP_APP_COL 					= 23
-Const SNAP_Expedited_COL			= 24
-Const SNAP_Elig_COL 				= 25
-Const CASH_APP_COL 					= 26
-Const CASH_Type_COL 				= 27
-Const CASH_Elig_COL 				= 28
-Const GRH_APP_COL 					= 29
-Const GRH_Elig_COL 					= 30
-Const EMER_APP_COL 					= 31
-Const EMER_Type_COL 				= 32
-Const EMER_Elig_COL 				= 33
-Const PND2_Denial_Date_COL			= 34
-Const Pending_Completed_COL			= 35
-Const FILE_NAME_COL 				= 36
+Const Interview_Worker_ID_COL		= 05
+Const Interview_Length_COL			= 06
+Const CASH_COL 						= 07
+Const FA_COL 						= 08
+Const SNAP_COL 						= 09
+Const Expedited_COL 				= 10
+Const GRH_COL 						= 11
+Const EMER_COL 						= 12
+Const EMER_REQ_TYPE_COL 			= 13
+Const Addtnl_Intrvwr_Note_COL		= 14
+Const CAF_NOTE_Date_COL 			= 15
+Const CAF_NOTE_Worker_COL 			= 16
+Const Next_Contact_Date_COL			= 17
+Const Next_Contact_Worker_COL		= 18
+Const Next_Contact_Header_COL		= 19
+Const Contacts_Count_COL			= 20
+Const NON_CAF_Followup_NOTE_Date_COL = 21
+Const NON_CAF_Followup_NOTE_Worker_COL = 22
+Const NON_CAF_Followup_NOTE_Header_COL = 23
+Const SNAP_APP_COL 					= 24
+Const SNAP_Expedited_COL			= 25
+Const SNAP_Elig_COL 				= 26
+Const CASH_APP_COL 					= 27
+Const CASH_Type_COL 				= 28
+Const CASH_Elig_COL 				= 29
+Const GRH_APP_COL 					= 30
+Const GRH_Elig_COL 					= 31
+Const EMER_APP_COL 					= 32
+Const EMER_Type_COL 				= 33
+Const EMER_Elig_COL 				= 34
+Const PND2_Denial_Date_COL			= 35
+Const Pending_Completed_COL			= 36
+Const FILE_NAME_COL 				= 37
 
-
+' TRACKING NOTES DOC: t_drive & "\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\Added to Work List\Support Documents\Tracking Log Notes and Information.docx"
 interview_tracking_excel = t_drive & "\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\Added to Work List\Interview Tracking.xlsx"
 Call excel_open(interview_tracking_excel, True, False, ObjExcel, objWorkbook)
+
+loged_tracking_records = t_drive & "\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\Added to Work List\Loged"
 
 excel_row = 2
 all_known_file_names = " "
@@ -126,6 +131,8 @@ ALL_KNOW_FILES_ARRAY = split(all_known_file_names)
 'creating some objects needed for XML handling
 Set xmlDoc = CreateObject("Microsoft.XMLDOM")
 Set xml = CreateObject("Msxml2.DOMDocument")
+Dim objTextStream
+xml_case_numbs = "*"
 
 'Looking at each xml in the folder for the Interview Team completion
 For Each objFile in colFiles								'looping through each file
@@ -134,99 +141,168 @@ For Each objFile in colFiles								'looping through each file
 	If file_type = "XML Source File" Then
 		quack = objFile.Name
 		file_recorded = False
+		xmlPath = objFile.Path												'identifying the current file
 
 		For each duck in ALL_KNOW_FILES_ARRAY
 			If duck = quack Then
 				file_recorded = True
+				With (CreateObject("Scripting.FileSystemObject"))
+					.MoveFile xmlPath , loged_tracking_records & "\" & quack & ".xml"
+				End With
+
 				Exit For
 			End If
 		Next
 
 		If file_recorded = False Then
-			xmlPath = objFile.Path												'identifying the current file
 			With (CreateObject("Scripting.FileSystemObject"))
 				'Creating an object for the stream of text which we'll use frequently
-				Dim objTextStream
 				If .FileExists(xmlPath) = True then
-					xmlDoc.Async = False
+					name_of_xml = objFile.Name
+					If InStr(name_of_xml, "details") Then
+						xmlDoc.Async = False
 
-					' Load the XML file
-					xmlDoc.load(xmlPath)
+						' Load the XML file
+						xmlDoc.load(xmlPath)
 
-					'reads data about the case from the XML
-					set node = xmlDoc.SelectSingleNode("//CaseNumber")
-					MAXIS_case_number = node.text
+						'reads data about the case from the XML
+						set node = xmlDoc.SelectSingleNode("//CaseNumber")
+						MAXIS_case_number = node.text
+						xml_case_numbs = xml_case_numbs & trim(MAXIS_case_number) & "*"
 
-					set node = xmlDoc.SelectSingleNode("//CAFDateStamp")
-					app_date = node.text
-					app_date = DateAdd("d", 0, app_date)
+						set node = xmlDoc.SelectSingleNode("//CAFDateStamp")
+						app_date = node.text
+						app_date = DateAdd("d", 0, app_date)
 
-					set node = xmlDoc.SelectSingleNode("//WorkerName")
-					worker_name = node.text
+						set node = xmlDoc.SelectSingleNode("//WorkerName")
+						worker_name = node.text
 
-					Set node = xmlDoc.SelectSingleNode("//InterviewLength")
-					interview_length = node.text
+						set node = xmlDoc.SelectSingleNode("//WindowsUserID")
+						worker_user_id = node.text
 
-					set node = xmlDoc.SelectSingleNode("//InterviewDate")
-					interview_date = node.text
-					interview_date = DateAdd("d", 0, interview_date)
+						Set node = xmlDoc.SelectSingleNode("//InterviewLength")
+						interview_length = node.text
 
-					set node = xmlDoc.SelectSingleNode("//CASHRequest")
-					req_cash = node.text
-					req_cash = req_cash * 1
+						set node = xmlDoc.SelectSingleNode("//InterviewDate")
+						interview_date = node.text
+						interview_date = DateAdd("d", 0, interview_date)
 
-					cash_type = ""
-					If req_cash = True Then
-						set node = xmlDoc.SelectSingleNode("//TypeOfCASH")
-						cash_type = node.text
+						set node = xmlDoc.SelectSingleNode("//CASHRequest")
+						req_cash = node.text
+						req_cash = req_cash * 1
+
+						cash_type = ""
+						If req_cash = True Then
+							set node = xmlDoc.SelectSingleNode("//TypeOfCASH")
+							cash_type = node.text
+						End If
+
+						If DateDiff("d", #1/13/2025#, interview_date) > 0 Then
+							set node = xmlDoc.SelectSingleNode("//GRHRequest")
+							req_grh = node.text
+							req_grh = req_grh * 1
+						End If
+
+						set node = xmlDoc.SelectSingleNode("//SNAPRequest")
+						req_snap = node.text
+						req_snap = req_snap * 1
+
+						set node = xmlDoc.SelectSingleNode("//EMERRequest")
+						req_emer = node.text
+						req_emer = req_emer * 1
+
+
+						set node = xmlDoc.SelectSingleNode("//ExpeditedDetermination")
+						exp_det = node.text
+						If exp_det <> "" Then exp_det = exp_det * 1
+
+						'Add the file information to the Excel document for the worklist
+						' MsgBox "app_date - " & app_date
+
+						ObjExcel.Cells(excel_row, Case_Number_COL).Value 		= MAXIS_case_number
+						ObjExcel.Cells(excel_row, Application_Date_COL).Value 	= app_date
+						ObjExcel.Cells(excel_row, Interview_Date_COL).Value 	= interview_date
+						ObjExcel.Cells(excel_row, Interview_Worker_COL).Value 	= worker_name
+						ObjExcel.Cells(excel_row, Interview_Worker_ID_COL).Value= worker_user_id
+						ObjExcel.Cells(excel_row, Interview_Length_COL).Value 	= interview_length
+						If req_cash = True  Then
+							ObjExcel.Cells(excel_row, CASH_COL).Value 									= "TRUE"
+							ObjExcel.Cells(excel_row, FA_COL).Value 									= cash_type
+						End If
+						If req_cash = False Then ObjExcel.Cells(excel_row, CASH_COL).Value 				= "FALSE"
+						If req_snap = True  Then
+							ObjExcel.Cells(excel_row, SNAP_COL).Value 									= "TRUE"
+							If exp_det = True  Then ObjExcel.Cells(excel_row, Expedited_COL).Value		= "TRUE"
+							If exp_det = False Then ObjExcel.Cells(excel_row, Expedited_COL).Value 		= "FALSE"
+						End If
+						If req_snap = False Then ObjExcel.Cells(excel_row, SNAP_COL).Value 				= "FALSE"
+						If req_grh  = True  Then ObjExcel.Cells(excel_row, GRH_COL).Value 				= "TRUE"
+						If req_grh  = False Then ObjExcel.Cells(excel_row, GRH_COL).Value 				= "FALSE"
+						If req_emer = True  Then ObjExcel.Cells(excel_row, EMER_COL).Value 				= "TRUE"
+						If req_emer = False Then ObjExcel.Cells(excel_row, EMER_COL).Value 				= "FALSE"
+
+						ObjExcel.Cells(excel_row, FILE_NAME_COL).Value 			= quack
+
+						excel_row = excel_row + 1		'increment the excel row to add more
+						STATS_counter = STATS_counter + 1
 					End If
+				End If
+			End With
+		End If
+	End If
+Next
 
-					If DateDiff("d", #1/13/2025#, interview_date) > 0 Then
-						set node = xmlDoc.SelectSingleNode("//GRHRequest")
-						req_grh = node.text
-						req_grh = req_grh * 1
+'Looking at each xml in the folder for the Interview Team completion
+For Each objFile in colFiles								'looping through each file
+	file_type = objFile.Type
+
+	If file_type = "XML Source File" Then
+		quack = objFile.Name
+		file_recorded = False
+		xmlPath = objFile.Path												'identifying the current file
+
+		If file_recorded = False Then
+			With (CreateObject("Scripting.FileSystemObject"))
+				'Creating an object for the stream of text which we'll use frequently
+				If .FileExists(xmlPath) = True then
+					name_of_xml = objFile.Name
+					If InStr(name_of_xml, "started") Then
+						xmlDoc.Async = False
+
+						' Load the XML file
+						xmlDoc.load(xmlPath)
+
+						'reads data about the case from the XML
+						set node = xmlDoc.SelectSingleNode("//CaseNumber")
+						MAXIS_case_number = node.text
+						search_numb = "*" & trim(MAXIS_case_number) & "*"
+
+						set node = xmlDoc.SelectSingleNode("//WorkerName")
+						worker_name = node.text
+
+						set node = xmlDoc.SelectSingleNode("//WindowsUserID")
+						worker_user_id = node.text
+
+						set node = xmlDoc.SelectSingleNode("//ScriptRunDate")
+						interview_date = node.text
+						interview_date = DateAdd("d", 0, interview_date)
+
+						If InStr(xml_case_numbs, search_numb) = 0 Then
+
+							ObjExcel.Cells(excel_row, Case_Number_COL).Value 		= MAXIS_case_number
+							' ObjExcel.Cells(excel_row, Application_Date_COL).Value 	= app_date
+							ObjExcel.Range(ObjExcel.Cells(excel_row, Application_Date_COL), ObjExcel.Cells(excel_row, Application_Date_COL)).Interior.ColorIndex = 3			'RED
+							ObjExcel.Cells(excel_row, Interview_Date_COL).Value 	= interview_date
+							ObjExcel.Cells(excel_row, Interview_Worker_COL).Value 	= worker_name
+							ObjExcel.Cells(excel_row, Interview_Worker_ID_COL).Value= worker_user_id
+							ObjExcel.Range(ObjExcel.Cells(excel_row, Interview_Length_COL), ObjExcel.Cells(excel_row, Interview_Length_COL)).Interior.ColorIndex = 3			'RED
+
+							ObjExcel.Cells(excel_row, FILE_NAME_COL).Value 			= quack
+
+							excel_row = excel_row + 1		'increment the excel row to add more
+							STATS_counter = STATS_counter + 1
+						End If
 					End If
-
-					set node = xmlDoc.SelectSingleNode("//SNAPRequest")
-					req_snap = node.text
-					req_snap = req_snap * 1
-
-					set node = xmlDoc.SelectSingleNode("//EMERRequest")
-					req_emer = node.text
-					req_emer = req_emer * 1
-
-
-					set node = xmlDoc.SelectSingleNode("//ExpeditedDetermination")
-					exp_det = node.text
-					If exp_det <> "" Then exp_det = exp_det * 1
-
-					'Add the file information to the Excel document for the worklist
-
-					ObjExcel.Cells(excel_row, Case_Number_COL).Value 		= MAXIS_case_number
-					ObjExcel.Cells(excel_row, Application_Date_COL).Value 	= app_date
-					ObjExcel.Cells(excel_row, Interview_Date_COL).Value 	= interview_date
-					ObjExcel.Cells(excel_row, Interview_Worker_COL).Value 	= worker_name
-					ObjExcel.Cells(excel_row, Interview_Length_COL).Value 	= interview_length
-					If req_cash = True  Then
-						ObjExcel.Cells(excel_row, CASH_COL).Value 									= "TRUE"
-						ObjExcel.Cells(excel_row, FA_COL).Value 									= cash_type
-					End If
-					If req_cash = False Then ObjExcel.Cells(excel_row, CASH_COL).Value 				= "FALSE"
-					If req_snap = True  Then
-						ObjExcel.Cells(excel_row, SNAP_COL).Value 									= "TRUE"
-						If exp_det = True  Then ObjExcel.Cells(excel_row, Expedited_COL).Value		= "TRUE"
-						If exp_det = False Then ObjExcel.Cells(excel_row, Expedited_COL).Value 		= "FALSE"
-					End If
-					If req_snap = False Then ObjExcel.Cells(excel_row, SNAP_COL).Value 				= "FALSE"
-					If req_grh  = True  Then ObjExcel.Cells(excel_row, GRH_COL).Value 				= "TRUE"
-					If req_grh  = False Then ObjExcel.Cells(excel_row, GRH_COL).Value 				= "FALSE"
-					If req_emer = True  Then ObjExcel.Cells(excel_row, EMER_COL).Value 				= "TRUE"
-					If req_emer = False Then ObjExcel.Cells(excel_row, EMER_COL).Value 				= "FALSE"
-
-					ObjExcel.Cells(excel_row, FILE_NAME_COL).Value 			= quack
-
-					excel_row = excel_row + 1		'increment the excel row to add more
-					STATS_counter = STATS_counter + 1
 				End If
 			End With
 		End If
@@ -234,6 +310,7 @@ For Each objFile in colFiles								'looping through each file
 Next
 objWorkbook.Save()		'saving the excel
 
+transmit
 Call check_for_MAXIS(False)
 
 'READ for Follow Up Notes
@@ -243,177 +320,215 @@ Do
 	MAXIS_case_number = trim(ObjExcel.Cells(excel_row, Case_Number_COL).Value)
 
 	Call read_boolean_from_excel(ObjExcel.Cells(excel_row, Pending_Completed_COL), is_case_completed)
-	If is_case_completed <> True Then
+	interviewer_name =  trim(ObjExcel.Cells(excel_row, Interview_Worker_COL))
+	If is_case_completed <> True or interviewer_name = "" Then
 		STATS_counter = STATS_counter + 1
 
 		app_date = trim(ObjExcel.Cells(excel_row, Application_Date_COL).Value)
-		app_date = DateAdd("d", 0, app_date)
-        Call convert_date_into_MAXIS_footer_month(app_date, MAXIS_footer_month, MAXIS_footer_year)
+		If app_date <> "" Then 			'For some tracking files we do not have all the information and so we cannot do all the things
+			app_date = DateAdd("d", 0, app_date)
+			Call convert_date_into_MAXIS_footer_month(app_date, MAXIS_footer_month, MAXIS_footer_year)
 
-		Call determine_program_and_case_status_from_CASE_CURR(case_active, case_pending, case_rein, family_cash_case, mfip_case, dwp_case, adult_cash_case, ga_case, msa_case, grh_case, snap_case, ma_case, msp_case, emer_case, unknown_cash_pending, unknown_hc_pending, ga_status, msa_status, mfip_status, dwp_status, grh_status, snap_status, ma_status, msp_status, msp_type, emer_status, emer_type, case_status, list_active_programs, list_pending_programs)
-		application_processed = False
-		If case_pending = False Then application_processed = True
-		If case_pending = True Then
-			If unknown_cash_pending = False and ga_status <> "PENDING" and msa_status <> "PENDING" and mfip_status <> "PENDING" and dwp_status <> "PENDING" and grh_status <> "PENDING" and snap_status <> "PENDING" and emer_status <> "PENDING" Then application_processed = True
-		End If
-		If application_processed = True Then excel_rows_with_processing_completed = excel_rows_with_processing_completed & excel_row & " "
-
-		Call read_boolean_from_excel(ObjExcel.Cells(excel_row, EMER_COL), emer_request)
-		emer_pend_type = trim(ObjExcel.Cells(excel_row, EMER_REQ_TYPE_COL))
-		' MsgBox "emer_request - " & emer_request & vbCr & "emer_pend_type - " & emer_pend_type
-		If emer_request = True and emer_pend_type = "" Then
-			' MsgBox "IN IT" & vbCr & "emer_type - " & emer_type
-			ObjExcel.Cells(excel_row, EMER_REQ_TYPE_COL) = emer_type
-		End If
-
-
-		interview_date = trim(ObjExcel.Cells(excel_row, Interview_Date_COL).Value)
-		interview_date = DateAdd("d", 0, interview_date)
-		CAF_Note_date = trim(ObjExcel.Cells(excel_row, CAF_NOTE_Date_COL))
-		FollowUp_Note_date = trim(ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Date_COL))
-
-		CAF_date = ""
-		CAF_worker = ""
-		FollowUp_date = ""
-		FollowUp_worker = ""
-		FollowUp_text = ""
-		Contact_date = ""
-		Contact_worker = ""
-		Contact_text = ""
-		Contact_count = 0
-		PND2_denial_date = ""
-		additional_interviewer_note = False
-
-		interviewer_name =  trim(ObjExcel.Cells(excel_row, Interview_Worker_COL))
-		interviewer_mx_number = ""
-		run_by_interview_team = False										'Default the interview team option to false
-		For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
-			If UCase(interviewer_name) = UCase(worker.interviewer_full_name) Then
-				interviewer_mx_number = UCase(worker.interviewer_x_number)
-				Exit For
+			Call determine_program_and_case_status_from_CASE_CURR(case_active, case_pending, case_rein, family_cash_case, mfip_case, dwp_case, adult_cash_case, ga_case, msa_case, grh_case, snap_case, ma_case, msp_case, emer_case, unknown_cash_pending, unknown_hc_pending, ga_status, msa_status, mfip_status, dwp_status, grh_status, snap_status, ma_status, msp_status, msp_type, emer_status, emer_type, case_status, list_active_programs, list_pending_programs)
+			application_processed = False
+			If case_pending = False Then application_processed = True
+			If case_pending = True Then
+				If unknown_cash_pending = False and ga_status <> "PENDING" and msa_status <> "PENDING" and mfip_status <> "PENDING" and dwp_status <> "PENDING" and grh_status <> "PENDING" and snap_status <> "PENDING" and emer_status <> "PENDING" Then application_processed = True
 			End If
-		Next
+			If application_processed = True Then excel_rows_with_processing_completed = excel_rows_with_processing_completed & excel_row & " "
 
-		If CAF_Note_date = "" or (application_processed = True and FollowUp_Note_date = "") Then
+			Call read_boolean_from_excel(ObjExcel.Cells(excel_row, EMER_COL), emer_request)
+			emer_pend_type = trim(ObjExcel.Cells(excel_row, EMER_REQ_TYPE_COL))
+			' MsgBox "emer_request - " & emer_request & vbCr & "emer_pend_type - " & emer_pend_type
+			If emer_request = True and emer_pend_type = "" Then
+				' MsgBox "IN IT" & vbCr & "emer_type - " & emer_type
+				ObjExcel.Cells(excel_row, EMER_REQ_TYPE_COL) = emer_type
+			End If
 
-			Call Navigate_to_MAXIS_screen("CASE", "NOTE")               'Now we navigate to CASE:NOTES
-			too_old_date = DateAdd("D", -1, interview_date)              'We don't need to read notes from before the CAF date
 
-			note_row = 5
-			Do
-				EMReadScreen note_date, 	8, note_row, 6                  'reading the note date
-				EMReadScreen note_worker, 	7, note_row, 16
-				EMReadScreen note_title, 	55, note_row, 25               'reading the note header
-				note_title = trim(note_title)
+			interview_date = trim(ObjExcel.Cells(excel_row, Interview_Date_COL).Value)
+			interview_date = DateAdd("d", 0, interview_date)
+			CAF_Note_date = trim(ObjExcel.Cells(excel_row, CAF_NOTE_Date_COL))
+			FollowUp_Note_date = trim(ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Date_COL))
 
-				If left(note_title, 24) = "~ Interview Completed on" Then Exit Do
-				If note_title = "Processing Needed: follow up notes from Interview" Then Exit Do
-				If note_date = "        " Then Exit Do                                      'if we are at the end of the list of notes - we can't read any more
+			CAF_date = ""
+			CAF_worker = ""
+			FollowUp_date = ""
+			FollowUp_worker = ""
+			FollowUp_text = ""
+			Contact_date = ""
+			Contact_worker = ""
+			Contact_text = ""
+			Contact_count = 0
+			PND2_denial_date = ""
+			additional_interviewer_note = False
 
-				exclude_this_note = False
-				If note_title = "~~~continued from previous note~~~" Then exclude_this_note = True
-				If left(note_title, 11) = "APPROVAL - " Then exclude_this_note = True
-				If left(note_title, 16) =  "REVW COMPLETE - " Then exclude_this_note = True
-				If left(note_title, 16) = "MFIP Orientation" Then exclude_this_note = True
-				If note_title = "**AREP removed**" Then exclude_this_note = True
-				If note_title = "Phone Interview Attempted but Interview NOT Completed" Then exclude_this_note = True
-				If interviewer_mx_number = note_worker Then exclude_this_note = True		'we are not interested in notes by the interviewing worker.
-				If note_worker = "X127L1S" Then exclude_this_note = True
-				If note_worker = "X127DC6" Then exclude_this_note = True
-				If note_worker = "X127MR7" Then exclude_this_note = True
-				If left(note_title, 24) = "~ Application Received (" Then exclude_this_note = True
-				If left(note_title, 23) = "~ HC Pended from a METS" Then exclude_this_note = True
-				If left(note_title, 32) = "~ Received Application for SNAP," Then exclude_this_note = True
-				If left(note_title, 33) = "~ Appointment letter sent in MEMO" Then exclude_this_note = True
-				If InStr(note_title, " EBT TRX ") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "MONY/CHCK ISSUED ON ") <> 0 Then exclude_this_note = True
-				If InStr(note_title, " PARIS Match (") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "Paris match -  ") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "WAGE MATCH (") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "WAGE MATCH(") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "-----Appeal ") <> 0 Then exclude_this_note = True
-				If InStr(note_title, "DISB ") <> 0 and note_worker = "CS DAIL" Then exclude_this_note = True
-				If left(note_worker, 2) = "PW" Then exclude_this_note = True
-				If left(note_title, 25) = "Client picked up EBT card" Then exclude_this_note = True
-				If note_title = "EDRS RAN FOR THE CASE" Then exclude_this_note = True
-				If left(note_title, 22) = "DD set on this account" Then exclude_this_note = True
-				If left(note_title, 13) = "*** EX PARTE " Then exclude_this_note = True
-				If note_title = "~ Client has not completed application interview, NOMI" Then exclude_this_note = True
+			interviewer_name =  trim(ObjExcel.Cells(excel_row, Interview_Worker_COL))
+			interviewer_user_id = trim(ObjExcel.Cells(excel_row, Interview_Worker_ID_COL))
+			interviewer_mx_number = ""
+			run_by_interview_team = False										'Default the interview team option to false
+			If trim(interviewer_name) = "" and trim(interviewer_user_id) <> "" Then
+				For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
+					If UCase(interviewer_user_id) = UCase(worker.interviewer_id_number) Then
+						interviewer_name = worker.interviewer_full_name
+						interviewer_mx_number = UCase(worker.interviewer_x_number)
+						ObjExcel.Cells(excel_row, Interview_Worker_COL) = worker.interviewer_full_name
+						Exit For
+					End If
+				Next
+			Else
+				For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
+					If UCase(interviewer_name) = UCase(worker.interviewer_full_name) Then
+						interviewer_mx_number = UCase(worker.interviewer_x_number)
+						Exit For
+					End If
+				Next
+			End If
 
-				' MsgBox "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker
+			If CAF_Note_date = "" or (application_processed = True and FollowUp_Note_date = "") Then
 
-				If Instr(note_title, " HUF for ") <> 0 or Instr(note_title, " CAF for ") <> 0 Then
-					CAF_date = note_date
-					CAF_worker = note_worker
-				ElseIf Instr(note_title, "Office visit from") <> 0 or InStr(note_title, "Phone call from") <> 0 or InStr(note_title, "Voicemail to") <> 0 or InStr(note_title, "Voicemail from") <> 0  or InStr(note_title, "Chat Message from") <> 0 or InStr(note_title, "Infokeep chat from") <> 0 Then		'or InStr(note_title, "Phone call to") <> 0
-					Contact_date = note_date
-					Contact_worker = note_worker
-					Contact_text = note_title
-					Contact_count = Contact_count + 1
-				ElseIf InStr(note_title, "DENIAL of ") <> 0 Then
-					PND2_denial_date = note_date
-				ElseIF exclude_this_note = False Then
-					additional_contact_with_interview_team = False
-					For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
-						' MsgBox "NOTE WORKER - " & note_worker & vbCr & vbCr & "worker x number - " & worker.interviewer_x_number & vbCr & "trainer - " & worker.interview_trainer
-						If worker.interview_trainer = False and UCase(worker.interviewer_x_number) <> "X127XXX" and worker.interviewer_x_number <> "" Then
-							If note_worker = UCase(worker.interviewer_x_number) Then
-								' MsgBox "MATCH !!!" & vbCr & vbCr & "NOTE WORKER - " & note_worker & vbCr & vbCr & "worker x number - " & worker.interviewer_x_number & vbCr & "trainer - " & worker.interview_trainer
-								additional_contact_with_interview_team = True
-								Contact_date = note_date
-								Contact_worker = note_worker
-								Contact_text = note_title
-								Contact_count = Contact_count + 1
+				Call navigate_to_MAXIS_screen_review_PRIV("CASE", "NOTE", is_this_priv)               'Now we navigate to CASE:NOTES
+				If is_this_priv = False Then
+					too_old_date = DateAdd("D", -1, interview_date)              'We don't need to read notes from before the CAF date
+
+					note_row = 5
+					Do
+						EMReadScreen note_date, 	8, note_row, 6                  'reading the note date
+						EMReadScreen note_worker, 	7, note_row, 16
+						EMReadScreen note_title, 	55, note_row, 25               'reading the note header
+						note_title = trim(note_title)
+
+						If left(note_title, 24) = "~ Interview Completed on" Then
+							If interviewer_name = "" Then
+								For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
+									If UCase(note_worker) = UCase(worker.interviewer_x_number) Then
+										interviewer_name = worker.interviewer_full_name
+										ObjExcel.Cells(excel_row, Interview_Worker_COL).Value = interviewer_name
+										Exit For
+									End If
+								Next
 								Exit Do
 							End If
 						End If
-					Next
-					If additional_contact_with_interview_team = False Then
-						FollowUp_date = note_date
-						FollowUp_worker = note_worker
-						FollowUp_text = note_title
-					End If
-				ElseIf interviewer_mx_number = note_worker Then
-					' MsgBox "MATCH !!!" & vbCr & vbCr & "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker & vbCr & vbCr & "note_title - " & note_title
+						' If note_title = "Processing Needed: follow up notes from Interview" Then Exit Do
+						If note_date = "        " Then Exit Do                                      'if we are at the end of the list of notes - we can't read any more
 
-					If note_title <> "Processing Needed: follow up notes from Interview" and note_title <> "~~~continued from previous note~~~" and left(note_title, 24) <> "~ Interview Completed on" and note_title <> "VERIFICATIONS REQUESTED" and left(note_title, 25) <> "Expedited Determination: " and note_title <> "INTERVIEW INCOMPLETE - Attempt made but additional deta" Then
-						' MsgBox "SAVE !!!" & vbCr & vbCr & "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker & vbCr & vbCr & "note_title - " & note_title
-						additional_interviewer_note = True
-					End If
+						exclude_this_note = False
+						If note_title = "~~~continued from previous note~~~" Then exclude_this_note = True
+						If left(note_title, 11) = "APPROVAL - " Then exclude_this_note = True
+						If left(note_title, 16) =  "REVW COMPLETE - " Then exclude_this_note = True
+						If left(note_title, 16) = "MFIP Orientation" Then exclude_this_note = True
+						If note_title = "**AREP removed**" Then exclude_this_note = True
+						If note_title = "Phone Interview Attempted but Interview NOT Completed" Then exclude_this_note = True
+						If interviewer_mx_number = note_worker Then exclude_this_note = True		'we are not interested in notes by the interviewing worker.
+						If note_worker = "X127L1S" Then exclude_this_note = True
+						If note_worker = "X127DC6" Then exclude_this_note = True
+						If note_worker = "X127MR7" Then exclude_this_note = True
+						If left(note_title, 24) = "~ Application Received (" Then exclude_this_note = True
+						If left(note_title, 23) = "~ HC Pended from a METS" Then exclude_this_note = True
+						If left(note_title, 32) = "~ Received Application for SNAP," Then exclude_this_note = True
+						If left(note_title, 33) = "~ Appointment letter sent in MEMO" Then exclude_this_note = True
+						If left(note_title, 34) = "Subsequent Application Requesting:" Then exclude_this_note = True
+						If InStr(note_title, " EBT TRX ") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "MONY/CHCK ISSUED ON ") <> 0 Then exclude_this_note = True
+						If InStr(note_title, " PARIS Match (") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "Paris match -  ") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "WAGE MATCH (") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "WAGE MATCH(") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "-----Appeal ") <> 0 Then exclude_this_note = True
+						If InStr(note_title, "DISB ") <> 0 and note_worker = "CS DAIL" Then exclude_this_note = True
+						If left(note_worker, 2) = "PW" Then exclude_this_note = True
+						If left(note_title, 25) = "Client picked up EBT card" Then exclude_this_note = True
+						If note_title = "EDRS RAN FOR THE CASE" Then exclude_this_note = True
+						If left(note_title, 22) = "DD set on this account" Then exclude_this_note = True
+						If left(note_title, 13) = "*** EX PARTE " Then exclude_this_note = True
+						If note_title = "~ Client has not completed application interview, NOMI" Then exclude_this_note = True
+						If InStr(note_title, "HC Certain Pops App:") Then exclude_this_note = True
+						If InStr(note_title, "HC Renewal Form:") Then exclude_this_note = True
+						If InStr(note_title, "Ex Parte Renewal") Then exclude_this_note = True
+						If InStr(note_title, "DHS-3876 (Certain Pops App)") Then exclude_this_note = True
+						If InStr(UCASE(note_title), "OOPS") Then exclude_this_note = True
+						If left(note_title, 7) = "**EBT**" Then exclude_this_note = True
+
+						' MsgBox "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker
+
+						If Instr(note_title, " HUF for ") <> 0 or Instr(note_title, " CAF for ") <> 0 Then
+							CAF_date = note_date
+							CAF_worker = note_worker
+						ElseIf Instr(note_title, "Office visit at") <> 0 or Instr(note_title, "Office visit from") <> 0 or InStr(note_title, "Phone call from") <> 0 or InStr(note_title, "Voicemail to") <> 0 or InStr(note_title, "Voicemail from") <> 0  or InStr(note_title, "Chat Message from") <> 0 or InStr(note_title, "Infokeep chat from") <> 0 or InStr(note_title, "Voicemail assignment") Then		'or InStr(note_title, "Phone call to") <> 0
+							Contact_date = note_date
+							Contact_worker = note_worker
+							Contact_text = note_title
+							Contact_count = Contact_count + 1
+						ElseIf InStr(note_title, "DENIAL of ") <> 0 Then
+							PND2_denial_date = note_date
+						ElseIF exclude_this_note = False Then
+							additional_contact_with_interview_team = False
+							For each worker in interviewer_array 								'loop through all of the workers listed in the interviewer_array
+								' MsgBox "NOTE WORKER - " & note_worker & vbCr & vbCr & "worker x number - " & worker.interviewer_x_number & vbCr & "trainer - " & worker.interview_trainer
+								If worker.interview_trainer = False and UCase(worker.interviewer_x_number) <> "X127XXX" and worker.interviewer_x_number <> "" Then
+									If note_worker = UCase(worker.interviewer_x_number) Then
+										' MsgBox "MATCH !!!" & vbCr & vbCr & "NOTE WORKER - " & note_worker & vbCr & vbCr & "worker x number - " & worker.interviewer_x_number & vbCr & "trainer - " & worker.interview_trainer
+										additional_contact_with_interview_team = True
+										Contact_date = note_date
+										Contact_worker = note_worker
+										Contact_text = note_title
+										Contact_count = Contact_count + 1
+										Exit Do
+									End If
+								End If
+							Next
+							If additional_contact_with_interview_team = False Then
+								FollowUp_date = note_date
+								FollowUp_worker = note_worker
+								FollowUp_text = note_title
+							End If
+						ElseIf interviewer_mx_number = note_worker Then
+							' MsgBox "MATCH !!!" & vbCr & vbCr & "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker & vbCr & vbCr & "note_title - " & note_title
+
+							If note_title <> "Processing Needed: follow up notes from Interview" and note_title <> "~~~continued from previous note~~~" and left(note_title, 24) <> "~ Interview Completed on" and note_title <> "VERIFICATIONS REQUESTED" and left(note_title, 25) <> "Expedited Determination: " and note_title <> "INTERVIEW INCOMPLETE - Attempt made but additional deta" Then
+								' MsgBox "SAVE !!!" & vbCr & vbCr & "interviewer_mx_number - " & interviewer_mx_number & vbCr & "note_worker - " & note_worker & vbCr & vbCr & "note_title - " & note_title
+								additional_interviewer_note = True
+							End If
+						End If
+
+
+						note_row = note_row + 1
+						If note_row = 19 Then
+							note_row = 5
+							PF8
+							EMReadScreen check_for_last_page, 9, 24, 14
+							If check_for_last_page = "LAST PAGE" Then Exit Do
+						End If
+						EMReadScreen next_note_date, 8, note_row, 6
+						If next_note_date = "        " Then Exit Do
+					Loop until DateDiff("d", too_old_date, next_note_date) <= 0
+				Else
+					FollowUp_text = "PRIVILEGED CASE"
 				End If
+			End If
 
-
-				note_row = note_row + 1
-				If note_row = 19 Then
-					note_row = 5
-					PF8
-					EMReadScreen check_for_last_page, 9, 24, 14
-					If check_for_last_page = "LAST PAGE" Then Exit Do
-				End If
-				EMReadScreen next_note_date, 8, note_row, 6
-				If next_note_date = "        " Then Exit Do
-			Loop until DateDiff("d", too_old_date, next_note_date) <= 0
-
+			If CAF_date <> "" Then
+				ObjExcel.Cells(excel_row, CAF_NOTE_Date_COL).Value = CAF_date
+				ObjExcel.Cells(excel_row, CAF_NOTE_Worker_COL).Value = CAF_worker
+			End If
+			If FollowUp_date <> "" Then
+				' MsgBox "excel_row - " & excel_row & vbCr & "FollowUp_text - " & FollowUp_text
+				If left(FollowUp_text, 1) = "=" Then FollowUp_text = "'" & FollowUp_text
+				ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Date_COL).Value = FollowUp_date
+				ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Worker_COL).Value = FollowUp_worker
+				ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Header_COL).Value = FollowUp_text
+			End If
+			If Contact_date <> "" Then
+				If left(Contact_text, 1) = "=" Then Contact_text = "'" & Contact_text
+				ObjExcel.Cells(excel_row, Next_Contact_Date_COL).Value 		= Contact_date
+				ObjExcel.Cells(excel_row, Next_Contact_Worker_COL).Value 	= Contact_worker
+				ObjExcel.Cells(excel_row, Next_Contact_Header_COL).Value 	= Contact_text
+				ObjExcel.Cells(excel_row, Contacts_Count_COL).Value 	= Contact_count
+			End If
+			ObjExcel.Cells(excel_row, PND2_Denial_Date_COL).Value = PND2_denial_date
+			If additional_interviewer_note = True Then ObjExcel.Cells(excel_row, Addtnl_Intrvwr_Note_COL).Value = "TRUE"
 		End If
-
-		If CAF_date <> "" Then
-			ObjExcel.Cells(excel_row, CAF_NOTE_Date_COL).Value = CAF_date
-			ObjExcel.Cells(excel_row, CAF_NOTE_Worker_COL).Value = CAF_worker
-		End If
-		If FollowUp_date <> "" Then
-			ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Date_COL).Value = FollowUp_date
-			ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Worker_COL).Value = FollowUp_worker
-			ObjExcel.Cells(excel_row, NON_CAF_Followup_NOTE_Header_COL).Value = FollowUp_text
-		End If
-		If Contact_date <> "" Then
-			ObjExcel.Cells(excel_row, Next_Contact_Date_COL).Value 		= Contact_date
-			ObjExcel.Cells(excel_row, Next_Contact_Worker_COL).Value 	= Contact_worker
-			ObjExcel.Cells(excel_row, Next_Contact_Header_COL).Value 	= Contact_text
-			ObjExcel.Cells(excel_row, Contacts_Count_COL).Value 	= Contact_count
-		End If
-		ObjExcel.Cells(excel_row, PND2_Denial_Date_COL).Value = PND2_denial_date
-		If additional_interviewer_note = True Then ObjExcel.Cells(excel_row, Addtnl_Intrvwr_Note_COL).Value = "TRUE"
-
 	End If
 	Call back_to_SELF
 	excel_row = excel_row + 1
@@ -421,6 +536,9 @@ Do
 	next_case = trim(ObjExcel.Cells(excel_row, Case_Number_COL).Value)
 Loop until next_case = ""
 objWorkbook.Save()		'saving the excel
+
+transmit
+Call check_for_MAXIS(False)
 
 'READ for approvals
 excel_row = 2
@@ -432,156 +550,157 @@ Do
 		STATS_counter = STATS_counter + 1
 
 		app_date = trim(ObjExcel.Cells(excel_row, Application_Date_COL).Value)
-		app_date = DateAdd("d", 0, app_date)
-		interview_date = trim(ObjExcel.Cells(excel_row, Interview_Date_COL).Value)
-		interview_date = DateAdd("d", 0, interview_date)
+		If app_date <> "" Then 			'For some tracking files we do not have all the information and so we cannot do all the things
+			app_date = DateAdd("d", 0, app_date)
+			interview_date = trim(ObjExcel.Cells(excel_row, Interview_Date_COL).Value)
+			interview_date = DateAdd("d", 0, interview_date)
 
-        Call convert_date_into_MAXIS_footer_month(app_date, MAXIS_footer_month, MAXIS_footer_year)
+			Call convert_date_into_MAXIS_footer_month(app_date, MAXIS_footer_month, MAXIS_footer_year)
 
-		Call navigate_to_MAXIS_screen("ELIG", "SUMM")
-		EMReadScreen numb_DWP_versions, 		1, 7, 40
-		EMReadScreen numb_MFIP_versions, 		1, 8, 40
-		EMReadScreen numb_MSA_versions, 		1, 11, 40
-		EMReadScreen numb_GA_versions, 			1, 12, 40
-		EMReadScreen numb_CASH_denial_versions, 1, 13, 40
-		EMReadScreen numb_GRH_versions, 		1, 14, 40
-		EMReadScreen numb_EMER_versions, 		1, 16, 40
-		EMReadScreen numb_SNAP_versions, 		1, 17, 40
+			Call navigate_to_MAXIS_screen("ELIG", "SUMM")
+			EMReadScreen numb_DWP_versions, 		1, 7, 40
+			EMReadScreen numb_MFIP_versions, 		1, 8, 40
+			EMReadScreen numb_MSA_versions, 		1, 11, 40
+			EMReadScreen numb_GA_versions, 			1, 12, 40
+			EMReadScreen numb_CASH_denial_versions, 1, 13, 40
+			EMReadScreen numb_GRH_versions, 		1, 14, 40
+			EMReadScreen numb_EMER_versions, 		1, 16, 40
+			EMReadScreen numb_SNAP_versions, 		1, 17, 40
 
-		If numb_SNAP_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "FS  ")
-			EMReadScreen on_elig_fs, 4, 3, 48
-			If on_elig_fs = "FSPR" Then
-				Call find_last_approved_ELIG_version(19, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, SNAP_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, SNAP_Elig_COL).Value = elig_version_result
+			If numb_SNAP_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "FS  ")
+				EMReadScreen on_elig_fs, 4, 3, 48
+				If on_elig_fs = "FSPR" Then
+					Call find_last_approved_ELIG_version(19, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, SNAP_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, SNAP_Elig_COL).Value = elig_version_result
 
-						If elig_version_result = "ELIGIBLE" Then
-							snap_expedited = False
-							transmit 		'FSCR
-							EMReadScreen case_expedited_indicator, 9, 4, 3
-							If case_expedited_indicator = "EXPEDITED" Then snap_expedited = True
-							If snap_expedited = True Then ObjExcel.Cells(excel_row, SNAP_Expedited_COL).Value = "TRUE"
-							If snap_expedited = False Then ObjExcel.Cells(excel_row, SNAP_Expedited_COL).Value = "FALSE"
+							If elig_version_result = "ELIGIBLE" Then
+								snap_expedited = False
+								transmit 		'FSCR
+								EMReadScreen case_expedited_indicator, 9, 4, 3
+								If case_expedited_indicator = "EXPEDITED" Then snap_expedited = True
+								If snap_expedited = True Then ObjExcel.Cells(excel_row, SNAP_Expedited_COL).Value = "TRUE"
+								If snap_expedited = False Then ObjExcel.Cells(excel_row, SNAP_Expedited_COL).Value = "FALSE"
+							End If
+
 						End If
-
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_EMER_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "EMER")
-			Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-			If approved_version_found = True Then
-				If DATEDiff("d", app_date, elig_version_date) > 0 Then
-					EMReadScreen the_type, 3, 4, 45
-					ObjExcel.Cells(excel_row, EMER_Type_COL).Value = trim(the_type)
-					ObjExcel.Cells(excel_row, EMER_APP_COL).Value = elig_version_date
-					ObjExcel.Cells(excel_row, EMER_Elig_COL).Value = elig_version_result
-				End If
-			End If
-			PF3
-		End If
-
-		If numb_GRH_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "GRH ")
-			EMReadScreen on_elig_grh, 4, 3, 47
-			If on_elig_grh = "GRPR" Then
+			If numb_EMER_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "EMER")
 				Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
 				If approved_version_found = True Then
 					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, GRH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, GRH_Elig_COL).Value = elig_version_result
+						EMReadScreen the_type, 3, 4, 45
+						ObjExcel.Cells(excel_row, EMER_Type_COL).Value = trim(the_type)
+						ObjExcel.Cells(excel_row, EMER_APP_COL).Value = elig_version_date
+						ObjExcel.Cells(excel_row, EMER_Elig_COL).Value = elig_version_result
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_CASH_denial_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "DENY")
-			EMReadScreen on_elig_deny, 4, 3, 48
-			If on_elig_deny = "CAPR" Then
-				Call find_last_approved_ELIG_version(19, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "None"
-						ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+			If numb_GRH_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "GRH ")
+				EMReadScreen on_elig_grh, 4, 3, 47
+				If on_elig_grh = "GRPR" Then
+					Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, GRH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, GRH_Elig_COL).Value = elig_version_result
+						End If
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_DWP_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "DWP ")
-			EMReadScreen on_elig_dwp, 4, 3, 47
-			If on_elig_dwp = "DWPR" Then
-				Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "DWP"
-						ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+			If numb_CASH_denial_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "DENY")
+				EMReadScreen on_elig_deny, 4, 3, 48
+				If on_elig_deny = "CAPR" Then
+					Call find_last_approved_ELIG_version(19, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "None"
+							ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+						End If
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_MSA_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "MSA ")
-			EMReadScreen on_elig_msa, 4, 3, 47
-			If on_elig_msa = "MSPR" Then
-				Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "MSA"
-						ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+			If numb_DWP_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "DWP ")
+				EMReadScreen on_elig_dwp, 4, 3, 47
+				If on_elig_dwp = "DWPR" Then
+					Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "DWP"
+							ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+						End If
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_GA_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "GA  ")
-			EMReadScreen on_elig_ga, 4, 3, 48
-			If on_elig_ga = "GAPR" Then
-				Call find_last_approved_ELIG_version(20, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "GA"
-						ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+			If numb_MSA_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "MSA ")
+				EMReadScreen on_elig_msa, 4, 3, 47
+				If on_elig_msa = "MSPR" Then
+					Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "MSA"
+							ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+						End If
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
-		If numb_MFIP_versions <> " " Then
-			call navigate_to_MAXIS_screen("ELIG", "MFIP")
-			EMReadScreen on_elig_mfip, 4, 3, 47
-			If on_elig_mfip = "MFPR" Then
-				Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
-				If approved_version_found = True Then
-					If DATEDiff("d", app_date, elig_version_date) > 0 Then
-						ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "MFIP"
-						ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
-						ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+			If numb_GA_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "GA  ")
+				EMReadScreen on_elig_ga, 4, 3, 48
+				If on_elig_ga = "GAPR" Then
+					Call find_last_approved_ELIG_version(20, 78, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "GA"
+							ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+						End If
 					End If
 				End If
+				PF3
 			End If
-			PF3
-		End If
 
+			If numb_MFIP_versions <> " " Then
+				call navigate_to_MAXIS_screen("ELIG", "MFIP")
+				EMReadScreen on_elig_mfip, 4, 3, 47
+				If on_elig_mfip = "MFPR" Then
+					Call find_last_approved_ELIG_version(20, 79, elig_version_number, elig_version_date, elig_version_result, approved_version_found)
+					If approved_version_found = True Then
+						If DATEDiff("d", app_date, elig_version_date) > 0 Then
+							ObjExcel.Cells(excel_row, CASH_Type_COL).Value = "MFIP"
+							ObjExcel.Cells(excel_row, CASH_APP_COL).Value = elig_version_date
+							ObjExcel.Cells(excel_row, CASH_Elig_COL).Value = elig_version_result
+						End If
+					End If
+				End If
+				PF3
+			End If
+		End If
 	End If
 	Call back_to_SELF
 	excel_row = excel_row + 1

--- a/admin/interview-team-cases-worklist.vbs
+++ b/admin/interview-team-cases-worklist.vbs
@@ -945,7 +945,7 @@ If developer_mode = False Then
 
 	unlock_end = excel_row + fam_cases_assigned_count
 	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Unprotect
-	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A1:E" & unlock_end).Locked = False
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A3:E" & unlock_end).Locked = False
 
 	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
 		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Families" Then
@@ -973,7 +973,7 @@ If developer_mode = False Then
 
 	unlock_end = excel_row + adul_cases_assigned_count
 	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Unprotect
-	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A1:E" & unlock_end).Locked = False
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A3:E" & unlock_end).Locked = False
 
 	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
 		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Adults" Then

--- a/admin/interview-team-cases-worklist.vbs
+++ b/admin/interview-team-cases-worklist.vbs
@@ -51,20 +51,303 @@ call changelog_update("01/13/2025", "Initial version.", "Casey Love, Hennepin Co
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
 
+'DECLARATIONS ==============================================================================================================
+
+set basket_detail = CreateObject("Scripting.Dictionary")
+
+'Team 1 Clifton			'Team 2 Coenen			'Team 3 Garrett			'Team 4 Groves
+basket_detail.add "X127EQ9", "Adults"			'OLD BASKET STRUCTURE???
+basket_detail.add "X127EK8", "Adults" ' - Pending 1"
+basket_detail.add "X127EH1", "Adults" ' - Pending 1"
+basket_detail.add "X127EP1", "Adults" ' - Pending 1"
+basket_detail.add "X127EP2", "Adults" ' - Pending 2"
+basket_detail.add "X127EH8", "Adults" ' - Pending 2"
+basket_detail.add "X127EP6", "Adults" ' - Pending 2"
+basket_detail.add "X127EP7", "Adults" ' - Pending 3"
+basket_detail.add "X127EP8", "Adults" ' - Pending 3"
+basket_detail.add "X127EP3", "Adults" ' - Pending 3"
+basket_detail.add "X127EH7", "Adults" ' - Pending 4"
+basket_detail.add "X127EK3", "Adults" ' - Pending 4"
+basket_detail.add "X127EK7", "Adults" ' - Pending 4"
+basket_detail.add "X127EQ5", "Adults" ' Active 1"
+basket_detail.add "X127EQ6", "Adults" ' Active 1"
+basket_detail.add "X127EQ7", "Adults" ' Active 1"
+basket_detail.add "X127EQ8", "Adults" ' Active 1"
+basket_detail.add "X127EX1", "Adults" ' Active 1"
+basket_detail.add "X127EX2", "Adults" ' Active 1"
+basket_detail.add "X127EX3", "Adults" ' Active 1"
+basket_detail.add "X127EX4", "Adults" ' Active 1"
+basket_detail.add "X127EX5", "Adults" ' Active 1"
+basket_detail.add "X127EX7", "Adults" ' Active 1"
+' basket_detail.add "X127F3H", "Adults" ' Active 1"		'DELETE?
+basket_detail.add "X127EL7", "Adults" ' Active 2"
+basket_detail.add "X127EL8", "Adults" ' Active 2"
+basket_detail.add "X127EL9", "Adults" ' Active 2"
+basket_detail.add "X127EN1", "Adults" ' Active 2"
+basket_detail.add "X127EN2", "Adults" ' Active 2"
+basket_detail.add "X127EN3", "Adults" ' Active 2"
+basket_detail.add "X127EN5", "Adults" ' Active 2"
+basket_detail.add "X127EN4", "Adults" ' Active 2"
+basket_detail.add "X127EN7", "Adults" ' Active 2"
+basket_detail.add "X127EN8", "Adults" ' Active 3"
+basket_detail.add "X127EN9", "Adults" ' Active 3"
+basket_detail.add "X127EQ1", "Adults" ' Active 3"
+basket_detail.add "X127EQ2", "Adults" ' Active 3"
+basket_detail.add "X127EQ3", "Adults" ' Active 3"
+basket_detail.add "X127EQ4", "Adults" ' Active 3"
+basket_detail.add "X127EX8", "Adults" ' Active 3"
+basket_detail.add "X127EX9", "Adults" ' Active 3"
+basket_detail.add "X127EG4", "Adults" ' Active 3"
+basket_detail.add "X127ED8", "Adults" ' Active 4"
+basket_detail.add "X127EE1", "Adults" ' Active 4"
+basket_detail.add "X127EE2", "Adults" ' Active 4"
+basket_detail.add "X127EE3", "Adults" ' Active 4"
+basket_detail.add "X127EE4", "Adults" ' Active 4"
+basket_detail.add "X127EE5", "Adults" ' Active 4"
+basket_detail.add "X127EE6", "Adults" ' Active 4"
+basket_detail.add "X127EE7", "Adults" ' Active 4"
+basket_detail.add "X127EL1", "Adults" ' Active 4"
+basket_detail.add "X127EL2", "Adults" ' Active 4"
+basket_detail.add "X127EL3", "Adults" ' Active 4"
+basket_detail.add "X127EL4", "Adults" ' Active 4"
+basket_detail.add "X127EL5", "Adults" ' Active 4"
+basket_detail.add "X127EL6", "Adults" ' Active 4"
+
+basket_detail.add "X127ET5", "Families" 		'Active 1"
+basket_detail.add "X127ET6", "Families" 		'Active 1"
+basket_detail.add "X127ET7", "Families" 		'Active 1"
+basket_detail.add "X127ET8", "Families" 		'Active 1"
+basket_detail.add "X127ET9", "Families" 		'Active 1"
+basket_detail.add "X127EZ1", "Families" 		'Active 1"
+basket_detail.add "X127ES1", "Families" 		'Active 2"
+basket_detail.add "X127ES2", "Families" 		'Active 2"
+basket_detail.add "X127ET1", "Families" 		'Active 2"
+' basket_detail.add "X127F4E", "Families" 		'Active 2"		'DELETE?
+basket_detail.add "X127EZ7", "Families" 		'Active 2"
+basket_detail.add "X127FB7", "Families" 		'Active 2"
+basket_detail.add "X127ET2", "Families" 		'Active 3"
+basket_detail.add "X127ET3", "Families" 		'Active 3"
+basket_detail.add "X127ET4", "Families" 		'Active 3"
+basket_detail.add "X127ES3", "Families" 		'Active 4"
+basket_detail.add "X127ES4", "Families" 		'Active 4"
+basket_detail.add "X127ES5", "Families" 		'Active 4"
+basket_detail.add "X127ES6", "Families" 		'Active 4"
+basket_detail.add "X127ES7", "Families" 		'Active 4"
+basket_detail.add "X127ES8", "Families" 		'Active 4"
+basket_detail.add "X127ES9", "Families" 		'Active 4"
+basket_detail.add "X127EZ6", "Families" 		'- Pending 1"
+basket_detail.add "X127EZ8", "Families" 		'- Pending 1"
+basket_detail.add "X127EZ9", "Families" 		'- Pending 2"
+basket_detail.add "X127EH4", "Families" 		'- Pending 2"
+basket_detail.add "X127EH5", "Families" 		'- Pending 3"
+basket_detail.add "X127EH6", "Families" 		'- Pending 3"
+basket_detail.add "X127EZ3", "Families" 		'- Pending 4"
+basket_detail.add "X127EZ4", "Families" 		'- Pending 4"
+
+basket_detail.add "X127F3P", "Adults"   'MA-EPD Adults Basket
+basket_detail.add "X127F3K", "Families"  'MA-EPD FAD Basket
+' basket_detail.add "X127F3P", "Families - General"		- this is MAEPD
+
+basket_detail.add "X127FE7", "DWP"
+basket_detail.add "X127FE8", "DWP"
+basket_detail.add "X127FE9", "DWP"
+basket_detail.add "X127EY8", "DWP"
+basket_detail.add "X127EY9", "DWP"
+
+basket_detail.add "X127FA5", "YET"
+basket_detail.add "X127FA6", "YET"
+basket_detail.add "X127FA7", "YET"
+basket_detail.add "X127FA8", "YET"
+basket_detail.add "X127FB1", "YET"
+basket_detail.add "X127FA9", "YET"
+
+basket_detail.add "X127EN6", "TEFRA"
+basket_detail.add "X127FG1", "Foster Care / IV-E"
+basket_detail.add "X127EW6", "Foster Care / IV-E"
+basket_detail.add "X1274EC", "Foster Care / IV-E"
+basket_detail.add "X127FG2", "Foster Care / IV-E"
+basket_detail.add "X127EW4", "Foster Care / IV-E"
+
+basket_detail.add "X127EM8", "GRH / HS - Adults Pending"
+basket_detail.add "X127FE6", "GRH / HS - Adults Pending"
+basket_detail.add "X127EZ2", "GRH / HS - Families Pending"
+basket_detail.add "X127EM2", "GRH / HS - Maintenance"
+basket_detail.add "X127EH9", "GRH / HS - Maintenance"
+basket_detail.add "X127EJ4", "GRH / HS - Maintenance"
+basket_detail.add "X127EH2", "GRH / HS - Maintenance"
+basket_detail.add "X127EP4", "GRH / HS - Maintenance"
+basket_detail.add "X127EK5", "GRH / HS - Maintenance"
+basket_detail.add "X127EG5", "GRH / HS - Maintenance"
+
+'basket_detail.add "X127EG4", "MIPPA"
+basket_detail.add "X127F3D", "MA - BC"
+
+basket_detail.add "X127EF8", "1800"
+basket_detail.add "X127EF9", "1800"
+basket_detail.add "X127EG9", "1800"
+basket_detail.add "X127EG0", "1800"
+
+basket_detail.add "X1275H5", "Privileged Cases"
+basket_detail.add "X127FAT", "Privileged Cases"
+basket_detail.add "X127F3H", "Privileged Cases"
+'Contacted Case Mgt
+basket_detail.add "X127FG6", "LTC+"           '"Kristen Kasem"
+basket_detail.add "X127FG7", "LTC+"           '"Kristen Kasem"
+basket_detail.add "X127EM3", "LTC+"           '"True L. or Gina G."
+basket_detail.add "X127EM4", "LTC+"            '"True L. or Gina G."
+basket_detail.add "X127EW7", "LTC+"            '"Kimberly Hill"
+basket_detail.add "X127EW8", "LTC+"            '"Kimberly Hill"
+basket_detail.add "X127FF4", "LTC+"            '"Alyssa Taylor"
+basket_detail.add "X127FF5", "LTC+"            '"Alyssa Taylor"
+basket_detail.add "X127FF8", "LTC+"				'"Contracted - North Memorial"
+basket_detail.add "X127FF6", "LTC+"				'"Contracted - HCMC"
+basket_detail.add "X127FF7", "LTC+"				'"Contracted - HCMC"
+
+' basket_detail.add "X127EK4", "LTC+ - General"
+' basket_detail.add "X127EK9", "LTC+ - General"
+' basket_detail.add "X127EH1", "LTC+"
+basket_detail.add "X127EH3", "LTC+"
+' basket_detail.add "X127EH4", "LTC+"
+' basket_detail.add "X127EH5", "LTC+"
+' basket_detail.add "X127EH6", "LTC+"
+' basket_detail.add "X127EH7", "LTC+"
+basket_detail.add "X127EJ8", "LTC+"
+basket_detail.add "X127EK1", "LTC+"
+basket_detail.add "X127EK2", "LTC+"
+' basket_detail.add "X127EK3", "LTC+"
+basket_detail.add "X127EK4", "LTC+"
+basket_detail.add "X127EK6", "LTC+"
+' basket_detail.add "X127EK7", "LTC+"
+' basket_detail.add "X127EK8", "LTC+"
+basket_detail.add "X127EK9", "LTC+"
+basket_detail.add "X127EM9", "LTC+"
+' basket_detail.add "X127EN6", "LTC+"
+basket_detail.add "X127EP5", "LTC+"
+basket_detail.add "X127EP9", "LTC+"
+basket_detail.add "X127EZ5", "LTC+"
+basket_detail.add "X127F3F", "LTC+"
+basket_detail.add "X127FE5", "LTC+"
+basket_detail.add "X127FH4", "LTC+"
+basket_detail.add "X127FH5", "LTC+"
+basket_detail.add "X127FI2", "LTC+"
+basket_detail.add "X127FI7", "LTC+"
+
+basket_detail.add "X127FI1", "METS Retro Request"
+
+
+curr_month = MonthName(DatePart("M",date))
+curr_day = DatePart("d",date)
+curr_year = DatePart("yyyy", date)
+
+manager_log_file_path 				= "https://hennepin.sharepoint.com/teams/InterviewPhoneHSRs-Supervisors/Shared%20Documents/Management%20Team-HSR%20Interviews/Manager%20Log%20" & curr_year & "%20" & curr_month & ".xlsx"
+staff_assignment_log_file_path 		= "https://hennepin.sharepoint.com/teams/InterviewPhoneHSRs-EligibilityHSRs/Shared%20Documents/Eligibility%20HSRs/Eligibility%20Staff%20" & curr_year & "%20" & curr_month & ".xlsx"
+
+template_manager_log_file_path 			= t_drive & "\Eligibility Support\Assignments\Interview Team Cases Worklists\Support Documents\Template Manager Log.xlsx"
+template_staff_assignment_log_file_path = t_drive & "\Eligibility Support\Assignments\Interview Team Cases Worklists\Support Documents\Eligibility Staff Template.xlsx"
+
+end_message = ""
+'END DECLARATIONS ==========================================================================================================
+
+
+'THE SCRIPT ===========================================================================================================
+
+'Now we are ready to start the script
+
 'Dialog is just to alert user that the script starts with information gathering and takes time.
 Dialog1 = ""
-BeginDialog Dialog1, 0, 0, 191, 105, "Interview Team Cases Worklist"
+BeginDialog Dialog1, 0, 0, 186, 115, "Interview Team Cases Worklist"
   ButtonGroup ButtonPressed
-    OkButton 125, 80, 50, 15
-  Text 10, 10, 175, 20, "This script will create a list of cases with interviews completed by the Interview Team."
-  Text 10, 35, 165, 20, "First the script needs to gather some information, which may take a minute or two. "
-  Text 10, 65, 145, 10, "Please be patient, the script is running!"
-  Text 10, 80, 105, 10, "Press OK to start info gather."
+    OkButton 125, 90, 50, 15
+  Text 10, 10, 175, 25, "This script will create a list of cases with interviews completed by the Interview Team. It will also update the files used by the processing team to assign work. "
+  Text 10, 45, 165, 20, "First the script needs to gather some information, which may take a minute or two. "
+  Text 10, 75, 145, 10, "Please be patient, the script is running!"
+  Text 10, 90, 105, 10, "Press OK to start info gather."
 EndDialog
 
 'no options on the dialog so no loop is necessary
 dialog Dialog1
 cancel_confirmation
+
+'FILE MANAGEMENT ===========================================================================================================
+'This section ensures the files needed for the run are up available and up to date.
+
+'Sharepoint files do not have the same 'FileExists' possibility so we need to try to open them and see if there is an error to determine if a new file is needed.
+If curr_day < 7 Then
+	On Error Resume Next			'allow for errors to occur and then use them to identify missing files.
+
+	'not using the function because we need to disable the alerts BEFORE trying to open the workbook
+	Set objExcel = CreateObject("Excel.Application") 'Allows a user to perform functions within Microsoft Excel
+	objExcel.Visible = False
+	objExcel.DisplayAlerts = False
+	Set objWorkbook = objExcel.Workbooks.Open(staff_assignment_log_file_path) 'Opens an excel file from a specific URL
+	' MsgBox "Error Number: " & Err.Number
+	If Err.Number <> 0 Then
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+
+		Call excel_open(template_staff_assignment_log_file_path, False, False, ObjExcel, objWorkbook)
+		ObjExcel.ActiveWorkbook.SaveAs staff_assignment_log_file_path
+		ObjExcel.ActiveWorkbook.Close
+		ObjExcel.Application.Quit
+		ObjExcel.Quit
+
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+		end_message = end_message & "New Eligibility Staff Excel created for " & curr_month & ". The file has been saved to the TEAMS location." & vbCr
+	End If
+	If Err.Number = 0 Then
+		objExcel.ActiveWorkbook.Close
+		objExcel.Application.Quit
+		objExcel.Quit
+
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+	End If
+
+	Err.Clear
+
+	Set objExcel = CreateObject("Excel.Application") 'Allows a user to perform functions within Microsoft Excel
+	objExcel.Visible = False
+	objExcel.DisplayAlerts = False
+	Set objWorkbook = objExcel.Workbooks.Open(manager_log_file_path) 'Opens an excel file from a specific URL
+	' MsgBox "Error Number: " & Err.Number
+	If Err.Number <> 0 Then
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+
+		first_of_the_month = DatePart("M",date) & "/1/" & curr_year
+		first_of_the_month = DateAdd("d", 0, first_of_the_month)
+
+		Call excel_open(template_manager_log_file_path, False, False, ObjExcel, objWorkbook)
+		ObjExcel.worksheets("Counts").Activate
+		ObjExcel.Cells(2,3).Value = first_of_the_month	'set up the counts sheet for the current month
+		ObjExcel.worksheets("Manager log").Activate
+
+		ObjExcel.ActiveWorkbook.SaveAs manager_log_file_path
+		ObjExcel.ActiveWorkbook.Close
+		ObjExcel.Application.Quit
+		ObjExcel.Quit
+
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+		end_message = end_message & "New Manager Log Excel created for " & curr_month & ". The file has been saved to the TEAMS location." & vbCr
+	End If
+	'Call script_end_procedure("The Staff assignment log for " & curr_month & " " & curr_year & " is not available. Create the Excel first and Rerun the script")
+
+	If Err.Number = 0 Then
+		objExcel.ActiveWorkbook.Close
+		objExcel.Application.Quit
+		objExcel.Quit
+
+		Set ObjExcel = Nothing
+		Set objWorkbook = Nothing
+	End If
+
+	Err.Clear
+
+	On Error Goto 0
+End If
+
 
 'Setting the folder paths and objects to handle folder and file manipulation
 interview_team_cases_folder = t_drive & "\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage"
@@ -80,7 +363,10 @@ Const month_const 	= 02
 Const day_const		= 03
 Const count_const	= 04
 Const checkbox_const = 05
-Const dates_last_const	= 10
+const added_count	= 06
+const fam_count 	= 07
+const adul_count	= 08
+Const dates_last_const	= 20
 
 'This array gathers all the dates but is not sorted
 Dim TEMP_ARRAY()
@@ -198,16 +484,41 @@ Do
 	If err_msg <> "" Then MsgBox "* * * NOTICE * * * " & vbCr & vbCr & "Please resolve to continue:" & vbCr & err_msg
 Loop until err_msg = ""
 
+developer_mode = False
+If user_ID_for_validation = "CALO001" Then developer_mode = True
+
+const x_numb_const		= 00
+const case_numb_const	= 01
+const population_const	= 02
+const intvw_date_const	= 03
+const appears_xfs_const	= 04
+const cash_select_const	= 05
+const cash_prog_const	= 06
+const grh_select_const	= 07
+const snap_select_const	= 08
+const emer_select_const	= 09
+const assign_pop_const	= 10
+const assigned_to_const	= 11
+const mngr_excel_row	= 12
+const end_const			= 20
+
+DIM CASES_TO_ASSIGN_ARRAY()
+ReDIM CASES_TO_ASSIGN_ARRAY(end_const, 0)
+intvws_count = 0
+
 'Here is the worklist creation section
 'these constants are to document the columns  - using a constant supports future changes
-Const case_numb_col 	= 1
-Const intvw_date_col 	= 2
-Const exp_det_col 		= 3
-Const cash_col 			= 4
-Const cash_type_col		= 5
-Const grh_col 			= 6
-Const snap_col 			= 7
-Const emer_col 			= 8
+Const basket_col		= 1
+Const case_numb_col 	= 2
+Const population_col 	= 3
+Const intvw_date_col 	= 4
+Const exp_det_col 		= 5
+Const assignment_col	= 6
+Const cash_col 			= 7
+Const cash_type_col		= 8
+Const grh_col 			= 9
+Const snap_col 			= 10
+Const emer_col 			= 11
 
 'Creating the Excel file
 Set objExcel = CreateObject("Excel.Application")
@@ -216,22 +527,31 @@ Set objWorkbook = objExcel.Workbooks.Add()
 objExcel.DisplayAlerts = True
 
 'Setting the first row with header information
+ObjExcel.Cells(1, basket_col).Value = "CASELOAD"
 ObjExcel.Cells(1, case_numb_col).Value = "CASE NUMBER"
+ObjExcel.Cells(1, population_col).Value = "POPULATION"
 ObjExcel.Cells(1, intvw_date_col).Value = "INTERVIEW COMPLETED"
 ObjExcel.Cells(1, exp_det_col).Value = "APPEARS EXPEDITED"
+ObjExcel.Cells(1, assignment_col).Value = "ASSIGNED TO"
+
 ObjExcel.Cells(1, cash_col).Value = "CASH"
 ObjExcel.Cells(1, cash_type_col).Value = "CASH TYPE"
 ObjExcel.Cells(1, grh_col).Value = "GRH"
 ObjExcel.Cells(1, snap_col).Value = "SNAP"
 ObjExcel.Cells(1, emer_col).Value = "EMER"
-FOR i = 1 to emer_col							'formatting the cells'
-	objExcel.Cells(1, i).Font.Bold = True		'bold font'
+FOR cow = 1 to emer_col							'formatting the cells'
+	objExcel.Cells(1, cow).Font.Bold = True		'bold font'
 NEXT
 excel_row = 2
+case_count = 0
 
 'creating some objects needed for XML handling
 Set xmlDoc = CreateObject("Microsoft.XMLDOM")
 Set xml = CreateObject("Msxml2.DOMDocument")
+
+xml_case_numbs = "*"
+'Creating an object for the stream of text which we'll use frequently
+Dim objTextStream
 
 'Looking at each xml in the folder for the Interview Team completion
 For Each objFile in colFiles								'looping through each file
@@ -251,87 +571,263 @@ For Each objFile in colFiles								'looping through each file
 		STATS_counter = STATS_counter + 1
 		xmlPath = objFile.Path												'identifying the current file
 		With (CreateObject("Scripting.FileSystemObject"))
-			'Creating an object for the stream of text which we'll use frequently
-			Dim objTextStream
+			Set file_object = CreateObject("Scripting.FileSystemObject")										'Create another FSO
+			Set xml_sig_command = file_object.OpenTextFile(xmlPath)			'Open the text file
+
+			name_of_xml = file_object.GetFileName(xmlPath)
+			If InStr(name_of_xml, "details") Then
+				If xml_sig_command.AtEndOfStream Then
+					attachment_here = ""
+					Call create_outlook_email("", "hsph.ews.bluezonescripts@hennepin.us", "", "", "XML in Interview Team Tracking is BLANK", 1, False, "", "", False, "", "XML File Path: " & xmlPath, True, attachment_here, True)
+					xml_sig_command.Close
+				ElseIf .FileExists(xmlPath) = True then
+					xml_sig_command.Close
+					xmlDoc.Async = False
+
+					' Load the XML file
+					xmlDoc.load(xmlPath)
+
+					'reads data about the case from the XML
+					set node = xmlDoc.SelectSingleNode("//CaseBasket")
+					case_basket_numb = node.text
+
+					set node = xmlDoc.SelectSingleNode("//CaseNumber")
+					MAXIS_case_number = node.text
+					xml_case_numbs = xml_case_numbs & trim(MAXIS_case_number) & "*"
+
+					set node = xmlDoc.SelectSingleNode("//InterviewDate")
+					interview_date = node.text
+					interview_date = DateAdd("d", 0, interview_date)
+
+					set node = xmlDoc.SelectSingleNode("//ScriptRunDate")
+					script_date = node.text
+					script_date = DateAdd("d", 0, script_date)
+
+					set node = xmlDoc.SelectSingleNode("//CASHRequest")
+					req_cash = node.text
+					req_cash = req_cash * 1
+
+					cash_type = ""
+					If req_cash = True Then
+						set node = xmlDoc.SelectSingleNode("//TypeOfCASH")
+						cash_type = node.text
+					End If
+
+					If DateDiff("d", #1/13/2025#, script_date) > 0 Then
+						set node = xmlDoc.SelectSingleNode("//GRHRequest")
+						req_grh = node.text
+						req_grh = req_grh * 1
+					End If
+
+					set node = xmlDoc.SelectSingleNode("//SNAPRequest")
+					req_snap = node.text
+					req_snap = req_snap * 1
+
+					set node = xmlDoc.SelectSingleNode("//EMERRequest")
+					req_emer = node.text
+					req_emer = req_emer * 1
+
+					set node = xmlDoc.SelectSingleNode("//ExpeditedDetermination")
+					exp_det = node.text
+					If exp_det <> "" Then exp_det = exp_det * 1
+
+					case_basket_numb = UCase(case_basket_numb)
+					population = ""
+					If basket_detail.Exists(case_basket_numb) Then
+						population = basket_detail.Item(case_basket_numb)
+					Else
+						population = "UNKNOWN"
+					End If
+
+					population_section = ""
+					If population = "Adults" 					Then population_section = "Adults"
+					If population = "GRH / HS - Adults Pending" Then population_section = "Adults"
+					If population = "GRH / HS - Maintenance" 	Then population_section = "Adults"
+					If population = "MA - BC" 					Then population_section = "Adults"
+					If population = "1800" 						Then population_section = "Adults"
+					If population = "LTC+" 						Then population_section = "Adults"
+
+					If population = "Families" 					Then population_section = "Families"
+					If population = "DWP" 						Then population_section = "Families"
+					If population = "YET" 						Then population_section = "Families"
+					If population = "TEFRA" 					Then population_section = "Families"
+					If population = "Foster Care / IV-E" 		Then population_section = "Families"
+					If population = "GRH / HS - Families Pending" Then population_section = "Families"
+
+					If population = "METS Retro Request" 		Then population_section = "Families"
+					If population = "Privileged Cases" 			Then population_section = "Families"
+					If population = "UNKNOWN" 					Then population_section = "Adults"
+
+					ReDim preserve CASES_TO_ASSIGN_ARRAY(end_const, intvws_count)
+					CASES_TO_ASSIGN_ARRAY(x_numb_const, intvws_count) 		= case_basket_numb
+					CASES_TO_ASSIGN_ARRAY(case_numb_const, intvws_count) 	= MAXIS_case_number
+					CASES_TO_ASSIGN_ARRAY(population_const, intvws_count) 	= population
+					CASES_TO_ASSIGN_ARRAY(intvw_date_const, intvws_count) 	= interview_date
+					If exp_det = True Then CASES_TO_ASSIGN_ARRAY(appears_xfs_const, intvws_count) 	= True
+					If exp_det <> True Then CASES_TO_ASSIGN_ARRAY(appears_xfs_const, intvws_count) 	= False
+					CASES_TO_ASSIGN_ARRAY(cash_select_const, intvws_count) 	= req_cash
+					If req_cash = True Then CASES_TO_ASSIGN_ARRAY(cash_prog_const, intvws_count) 	= cash_type
+					CASES_TO_ASSIGN_ARRAY(grh_select_const, intvws_count) 	= req_grh
+					CASES_TO_ASSIGN_ARRAY(snap_select_const, intvws_count) 	= req_snap
+					CASES_TO_ASSIGN_ARRAY(emer_select_const, intvws_count) 	= req_emer
+					CASES_TO_ASSIGN_ARRAY(assign_pop_const, intvws_count) 	= population_section
+					CASES_TO_ASSIGN_ARRAY(assigned_to_const, intvws_count) 	= ""
+
+					'Add the file information to the Excel document for the worklist
+					ObjExcel.Cells(excel_row, basket_col).Value = case_basket_numb
+					ObjExcel.Cells(excel_row, case_numb_col).Value = MAXIS_case_number
+					ObjExcel.Cells(excel_row, population_col).Value = population
+					ObjExcel.Cells(excel_row, intvw_date_col).Value = interview_date
+					If exp_det = True Then ObjExcel.Cells(excel_row, exp_det_col).Value = "Yes"
+					If req_cash = True Then
+						ObjExcel.Cells(excel_row, cash_col).Value = "True"
+						ObjExcel.Cells(excel_row, cash_type_col).Value = cash_type
+					End If
+					If req_grh = True Then ObjExcel.Cells(excel_row, grh_col).Value = "True"
+					If req_snap = True Then ObjExcel.Cells(excel_row, snap_col).Value = "True"
+					If req_emer = True Then ObjExcel.Cells(excel_row, emer_col).Value = "True"
+
+					'THIS IS NOT WORKING BUT WILL RECORD THE DATE AND TIME THE CASE IS ADDED TO A WORKLIST IN THE XML
+					' Set root = xmlDoc.SelectSingleNode"interview"
+					' Set root = xmlDoc.documentElement
+					' Set root = xmlDoc.SelectSingleNode("//inteview")
+					' Set element = xmlDoc.createElement("AddedToWorklist")
+					' xmlDoc.DocumentElement.appendChild element
+					' Set info = xmlDoc.createTextNode(now)
+					' element.appendChild info
+
+					' xml.Save xmlPath
+					' MsgBox "PAUSE"
+
+					excel_row = excel_row + 1		'increment the excel row to add more
+					case_count = case_count + 1
+					intvws_count = intvws_count + 1
+
+					If developer_mode = False Then
+						'moving each file to the folder for cases already in a worklist
+						.MoveFile xmlPath , interview_team_cases_already_on_worklist & "\" & file_name & ".xml"
+					End If
+				End If
+			End If
+		End With
+	End If
+Next
+
+'Looking at each xml in the folder for the Interview Team completion
+For Each objFile in colFiles								'looping through each file
+	file_name = objFile.Name
+	file_created_date = objFile.DateCreated					'Reading the date created
+
+	'determining if the XML is for a file in the dates selected by the user
+	save_file = False
+	For chkn_wg = 0 to UBound(DATES_WITH_INTERVIEWS_ARRAY, 2)
+		If DateDiff("d", DATES_WITH_INTERVIEWS_ARRAY(date_const, chkn_wg), file_created_date) = 0 Then
+			If DATES_WITH_INTERVIEWS_ARRAY(checkbox_const, chkn_wg) = checked Then save_file = True
+		End If
+	Next
+
+	'if this is from a date selected, we need to read details of the file for the worklist
+	If save_file = True Then
+		STATS_counter = STATS_counter + 1
+		xmlPath = objFile.Path												'identifying the current file
+		With (CreateObject("Scripting.FileSystemObject"))
+			' 'Creating an object for the stream of text which we'll use frequently
+			' Dim objTextStream
 
 			Set file_object = CreateObject("Scripting.FileSystemObject")										'Create another FSO
 			Set xml_sig_command = file_object.OpenTextFile(xmlPath)			'Open the text file
 
-			If xml_sig_command.AtEndOfStream Then
-				attachment_here = ""
-				Call create_outlook_email("", "hsph.ews.bluezonescripts@hennepin.us", "", "", "XML in Interview Team Tracking is BLANK", 1, False, "", "", False, "", "XML File Path: " & xmlPath, True, attachment_here, True)
-				xml_sig_command.Close
-			ElseIf .FileExists(xmlPath) = True then
-				xml_sig_command.Close
-				xmlDoc.Async = False
+			name_of_xml = file_object.GetFileName(xmlPath)
+			If InStr(name_of_xml, "started") Then
+				If xml_sig_command.AtEndOfStream Then
+					attachment_here = ""
+					Call create_outlook_email("", "hsph.ews.bluezonescripts@hennepin.us", "", "", "XML in Interview Team Tracking is BLANK", 1, False, "", "", False, "", "XML File Path: " & xmlPath, True, attachment_here, True)
+					xml_sig_command.Close
+				ElseIf .FileExists(xmlPath) = True then
+					xml_sig_command.Close
+					xmlDoc.Async = False
 
-				' Load the XML file
-				xmlDoc.load(xmlPath)
+					' Load the XML file
+					xmlDoc.load(xmlPath)
 
-				'reads data about the case from the XML
-				set node = xmlDoc.SelectSingleNode("//CaseNumber")
-				MAXIS_case_number = node.text
+					'reads data about the case from the XML
+					set node = xmlDoc.SelectSingleNode("//CaseBasket")
+					case_basket_numb = node.text
 
-				set node = xmlDoc.SelectSingleNode("//ScriptRunDate")
-				script_date = node.text
-				script_date = DateAdd("d", 0, script_date)
+					set node = xmlDoc.SelectSingleNode("//CaseNumber")
+					MAXIS_case_number = node.text
+					search_numb = "*" & trim(MAXIS_case_number) & "*"
 
-				set node = xmlDoc.SelectSingleNode("//CASHRequest")
-				req_cash = node.text
-				req_cash = req_cash * 1
+					set node = xmlDoc.SelectSingleNode("//ScriptRunDate")
+					script_date = node.text
+					script_date = DateAdd("d", 0, script_date)
 
-				cash_type = ""
-				If req_cash = True Then
-					set node = xmlDoc.SelectSingleNode("//TypeOfCASH")
-					cash_type = node.text
+
+					case_basket_numb = UCase(case_basket_numb)
+					population = ""
+					If basket_detail.Exists(case_basket_numb) Then
+						population = basket_detail.Item(case_basket_numb)
+					Else
+						population = "UNKNOWN"
+					End If
+
+					population_section = ""
+					If population = "Adults" 					Then population_section = "Adults"
+					If population = "GRH / HS - Adults Pending" Then population_section = "Adults"
+					If population = "GRH / HS - Maintenance" 	Then population_section = "Adults"
+					If population = "MA - BC" 					Then population_section = "Adults"
+					If population = "1800" 						Then population_section = "Adults"
+					If population = "LTC+" 						Then population_section = "Adults"
+
+					If population = "Families" 					Then population_section = "Families"
+					If population = "DWP" 						Then population_section = "Families"
+					If population = "YET" 						Then population_section = "Families"
+					If population = "TEFRA" 					Then population_section = "Families"
+					If population = "Foster Care / IV-E" 		Then population_section = "Families"
+					If population = "GRH / HS - Families Pending" Then population_section = "Families"
+
+					If population = "METS Retro Request" 		Then population_section = "Families"
+					If population = "Privileged Cases" 			Then population_section = "Families"
+					If population = "UNKNOWN" 					Then population_section = "Adults"
+
+					If InStr(xml_case_numbs, search_numb) = 0 Then
+						ReDim preserve CASES_TO_ASSIGN_ARRAY(end_const, intvws_count)
+						CASES_TO_ASSIGN_ARRAY(x_numb_const, intvws_count) 		= case_basket_numb
+						CASES_TO_ASSIGN_ARRAY(case_numb_const, intvws_count) 	= MAXIS_case_number
+						CASES_TO_ASSIGN_ARRAY(population_const, intvws_count) 	= population
+						CASES_TO_ASSIGN_ARRAY(intvw_date_const, intvws_count) 	= script_date
+						CASES_TO_ASSIGN_ARRAY(appears_xfs_const, intvws_count)	= "?"
+						CASES_TO_ASSIGN_ARRAY(assign_pop_const, intvws_count) 	= population_section
+						CASES_TO_ASSIGN_ARRAY(assigned_to_const, intvws_count) 	= ""
+
+						'Add the file information to the Excel document for the worklist
+						ObjExcel.Cells(excel_row, basket_col).Value = case_basket_numb
+						ObjExcel.Cells(excel_row, case_numb_col).Value = MAXIS_case_number
+						ObjExcel.Cells(excel_row, population_col).Value = population
+						ObjExcel.Cells(excel_row, intvw_date_col).Value = script_date
+						ObjExcel.Cells(excel_row, exp_det_col).Value = "?"
+
+						'THIS IS NOT WORKING BUT WILL RECORD THE DATE AND TIME THE CASE IS ADDED TO A WORKLIST IN THE XML
+						' Set root = xmlDoc.SelectSingleNode"interview"
+						' Set root = xmlDoc.documentElement
+						' Set root = xmlDoc.SelectSingleNode("//inteview")
+						' Set element = xmlDoc.createElement("AddedToWorklist")
+						' xmlDoc.DocumentElement.appendChild element
+						' Set info = xmlDoc.createTextNode(now)
+						' element.appendChild info
+
+						' xml.Save xmlPath
+						' MsgBox "PAUSE"
+
+						excel_row = excel_row + 1		'increment the excel row to add more
+						case_count = case_count + 1
+						intvws_count = intvws_count + 1
+					End If
+					If developer_mode = False Then
+						'moving each file to the folder for cases already in a worklist
+						.MoveFile xmlPath , interview_team_cases_already_on_worklist & "\" & file_name & ".xml"
+					End If
 				End If
-
-				If DateDiff("d", #1/13/2025#, script_date) > 0 Then
-					set node = xmlDoc.SelectSingleNode("//GRHRequest")
-					req_grh = node.text
-					req_grh = req_grh * 1
-				End If
-
-				set node = xmlDoc.SelectSingleNode("//SNAPRequest")
-				req_snap = node.text
-				req_snap = req_snap * 1
-
-				set node = xmlDoc.SelectSingleNode("//EMERRequest")
-				req_emer = node.text
-				req_emer = req_emer * 1
-
-				set node = xmlDoc.SelectSingleNode("//ExpeditedDetermination")
-				exp_det = node.text
-				If exp_det <> "" Then exp_det = exp_det * 1
-
-				'Add the file information to the Excel document for the worklist
-				ObjExcel.Cells(excel_row, case_numb_col).Value = MAXIS_case_number
-				ObjExcel.Cells(excel_row, intvw_date_col).Value = script_date
-				If exp_det = True Then ObjExcel.Cells(excel_row, exp_det_col).Value = "Yes"
-				If req_cash = True Then
-					ObjExcel.Cells(excel_row, cash_col).Value = "True"
-					ObjExcel.Cells(excel_row, cash_type_col).Value = cash_type
-				End If
-				If req_grh = True Then ObjExcel.Cells(excel_row, grh_col).Value = "True"
-				If req_snap = True Then ObjExcel.Cells(excel_row, snap_col).Value = "True"
-				If req_emer = True Then ObjExcel.Cells(excel_row, emer_col).Value = "True"
-
-				'THIS IS NOT WORKING BUT WILL RECORD THE DATE AND TIME THE CASE IS ADDED TO A WORKLIST IN THE XML
-				' Set root = xmlDoc.SelectSingleNode"interview"
-				' Set root = xmlDoc.documentElement
-				' Set root = xmlDoc.SelectSingleNode("//inteview")
-				' Set element = xmlDoc.createElement("AddedToWorklist")
-				' xmlDoc.DocumentElement.appendChild element
-				' Set info = xmlDoc.createTextNode(now)
-				' element.appendChild info
-
-				' xml.Save xmlPath
-				' MsgBox "PAUSE"
-
-				excel_row = excel_row + 1		'increment the excel row to add more
-
-				'moving each file to the folder for cases already in a worklist
-				.MoveFile xmlPath , interview_team_cases_already_on_worklist & "\" & file_name & ".xml"
 			End If
 		End With
 	End If
@@ -343,33 +839,173 @@ For col_to_autofit = 1 to emer_col
 	ObjExcel.columns(col_to_autofit).AutoFit()
 Next
 
-'Saves and closes the Excel Worklist - Naming convention is 'Interview Team Cases Worklist from MM-DD_MM-DD_MM-DD.xlsx' with all interview dates listed
-' formatted_date = replace(date, "/", "-")
-list_of_dates = " "
-For chkn_wg = 0 to UBound(DATES_WITH_INTERVIEWS_ARRAY, 2)
-	If DATES_WITH_INTERVIEWS_ARRAY(checkbox_const, chkn_wg) = checked Then list_of_dates = list_of_dates & DATES_WITH_INTERVIEWS_ARRAY(month_const, chkn_wg) & "-" & DATES_WITH_INTERVIEWS_ARRAY(day_const, chkn_wg) & " "
-Next
-list_of_dates = replace(trim(list_of_dates), " ", "_")
+If developer_mode = False Then
+	'Saves and closes the Excel Worklist - Naming convention is 'Interview Team Cases Worklist from MM-DD_MM-DD_MM-DD.xlsx' with all interview dates listed
+	' formatted_date = replace(date, "/", "-")
+	list_of_dates = " "
+	For chkn_wg = 0 to UBound(DATES_WITH_INTERVIEWS_ARRAY, 2)
+		If DATES_WITH_INTERVIEWS_ARRAY(checkbox_const, chkn_wg) = checked Then list_of_dates = list_of_dates & DATES_WITH_INTERVIEWS_ARRAY(month_const, chkn_wg) & "-" & DATES_WITH_INTERVIEWS_ARRAY(day_const, chkn_wg) & " "
+	Next
+	list_of_dates = replace(trim(list_of_dates), " ", "_")
 
-Set FSOxl = CreateObject("Scripting.FileSystemObject")
-base_file_name = worklist_folder & "\Interview Team Cases Worklist from " & list_of_dates
-worklist_file_name = worklist_folder & "\Interview Team Cases Worklist from " & list_of_dates
-full_worklist_file_name = worklist_file_name & ".xlsx"
-file_numb_count = 1
-Do
-	file_is_already_here = False
-	file_is_already_here = FSOxl.FileExists(full_worklist_file_name)
-	If file_is_already_here Then
-		worklist_file_name = base_file_name & "_" & file_numb_count
-		full_worklist_file_name = worklist_file_name & ".xlsx"
-		file_numb_count = file_numb_count + 1
-	End If
-Loop until file_is_already_here = False
+	Set FSOxl = CreateObject("Scripting.FileSystemObject")
+	base_file_name = worklist_folder & "\Interview Team Cases Worklist from " & list_of_dates
+	worklist_file_name = worklist_folder & "\Interview Team Cases Worklist from " & list_of_dates
+	full_worklist_file_name = worklist_file_name & ".xlsx"
+	file_numb_count = 1
+	Do
+		file_is_already_here = False
+		file_is_already_here = FSOxl.FileExists(full_worklist_file_name)
+		If file_is_already_here Then
+			worklist_file_name = base_file_name & "_" & file_numb_count
+			full_worklist_file_name = worklist_file_name & ".xlsx"
+			file_numb_count = file_numb_count + 1
+		End If
+	Loop until file_is_already_here = False
 
-objExcel.ActiveWorkbook.SaveAs full_worklist_file_name
+	objExcel.ActiveWorkbook.SaveAs full_worklist_file_name
+	objExcel.ActiveWorkbook.Close
+	objExcel.Application.Quit
+	objExcel.Quit
 
-end_msg = "Interviews from " & list_of_dates & " have been added to a worklist."
-end_msg = end_msg & vbCr & "Worklist Name: " & replace(full_worklist_file_name, worklist_folder & "\", "")
-end_msg = end_msg & vbCr & vbCr & "Worklist has been left open and can be found here:"
-end_msg = end_msg & vbCr & full_worklist_file_name
-Call script_end_procedure(end_msg)
+	end_message = end_message & vbCr & "Excel created to save the information of the interviews created today." & vbCr
+End If
+
+end_message = end_message & vbCr & "Interviews from " & list_of_dates & " have been added to a worklist."
+end_message = end_message & vbCr & "Cases found with an interview completed that needs processing: " & case_count
+If developer_mode = False Then
+	end_message = end_message & vbCr & vbCr & "Worklist has been left open and can be found here:"
+	end_message = end_message & vbCr & full_worklist_file_name
+Else
+	end_message = end_message & vbCr & "DEVELOPER MODE - FILE NOT SAVED"
+End If
+
+'TODO - expand these columns to copy completion data BACK to the manager log - need to identify more columns that have the worker enterd processing notes and dates
+mnger_logs_case_numb_col 	= 1
+mnger_logs_date_assign_col 	= 2
+mnger_logs_appears_xfs_col 	= 3
+mnger_log_area_col 			= 4
+mnger_log_processor_col		= 5
+
+assign_logs_case_numb_col 		= 1
+assign_logs_date_assign_col 	= 2
+assign_logs_appears_xfs_col 	= 3
+assign_log_area_col 			= 4
+assign_log_processor_col		= 5
+
+If developer_mode = False Then
+	Call excel_open(manager_log_file_path, True, False, ObjMngrExcel, objMngrWorkbook)
+	ObjMngrExcel.worksheets("Manager log").Activate
+	excel_row = 1
+	Do
+		excel_row = excel_row + 1
+		list_case_numb = trim(ObjMngrExcel.Cells(excel_row, mnger_logs_case_numb_col).Value)
+	Loop until list_case_numb = ""
+
+
+	total_cases_assigned_count = 0
+	fam_cases_assigned_count = 0
+	adul_cases_assigned_count = 0
+
+
+	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
+		ObjMngrExcel.Cells(excel_row, mnger_log_area_col).Value			= ""
+		ObjMngrExcel.Cells(excel_row, mnger_logs_case_numb_col).Value  	= CASES_TO_ASSIGN_ARRAY(case_numb_const, cow)
+		' ObjMngrExcel.Cells(excel_row, mnger_logs_date_assign_col).Value 	= date
+		ObjMngrExcel.Cells(excel_row, mnger_logs_date_assign_col).Value 	= CASES_TO_ASSIGN_ARRAY(intvw_date_const, cow)
+
+		If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = True Then ObjMngrExcel.Cells(excel_row, mnger_logs_appears_xfs_col).Value = "Yes"
+		If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = "?" Then ObjMngrExcel.Cells(excel_row, mnger_logs_appears_xfs_col).Value = "?"
+		ObjMngrExcel.Cells(excel_row, mnger_log_area_col).Value  		= CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow)
+		CASES_TO_ASSIGN_ARRAY(mngr_excel_row, cow) = excel_row
+
+		total_cases_assigned_count = total_cases_assigned_count + 1
+		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Families" Then fam_cases_assigned_count = fam_cases_assigned_count + 1
+		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Adults" Then adul_cases_assigned_count = adul_cases_assigned_count + 1
+
+		excel_row = excel_row + 1
+	Next
+
+	'We loop back through the Excel so that it has time to generate the processor name.
+	'When done in the initial loop, some of the names were missed.
+	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
+		CASES_TO_ASSIGN_ARRAY(assigned_to_const, cow) = trim(ObjMngrExcel.Cells(CASES_TO_ASSIGN_ARRAY(mngr_excel_row, cow), mnger_log_processor_col).Value)
+	Next
+
+
+	Call excel_open(staff_assignment_log_file_path, True, False, ObjStaffExcel, objStaffWorkbook)
+
+	ObjStaffExcel.worksheets("Families").Activate
+
+	excel_row = 1
+	Do
+		excel_row = excel_row + 1
+		list_case_numb = trim(ObjStaffExcel.Cells(excel_row, assign_logs_case_numb_col).Value)
+	Loop until list_case_numb = ""
+
+	unlock_end = excel_row + fam_cases_assigned_count
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Unprotect
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A1:E" & unlock_end).Locked = False
+
+	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
+		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Families" Then
+			ObjStaffExcel.Cells(excel_row, assign_logs_case_numb_col).Value 	= CASES_TO_ASSIGN_ARRAY(case_numb_const, cow)
+			ObjStaffExcel.Cells(excel_row, assign_logs_date_assign_col).Value 	= CASES_TO_ASSIGN_ARRAY(intvw_date_const, cow)
+			If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = True Then ObjStaffExcel.Cells(excel_row, assign_logs_appears_xfs_col).Value = "Yes"
+			If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = "?" Then ObjMngrExcel.Cells(excel_row, assign_logs_appears_xfs_col).Value = "?"
+			ObjStaffExcel.Cells(excel_row, assign_log_area_col).Value 		= CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow)
+			ObjStaffExcel.Cells(excel_row, assign_log_processor_col).Value	= CASES_TO_ASSIGN_ARRAY(assigned_to_const, cow)
+
+			excel_row = excel_row + 1
+		End If
+	Next
+
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A3:E" & unlock_end).Locked = True
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Protect
+
+	ObjStaffExcel.worksheets("Adults").Activate
+
+	excel_row = 1
+	Do
+		excel_row = excel_row + 1
+		list_case_numb = trim(ObjStaffExcel.Cells(excel_row, assign_logs_case_numb_col).Value)
+	Loop until list_case_numb = ""
+
+	unlock_end = excel_row + adul_cases_assigned_count
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Unprotect
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A1:E" & unlock_end).Locked = False
+
+	For cow = 0 to Ubound(CASES_TO_ASSIGN_ARRAY, 2)
+		If CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow) = "Adults" Then
+			ObjStaffExcel.Cells(excel_row, assign_logs_case_numb_col).Value 	= CASES_TO_ASSIGN_ARRAY(case_numb_const, cow)
+			ObjStaffExcel.Cells(excel_row, assign_logs_date_assign_col).Value 	= CASES_TO_ASSIGN_ARRAY(intvw_date_const, cow)
+			If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = True Then ObjStaffExcel.Cells(excel_row, assign_logs_appears_xfs_col).Value = "Yes"
+			If CASES_TO_ASSIGN_ARRAY(appears_xfs_const, cow) = "?" Then ObjMngrExcel.Cells(excel_row, assign_logs_appears_xfs_col).Value = "?"
+			ObjStaffExcel.Cells(excel_row, assign_log_area_col).Value 		= CASES_TO_ASSIGN_ARRAY(assign_pop_const, cow)
+			ObjStaffExcel.Cells(excel_row, assign_log_processor_col).Value	= CASES_TO_ASSIGN_ARRAY(assigned_to_const, cow)
+
+			excel_row = excel_row + 1
+		End If
+	Next
+	'ADD an LOCK to the spreadsheet columns with information
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Range("A3:E" & unlock_end).Locked = True
+	ObjStaffExcel.ActiveWorkbook.ActiveSheet.Protect
+
+	'save the manager log file and close
+	' objStaffWorkbook.Save()
+	' ObjStaffExcel.ActiveWorkbook.Close
+	' ObjStaffExcel.Application.Quit
+	' ObjStaffExcel.Quit
+End If
+internal_run_time = timer - start_time
+internal_run_min = int(internal_run_time/60)
+internal_run_sec = internal_run_time MOD 60
+
+end_message = end_message & vbCr & "Manager Log and Eligibility Staff Excel files updated with cases:"
+end_message = end_message & vbCr & "Total Cases added to logs: " & total_cases_assigned_count
+end_message = end_message & vbCr & "FAMILIES Cases added to logs: " & fam_cases_assigned_count
+end_message = end_message & vbCr & "ADULTS Cases added to logs: " & adul_cases_assigned_count
+end_message = end_message & vbCr & "Files left open for review but updates are compelete." & vbCr
+end_message = end_message & vbCr & "Script run time: " & internal_run_min & " min, " & internal_run_sec & " sec."
+
+Call script_end_procedure(end_message)

--- a/notes/interview.vbs
+++ b/notes/interview.vbs
@@ -7200,6 +7200,69 @@ Do
 Loop until summ_check = "SUMM"
 EMReadScreen case_pw, 7, 21, 17
 
+
+If run_by_interview_team = True and developer_mode = False Then
+	'creates an XML File with details of the the interview
+	Set xmlTracDoc = CreateObject("Microsoft.XMLDOM")
+	xmlTracPath = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\interview_started_" & MAXIS_case_number & ".xml"
+
+	xmlTracDoc.async = False
+
+	Set root = xmlTracDoc.createElement("interview")
+	xmlTracDoc.appendChild root
+
+	Set element = xmlTracDoc.createElement("ScriptRunDate")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(date)
+	element.appendChild info
+
+	Set element = xmlTracDoc.createElement("ScriptRunTime")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(time)
+	element.appendChild info
+
+	Set element = xmlTracDoc.createElement("WorkerName")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(worker_name)
+	element.appendChild info
+
+	Set element = xmlTracDoc.createElement("WindowsUserID")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(windows_user_ID)
+	element.appendChild info
+
+	Set element = xmlTracDoc.createElement("CaseNumber")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(MAXIS_case_number)
+	element.appendChild info
+
+	Set element = xmlTracDoc.createElement("CaseBasket")
+	root.appendChild element
+	Set info = xmlTracDoc.createTextNode(case_pw)
+	element.appendChild info
+
+	xmlTracDoc.save(xmlTracPath)
+
+	Set xml = CreateObject("Msxml2.DOMDocument")
+	Set xsl = CreateObject("Msxml2.DOMDocument")
+
+	Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
+	txt = Replace(fso.OpenTextFile(xmlTracPath).ReadAll, "><", ">" & vbCrLf & "<")
+	stylesheet = "<xsl:stylesheet version=""1.0"" xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"">" & _
+	"<xsl:output method=""xml"" indent=""yes""/>" & _
+	"<xsl:template match=""/"">" & _
+	"<xsl:copy-of select="".""/>" & _
+	"</xsl:template>" & _
+	"</xsl:stylesheet>"
+
+	xsl.loadXML stylesheet
+	xml.loadXML txt
+
+	xml.transformNode xsl
+
+	xml.Save xmlTracPath
+End if
+
 If select_err_msg_handling = "Alert at the time you attempt to save each page of the dialog." Then show_err_msg_during_movement = TRUE
 If select_err_msg_handling = "Alert only once completing and leaving the final dialog." Then show_err_msg_during_movement = FALSE
 
@@ -8520,6 +8583,9 @@ If ButtonPressed = incomplete_interview_btn Then
 		Call write_interview_CASE_NOTE
 		PF3
 	End If
+
+	xmlSavePath = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\interview_started_" & MAXIS_case_number & ".xml"
+	If ObjFSO.FileExists(xmlSavePath) Then objFSO.DeleteFile(xmlSavePath)
 
 	Call start_a_blank_case_note
 
@@ -11416,7 +11482,7 @@ End With
 If run_by_interview_team = True and developer_mode = False Then
 	'creates an XML File with details of the the interview
 	Set xmlTracDoc = CreateObject("Microsoft.XMLDOM")
-	xmlTracPath = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\interview_details_" & MAXIS_case_number & "_at_" & replace(replace(replace(now, "/", "_"),":", "_")," ", "_") & ".xml"
+	xmlTracPath = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\interview_details_" & MAXIS_case_number & "_on_" & replace(replace(interview_date, "/", "_")," ", "_") & ".xml"
 
 	xmlTracDoc.async = False
 
@@ -11828,6 +11894,9 @@ If run_by_interview_team = True and developer_mode = False Then
 	xml.transformNode xsl
 
 	xml.Save xmlTracPath
+
+	xmlSavePath = "\\hcgg.fr.co.hennepin.mn.us\lobroot\hsph\team\Eligibility Support\Assignments\Script Testing Logs\Interview Team Usage\interview_started_" & MAXIS_case_number & ".xml"
+	If ObjFSO.FileExists(xmlSavePath) Then objFSO.DeleteFile(xmlSavePath)
 End If
 
 STATS_manualtime = STATS_manualtime + (timer - start_time + add_to_time)


### PR DESCRIPTION
Update to Interview - added the XML creation at the beginning to prevent losing cases. 
   *Testing is hard because developer mode turns off the XMLs. Developer mode is triggered by being in TRAINING. If you turn it 
     off, make sure to delete your XMLs AND the PDFs of the interview notes. I ran through tests in training on this. 

Interview Worklist - now adds cases directly to the spreadsheets the  processors use
** I have run this worklist successfully and will be directly supporting the few workers who will run it daily next week to ensure no bugs. 

Interview Tracking is just here to stay connected - it is not ready for release and I am the only user of this script. 

If I can get reviews on this, I will pull in on Monday morning and be ready for any unforeseen bugs. 
