### PR TITLE
#2448 Caseload directory file

### DIFF
--- a/misc/caseload-directory.vbs
+++ b/misc/caseload-directory.vbs
@@ -217,7 +217,7 @@ caseload_manager.add "1800 - Team 160",                          "Monique Moore"
 caseload_manager.add "MA - BC",                                  "Jackie Poidinger"
 caseload_manager.add "Foster Care / IV-E",                       "Brianna Fleeman Schneider"
 caseload_manager.add "METS Retro Request",                       "Tenzing Yarphel"
-caseload_manager.add "YET",                                      "Tenzig Yarphel"
+caseload_manager.add "YET",                                      "Tenzing Yarphel"
 
 
 


### PR DESCRIPTION
This is a simple file to hold the dictionaries for caseloads and PMs, to be referenced by other scripts for case assignment and transfers.