### PR TITLE
#2472 NOTES - Elig Summ - multiple deemers header

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -11735,6 +11735,16 @@ class mfip_eligibility_detail
 					dm_col = 1
 					EMSearch "MAXIS Person Deemer Income Budget", dm_row, dm_col
 				End If
+                If dm_row = 0 Then
+                    dm_row = 1
+                    dm_col = 1
+                    EMSearch "Maxis Person Monthly Income Budget", dm_row, dm_col
+                End If
+                If dm_row = 0 Then
+                    dm_row = 1
+                    dm_col = 1
+                    EMSearch "MAXIS Person Monthly Income Budget", dm_row, dm_col
+                End If
 			Loop
 
 			Call write_value_and_transmit("X", 13, 3)		'Child Support Exclusion'


### PR DESCRIPTION
Maybe there could be multiple deemers on a case that header needs to be looked for newly before the next loop. Missed this in the last update but we got a case reported to test on today. 