### PR TITLE
#2467 & #2487 ELIG SUMM - MSA HRF error and Allow late note

### DIFF
--- a/notes/eligibility-summary.vbs
+++ b/notes/eligibility-summary.vbs
@@ -20639,7 +20639,6 @@ If user_ID_for_validation = "FRYA001" Then hc_access_only = True 		' FY
 If user_ID_for_validation = "MAZI002" Then hc_access_only = True 		' MZ
 
 Call MAXIS_background_check				'we are adding a background check to make sure the case is through background before attempting to read ELIG.
-' If MAXIS_case_number = "2683408" Then allow_late_note = True
 Call date_array_generator(first_footer_month, first_footer_year, MONTHS_ARRAY)
 
 ex_parte_approval = False


### PR DESCRIPTION
Updated Eligibility Summary to support the MSA HRF processing. This functionality was updated but we couldn't test it until a case came up and a worker reported an error today. 

Additionally, added functionality to add allowance for eligibility summary to allow for a late CASE/NOTE by specific case number without requiring a pull request. This will help support workers reporting issues with ELIG SUMM and still being able to use and test updates that cannot be completed same day. 